### PR TITLE
Implement store optimisations

### DIFF
--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -311,6 +311,37 @@ RoomBridgeStore.prototype.getRemoteLinks = function(matrixId) {
 };
 
 /**
+ * Retrieve a list of remote IDs linked to a list of matrix room IDs.
+ * @param {Array<string>} matrixIds A list of matrix room IDs to search for.
+ * @return {Promise<Map<string, RoomBridgeStore~Link[]>, Error>} A promise
+ * which resolves to a map with the keys as room IDs and the values set to a
+ * list of room links. If the same room ID appears multiple times in the
+ * input array, only 1 of the keys will be present in the map.
+ */
+RoomBridgeStore.prototype.batchGetRemoteLinks = function(matrixIds) {
+    return this.select({
+        type: "union",
+        matrix_id: {
+            $in: matrixIds
+        }
+    }).then(function(docs) {
+        var matrixIdMap = {};
+        docs = docs || [];
+        docs.forEach(function(doc) {
+            if (!matrixIdMap[doc.matrix_id]) {
+                matrixIdMap[doc.matrix_id] = [];
+            }
+            matrixIdMap[doc.matrix_id].push({
+                matrix: doc.matrix_id,
+                remote: doc.remote_id,
+                data: doc.data
+            });
+        });
+        return matrixIdMap;
+    });
+};
+
+/**
  * Get Matrix rooms linked to the given remote ID.
  * @param {string} remoteId The remote room ID
  * @param {Object=} dataQuery Additional constraints to apply to the set of

--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -323,6 +323,9 @@ RoomBridgeStore.prototype.getLinkedMatrixRooms = function(remoteId, dataQuery) {
         var matrixIds = links.map(function(link) {
             return link.matrix;
         });
+        if (matrixIds.length === 0) {
+            return [];
+        }
         return self.select({
             type: "matrix",
             id: { $in: matrixIds }
@@ -345,6 +348,9 @@ RoomBridgeStore.prototype.getLinkedRemoteRooms = function(matrixId, dataQuery) {
         var remoteIds = links.map(function(link) {
             return link.remote;
         });
+        if (remoteIds.length === 0) {
+            return [];
+        }
         return self.select({
             type: "remote",
             id: { $in: remoteIds }

--- a/spec/integ/room-bridge-store.spec.js
+++ b/spec/integ/room-bridge-store.spec.js
@@ -2,6 +2,7 @@
 var Datastore = require("nedb");
 var fs = require("fs");
 var log = require("../log");
+var Promise = require("bluebird");
 
 var RoomBridgeStore = require("../..").RoomBridgeStore;
 var MatrixRoom = require("../..").MatrixRoom;
@@ -323,6 +324,60 @@ describe("RoomBridgeStore", function() {
                         link.remote
                     )).not.toEqual(-1, "Bad remote ID returned");
                 });
+                done();
+            });
+        });
+    });
+
+    describe("batchGetRemoteLinks", function() {
+        var entries = [
+            { mx: new MatrixRoom("!foo:bar"), r: new RemoteRoom("#foo_bar") },
+            // same remote mapping
+            { mx: new MatrixRoom("!foo_bar:bar"), r: new RemoteRoom("#foo_bar") },
+            { mx: new MatrixRoom("!fizz:buzz"), r: new RemoteRoom("#fizz_buzz") },
+            { mx: new MatrixRoom("!alpha:beta"), r: new RemoteRoom("#alpha_beta") },
+            // same matrix mapping
+            { mx: new MatrixRoom("!alpha:beta"), r: new RemoteRoom("#alpha_bet") }
+        ];
+        var expectedOutput = {
+            "!foo:bar": ["#foo_bar"],
+            "!foo_bar:bar": ["#foo_bar"],
+            "!fizz:buzz": ["#fizz_buzz"],
+            "!alpha:beta": ["#alpha_beta", "#alpha_bet"]
+        }
+
+        // persist the links
+        beforeEach(function(done) {
+            Promise.all(entries.map(function(e) {
+                return store.linkRooms(e.mx, e.r);
+            })).done(function() {
+                done();
+            });
+        });
+
+        it("should return a map of links", function(done) {
+            var mxIds = Object.keys(expectedOutput);
+            store.batchGetRemoteLinks(mxIds).done(function(outputMap) {
+                // make sure the keys are all there with the right links
+                mxIds.forEach(function(roomId) {
+                    var outputLinks = outputMap[roomId];
+                    expect(outputLinks).toBeDefined();
+                    if (!outputLinks) {
+                        return;
+                    }
+                    expect(outputLinks.length).toEqual(expectedOutput[roomId].length);
+                    var linkIds = outputLinks.map(function(l) {
+                        return l.remote;
+                    });
+                    expect(linkIds.sort()).toEqual(expectedOutput[roomId].sort());
+                });
+                done();
+            });
+        });
+
+        it("should return an empty list if there are no links", function(done) {
+            store.batchGetRemoteLinks(["!nada:here", "!more:na"]).done(function(links) {
+                expect(Object.keys(links).length).toEqual(0);
                 done();
             });
         });


### PR DESCRIPTION
Specifically:
 - `RoomBridgeStore.batchGetRemoteLinks`
 - Do not query for mappings if there are no IDs to search on.