### PR TITLE
Reimplement the RoomBridgeStore database schema

### DIFF
--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -61,7 +61,7 @@ util.inherits(RoomBridgeStore, BridgeStore);
 
 /**
  * Insert an entry, clobbering based on the ID.
- * @param {Entry} entry
+ * @param {RoomBridgeStore~Entry} entry
  */
 RoomBridgeStore.prototype.upsertEntry = function(entry) {
     return this.upsert({
@@ -72,6 +72,7 @@ RoomBridgeStore.prototype.upsertEntry = function(entry) {
 /**
  * Get an existing entry based on the provided ID.
  * @param {String} id
+ * @return {?RoomBridgeStore~Entry}
  */
 RoomBridgeStore.prototype.getEntryById = function(id) {
     return this.selectOne({
@@ -84,6 +85,7 @@ RoomBridgeStore.prototype.getEntryById = function(id) {
 /**
  * Get a list of entries based on the matrix_id of each entry.
  * @param {string} matrixId
+ * @return @return {RoomBridgeStore~Entry[]}
  */
 RoomBridgeStore.prototype.getEntriesByMatrixId = function(matrixId) {
     return this.select({
@@ -96,7 +98,7 @@ RoomBridgeStore.prototype.getEntriesByMatrixId = function(matrixId) {
 /**
  * A batch version of <code>getEntriesByMatrixId</code>.
  * @param {String[]} ids
- * @return Promise<Map<string,Entry[]>, Error> Resolves to a map of room_id => Entry[]
+ * @return Promise<Map<string,RoomBridgeStore~Entry[]>, Error> Resolves to a map of room_id => Entry[]
  */
 RoomBridgeStore.prototype.getEntriesByMatrixIds = function(ids) {
     return this.select({
@@ -184,6 +186,7 @@ function createUniqueId(matrixRoomId, remoteRoomId) {
 /**
  * Construct a new RoomBridgeStore Entry.
  * @constructor
+ * @typedef RoomBridgeStore~Entry
  * @property {string} id The unique ID for this entry.
  * @property {?MatrixRoom} matrix The matrix room, if applicable.
  * @property {?RemoteRoom} remote The remote room, if applicable.

--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -53,9 +53,13 @@ var util = require("util");
  * @constructor
  * @param {Datastore} db The connected NEDB database instance
  * @param {Object} opts Options for this store.
+ * @property {string} delimiter The delimiter between matrix and
+ * remote IDs. Defaults to three spaces. If the schema of your remote IDs
+ * allows spaces, you will need to change this.
  */
 function RoomBridgeStore(db, opts) {
     this.db = db;
+    this.delimiter = "   ";
 }
 util.inherits(RoomBridgeStore, BridgeStore);
 
@@ -140,7 +144,7 @@ RoomBridgeStore.prototype.getEntriesByRemoteId = function(remoteId) {
  */
 RoomBridgeStore.prototype.linkRooms = function(matrixRoom, remoteRoom, data, linkKey) {
     data = data || {};
-    linkKey = linkKey || createUniqueId(matrixRoom.getId(), remoteRoom.getId());
+    linkKey = linkKey || createUniqueId(matrixRoom.getId(), remoteRoom.getId(), this.delimiter);
     var self = this;
     return self.upsert({
         id: linkKey
@@ -242,8 +246,8 @@ RoomBridgeStore.prototype.removeEntriesByMatrixRoomData = function(data) {
 };
 
 
-function createUniqueId(matrixRoomId, remoteRoomId) {
-    return (matrixRoomId || "") + "_@_" + (remoteRoomId || "");
+function createUniqueId(matrixRoomId, remoteRoomId, delimiter) {
+    return (matrixRoomId || "") + delimiter + (remoteRoomId || "");
 }
 
 

--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -223,6 +223,24 @@ RoomBridgeStore.prototype.getEntriesByMatrixRoomData = function(data) {
     }));
 };
 
+RoomBridgeStore.prototype.removeEntriesByRemoteRoomData = function(data) {
+    Object.keys(data).forEach(function(k) {
+        var query = data[k];
+        delete data[k];
+        data["remote." + k] = query;
+    });
+    return this.delete(data);
+};
+
+RoomBridgeStore.prototype.removeEntriesByMatrixRoomData = function(data) {
+    Object.keys(data).forEach(function(k) {
+        var query = data[k];
+        delete data[k];
+        data["matrix.extras." + k] = query;
+    });
+    return this.delete(data);
+};
+
 
 function createUniqueId(matrixRoomId, remoteRoomId) {
     return (matrixRoomId || "") + "_@_" + (remoteRoomId || "");

--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -37,9 +37,9 @@
  *    data: { .. custom data about the mapping ..}
  * }
  *
- * A unique index is forced on the 'id' key, and non-unique indexes are forced
- * on matrix_id and remote_id to make mappings quick to compute. You cannot
- * select based off the data fields `matrix`, `remote` and `data`.
+ * A unique, non-sparse index can be set on the 'id' key, and non-unique,
+ * sparse indexes can be set on matrix_id and remote_id to make mappings
+ * quicker to compute.
  *
  */
 "use strict";

--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -98,7 +98,8 @@ RoomBridgeStore.prototype.getEntriesByMatrixId = function(matrixId) {
 /**
  * A batch version of <code>getEntriesByMatrixId</code>.
  * @param {String[]} ids
- * @return Promise<Map<string,RoomBridgeStore~Entry[]>, Error> Resolves to a map of room_id => Entry[]
+ * @return Promise<Map<string,RoomBridgeStore~Entry[]>, Error> Resolves
+ * to a map of room_id => Entry[]
  */
 RoomBridgeStore.prototype.getEntriesByMatrixIds = function(ids) {
     return this.select({
@@ -167,6 +168,16 @@ RoomBridgeStore.prototype.getMatrixRoom = function(roomId) {
     });
 };
 
+RoomBridgeStore.prototype.getLinkedMatrixRooms = function(remoteId) {
+    return this.getEntriesByRemoteId(remoteId).then(function(entries) {
+        return entries.filter(function(e) {
+            return Boolean(e.matrix);
+        }).map(function(e) {
+            return e.matrix;
+        });
+    });
+};
+
 RoomBridgeStore.prototype.getLinkedRemoteRooms = function(matrixId) {
     return this.getEntriesByMatrixId(matrixId).then(function(entries) {
         return entries.filter(function(e) {
@@ -175,6 +186,41 @@ RoomBridgeStore.prototype.getLinkedRemoteRooms = function(matrixId) {
             return e.remote;
         });
     });
+};
+
+RoomBridgeStore.prototype.batchGetLinkedRemoteRooms = function(matrixIds) {
+    return this.getEntriesByMatrixIds(matrixIds).then(function(entryMap) {
+        Object.keys(entryMap).forEach(function(k) {
+            entryMap[k] = entryMap[k].filter(function(e) {
+                return Boolean(e.remote);
+            }).map(function(e) {
+                return e.remote;
+            });
+        })
+        return entryMap;
+    });
+};
+
+RoomBridgeStore.prototype.getEntriesByRemoteRoomData = function(data) {
+    Object.keys(data).forEach(function(k) {
+        var query = data[k];
+        delete data[k];
+        data["remote." + k] = query;
+    });
+    return this.select(data, this.convertTo(function(doc) {
+        return new Entry(doc);
+    }));
+};
+
+RoomBridgeStore.prototype.getEntriesByMatrixRoomData = function(data) {
+    Object.keys(data).forEach(function(k) {
+        var query = data[k];
+        delete data[k];
+        data["matrix.extras." + k] = query;
+    });
+    return this.select(data, this.convertTo(function(doc) {
+        return new Entry(doc);
+    }));
 };
 
 

--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -1,35 +1,46 @@
 /*
  * Room storage format:
  * {
- *   type: "matrix|remote",
- *   id: "room_id|remote_id",
- *   data: {
- *     .. matrix-specific info e.g. room name ..
- *     .. remote specific info e.g. IRC channel modes ..
- *   }
+ *   id: "matrix|remote|link_key",      // customisable
+ *   matrix_id: "room_id",
+ *   remote_id: "remote_room_id",
+ *   matrix: { serialised matrix room info },
+ *   remote: { serialised remote room info },
+ *   data: { ... any additional info ... }
  * }
  *
- * There is also a third type, the "union" type. This binds together a single
- * matrix <--> remote pairing. A single remote ID can have many matrix_id and
- * vice versa, via multiple union entries. Each union entry has an optional
- * 'data' attribute which functions in the same way as data for rooms. Unions
- * are keyed off a unique 'link_key' which is normally a concatenation of the
- * remote and matrix room ID.
- *
- * Example:
+ * Each document can either represent a matrix room, a remote room, or
+ * a mapping. They look like this:
+ * MATRIX
  * {
- *   type: "union",
- *   link_key: "!wefouh94w34rw:matrix.org #foo irc.domain.com",
- *   remote_id: "#foo irc.domain.com",
- *   matrix_id: "!wefouh94w34rw:matrix.org",
- *   data: {
- *     from_config_file: true
- *   }
+ *    id: "!room:id",
+ *    matrix_id: "!room:id",
+ *    remote_id: null,
+ *    matrix: { .. custom data eg name: "A happy place" .. }
  * }
  *
- * Union types clobber based off the link_key. This key can be customised by the
- * caller. This is useful for clobbering links based on custom data (e.g.
- * user ID tuples for admin rooms).
+ * REMOTE (e.g. IRC)
+ * {
+ *    id: "irc.freenode.net_#channame",
+ *    matrix_id: null,
+ *    remote_id: "irc.freenode.net_#channame",
+ *    remote: { .. custom data e.g. is_pm_room: true .. }
+ * }
+ *
+ * MAPPING
+ * {
+ *    id: "!room:id__irc.freenode.net_#channame", // link key; customisable.
+ *    matrix_id: "!room:id",
+ *    remote_id: "irc.freenode.net_#channame",
+ *    matrix: { .. custom data .. },
+ *    remote: { .. custom data .. },
+ *    data: { .. custom data about the mapping ..}
+ * }
+ *
+ * A unique index is forced on the 'id' key, and non-unique indexes are forced
+ * on matrix_id and remote_id to make mappings quick to compute. You cannot
+ * select based off the data fields `matrix`, `remote` and `data`.
+ *
  */
 "use strict";
 var BridgeStore = require("./bridge-store");
@@ -49,87 +60,75 @@ function RoomBridgeStore(db, opts) {
 util.inherits(RoomBridgeStore, BridgeStore);
 
 /**
- * Store a Matrix room. If it already exists, it will be updated. Equivalence
- * is determined by the room ID.
- * @param {MatrixRoom} matrixRoom The matrix room
- * @param {Object} updateQuery Update the room based on the data values given in this
- * object rather than the matrix room ID.
- * @return {Promise}
+ * Insert an entry, clobbering based on the ID.
+ * @param {Entry} entry
  */
-RoomBridgeStore.prototype.setMatrixRoom = function(matrixRoom, updateQuery) {
-    return setRoom(this, "matrix", matrixRoom, updateQuery);
+RoomBridgeStore.prototype.upsertEntry = function(entry) {
+    return this.upsert({
+        id: entry.id
+    }, serializeEntry(entry));
+}
+
+/**
+ * Get an existing entry based on the provided ID.
+ * @param {String} id
+ */
+RoomBridgeStore.prototype.getEntryById = function(id) {
+    return this.selectOne({
+        id: id
+    }, this.convertTo(function(doc) {
+        return new Entry(doc);
+    }));
+}
+
+/**
+ * Get a list of entries based on the matrix_id of each entry.
+ * @param {string} matrixId
+ */
+RoomBridgeStore.prototype.getEntriesByMatrixId = function(matrixId) {
+    return this.select({
+        matrix_id: matrixId
+    }, this.convertTo(function(doc) {
+        return new Entry(doc);
+    }));
 };
 
 /**
- * Store a Remote room. If it already exists, it will be updated. Equivalence
- * is determined by the room ID.
- * @param {RemoteRoom} remoteRoom The remote room
- * @param {Object} updateQuery Update the room based on the data values given in this
- * object rather than the remote ID.
- * @return {Promise}
+ * A batch version of <code>getEntriesByMatrixId</code>.
+ * @param {String[]} ids
+ * @return Promise<Map<string,Entry[]>, Error> Resolves to a map of room_id => Entry[]
  */
-RoomBridgeStore.prototype.setRemoteRoom = function(remoteRoom, updateQuery) {
-    return setRoom(this, "remote", remoteRoom, updateQuery);
+RoomBridgeStore.prototype.getEntriesByMatrixIds = function(ids) {
+    return this.select({
+        matrix_id: {
+            $in: ids
+        }
+    }).then(function(docs) {
+        var entries = {};
+        docs.forEach(function(doc) {
+            if (!entries[doc.matrix_id]) {
+                entries[doc.matrix_id] = [];
+            }
+            entries[doc.matrix_id].push(new Entry(doc));
+        });
+        return entries;
+    });
 };
 
 /**
- * Get a matrix room by its' room ID.
- * @param {string|Object} roomIdOrDataQuery The room id or a data query object.
- * If the data query returns multiple entries, only 1 will be returned. Data queries
- * for keys set via <code>MatrixRoom.set(key, val)</code> MUST be prefixed with
- * 'extras.'
- * @return {Promise<?MatrixRoom, Error>} Resolves to the room or null if it
- * does not exist. Rejects with an error if there was a problem querying the store.
- * @see RoomBridgeStore.getMatrixRooms
+ * Get entries based on their remote_id.
+ * @param {String} remoteId
  */
-RoomBridgeStore.prototype.getMatrixRoom = function(roomIdOrDataQuery) {
-    return getRoom(this, "matrix", MatrixRoom, roomIdOrDataQuery, false);
+RoomBridgeStore.prototype.getEntriesByRemoteId = function(remoteId) {
+    return this.select({
+        remote_id: remoteId
+    }, this.convertTo(function(doc) {
+        return new Entry(doc);
+    }));
 };
 
 /**
- * Get a remote room by its' room ID.
- * @param {string|Object} roomIdOrDataQuery The room id or a data query object.
- * If the data query returns multiple entries, only 1 will be returned.
- * @return {Promise<?RemoteRoom, Error>} Resolves to the room or null if it
- * does not exist. Rejects with an error if there was a problem querying the store.
- */
-RoomBridgeStore.prototype.getRemoteRoom = function(roomIdOrDataQuery) {
-    return getRoom(this, "remote", RemoteRoom, roomIdOrDataQuery, false);
-};
-
-/**
- * Get a list of matrix rooms by a data query.
- * @param {Object} dataQuery A data query object. Queries for keys set via
- * <code>MatrixRoom.set(key, val)</code> MUST be prefixed with 'extras.'
- * @return {Promise<MatrixRoom[], Error>}
- * @example
- * store.getMatrixRooms({
- *   name: "A room name",
- *   "extras.some_new_key": "some new val"
- * });
- */
-RoomBridgeStore.prototype.getMatrixRooms = function(dataQuery) {
-    return getRoom(this, "matrix", MatrixRoom, dataQuery, true);
-};
-
-/**
- * Get a list of remote rooms by a data query.
- * @param {Object} dataQuery A data query object.
- * @return {Promise<RemoteRoom[], Error>}
- */
-RoomBridgeStore.prototype.getRemoteRooms = function(dataQuery) {
-    return getRoom(this, "remote", RemoteRoom, dataQuery, true);
-};
-
-// ************
-// Link Methods
-// ************
-
-/**
- * Create a link between a matrix room and remote room. This will insert the
- * given rooms if they do not exist before creating the mapping. This is done to
- * ensure foreign key constraints are satisfied (so you cannot have a mapping to
- * a room ID which does not exist).
+ * Create a link between a matrix room and remote room.
  * @param {MatrixRoom} matrixRoom The matrix room
  * @param {RemoteRoom} remoteRoom The remote room
  * @param {Object=} data Information about this mapping.
@@ -138,365 +137,76 @@ RoomBridgeStore.prototype.getRemoteRooms = function(dataQuery) {
  */
 RoomBridgeStore.prototype.linkRooms = function(matrixRoom, remoteRoom, data, linkKey) {
     data = data || {};
-    linkKey = linkKey || createLinkKey(matrixRoom.getId(), remoteRoom.getId());
+    linkKey = linkKey || createUniqueId(matrixRoom.getId(), remoteRoom.getId());
     var self = this;
-    return self.insertIfNotExists({
-        type: "remote",
-        id: remoteRoom.getId()
+    return self.upsert({
+        id: linkKey
     }, {
-        type: "remote",
-        id: remoteRoom.getId(),
-        data: remoteRoom.serialize()
-    }).then(function() {
-        return self.insertIfNotExists({
-            type: "matrix",
-            id: matrixRoom.getId()
-        }, {
-            type: "matrix",
-            id: matrixRoom.getId(),
-            data: matrixRoom.serialize()
-        });
-    }).then(function() {
-        return self.upsert({
-            type: "union",
-            link_key: linkKey
-        }, {
-            type: "union",
-            link_key: linkKey,
-            remote_id: remoteRoom.getId(),
-            matrix_id: matrixRoom.getId(),
-            data: data
+        id: linkKey,
+        remote_id: remoteRoom.getId(),
+        matrix_id: matrixRoom.getId(),
+        remote: remoteRoom.serialize(),
+        matrix: matrixRoom.serialize(),
+        data: data
+    });
+};
+
+RoomBridgeStore.prototype.setMatrixRoom = function(matrixRoom) {
+    return this.upsertEntry({
+        id: matrixRoom.getId(),
+        matrix_id: matrixRoom.getId(),
+        matrix: matrixRoom
+    });
+};
+
+RoomBridgeStore.prototype.getMatrixRoom = function(roomId) {
+    return this.getEntryById(roomId).then(function(e) {
+        return e ? e.matrix : null;
+    });
+};
+
+RoomBridgeStore.prototype.getLinkedRemoteRooms = function(matrixId) {
+    return this.getEntriesByMatrixId(matrixId).then(function(entries) {
+        return entries.filter(function(e) {
+            return Boolean(e.remote);
+        }).map(function(e) {
+            return e.remote;
         });
     });
 };
 
-/**
- * Delete a link between a matrix room and a remote room.
- * @param {MatrixUser} matrixRoom The matrix user
- * @param {RemoteUser} remoteRoom The remote user
- * @return {Promise<Number, Error>} Resolves to the number of entries removed.
- */
-RoomBridgeStore.prototype.unlinkRooms = function(matrixRoom, remoteRoom) {
-    return this.unlinkRoomIds(matrixRoom.getId(), remoteRoom.getId());
-};
 
-/**
- * Delete a link between a matrix room ID and a remote room ID. This creates a
- * link key based on the provided IDs.
- * @param {string} matrixRoomId The matrix room ID
- * @param {string} remoteRoomId The remote room ID
- * @return {Promise<Number, Error>} Resolves to the number of entries removed.
- */
-RoomBridgeStore.prototype.unlinkRoomIds = function(matrixRoomId, remoteRoomId) {
-    return this.unlinkByKey(createLinkKey(matrixRoomId, remoteRoomId))
-};
-
-/**
- * Delete a link between a matrix room ID and a remote room ID based on a link
- * key.
- * @param {string} linkKey The link key to delete links by.
- * @return {Promise<Number, Error>} Resolves to the number of entries removed.
- */
-RoomBridgeStore.prototype.unlinkByKey = function(linkKey) {
-    return this.delete({
-        type: "union",
-        link_key: linkKey
-    });
-};
-
-RoomBridgeStore.prototype.getLinksByKey = function(linkKey) {
-    return this.select({
-        link_key: linkKey
-    }, this.convertTo(function(doc) {
-        return {
-            matrix: doc.matrix_id,
-            remote: doc.remote_id,
-            link_key: linkKey,
-            data: doc.data
-        };
-    }));
+function createUniqueId(matrixRoomId, remoteRoomId) {
+    return (matrixRoomId || "") + "_@_" + (remoteRoomId || "");
 }
 
-/**
- * Retrieve a list of links based on some information about the links themselves.
- * @param {Object} dataQuery The keys and matching values the links share.
- * This should use dot notation for nested types. For example:
- * <code> { "topLevel.midLevel.leaf": 42, "otherTopLevel": "foo" } </code>
- * @return {Promise<{RoomBridgeStore~Link[], Error>} Resolves to a possibly
- * empty list of {@link RoomBridgeStore~Link} objects. Rejects with an error if
- * there was a problem querying the store.
- * @throws If dataQuery isn't an object.
- * @example
- * store.linkRoomIds("!foo:bar", "_foo_bar", {
- *   custom: {
- *     stuff: "goes here"
- *   },
- *   or: "here"
- * });
- * store.getLinksByData({
- *   "custom.stuff": "goes here"
- * });
- */
-RoomBridgeStore.prototype.getLinksByData = function(dataQuery) {
-    if (typeof dataQuery !== "object") {
-        throw new Error("Data query must be an object.");
-    }
-    var query = {};
-    Object.keys(dataQuery).forEach(function(key) {
-        query["data." + key] = dataQuery[key];
-    });
-    query.type = "union";
-
-    return this.select(query, this.convertTo(function(doc) {
-        return {
-            matrix: doc.matrix_id,
-            remote: doc.remote_id,
-            link_key: doc.link_key,
-            data: doc.data
-        };
-    }));
-};
 
 /**
- * Delete links which have the matching data.
- * @param {Object} dataQuery The data query to match.
- * @return {Promise<Number, Error>} Resolves to the number of entries removed.
+ * Construct a new RoomBridgeStore Entry.
+ * @constructor
+ * @property {string} id The unique ID for this entry.
+ * @property {?MatrixRoom} matrix The matrix room, if applicable.
+ * @property {?RemoteRoom} remote The remote room, if applicable.
+ * @property {?Object} data Information about this mapping, which may be an empty.
  */
-RoomBridgeStore.prototype.unlinkByData = function(dataQuery) {
-    if (typeof dataQuery !== "object") {
-        throw new Error("Data query must be an object.");
-    }
-    var query = {};
-    Object.keys(dataQuery).forEach(function(key) {
-        query["data." + key] = dataQuery[key];
-    });
-    query.type = "union";
-    return this.delete(query);
-};
-
-/**
- * Retrieve a list of matrix room IDs linked to this remote ID.
- * @param {string} remoteId The remote ID
- * @return {Promise<RoomBridgeStore~Link[], Error>} A list of room IDs.
- */
-RoomBridgeStore.prototype.getMatrixLinks = function(remoteId) {
-    return this.select({
-        type: "union",
-        remote_id: remoteId
-    }, this.convertTo(function(doc) {
-        return {
-            matrix: doc.matrix_id,
-            remote: doc.remote_id,
-            data: doc.data
-        };
-    }));
-};
-
-/**
- * Retrieve a list of remote IDs linked to this matrix room ID.
- * @param {string} matrixId The matrix room ID
- * @return {Promise<RoomBridgeStore~Link[], Error>} A list of remote IDs.
- */
-RoomBridgeStore.prototype.getRemoteLinks = function(matrixId) {
-    return this.select({
-        type: "union",
-        matrix_id: matrixId
-    }, this.convertTo(function(doc) {
-        return {
-            matrix: doc.matrix_id,
-            remote: doc.remote_id,
-            data: doc.data
-        };
-    }));
-};
-
-/**
- * Retrieve a list of remote IDs linked to a list of matrix room IDs.
- * @param {Array<string>} matrixIds A list of matrix room IDs to search for.
- * @return {Promise<Map<string, RoomBridgeStore~Link[]>, Error>} A promise
- * which resolves to a map with the keys as room IDs and the values set to a
- * list of room links. If the same room ID appears multiple times in the
- * input array, only 1 of the keys will be present in the map.
- */
-RoomBridgeStore.prototype.batchGetRemoteLinks = function(matrixIds) {
-    return this.select({
-        type: "union",
-        matrix_id: {
-            $in: matrixIds
-        }
-    }).then(function(docs) {
-        var matrixIdMap = {};
-        docs = docs || [];
-        docs.forEach(function(doc) {
-            if (!matrixIdMap[doc.matrix_id]) {
-                matrixIdMap[doc.matrix_id] = [];
-            }
-            matrixIdMap[doc.matrix_id].push({
-                matrix: doc.matrix_id,
-                remote: doc.remote_id,
-                data: doc.data
-            });
-        });
-        return matrixIdMap;
-    });
-};
-
-/**
- * Get Matrix rooms linked to the given remote ID.
- * @param {string} remoteId The remote room ID
- * @param {Object=} dataQuery Additional constraints to apply to the set of
- * returned rooms.
- * @return {Promise<MatrixRoom[],Error>} A list of matrix rooms.
- */
-RoomBridgeStore.prototype.getLinkedMatrixRooms = function(remoteId, dataQuery) {
-    var self = this;
-    return this.getMatrixLinks(remoteId, dataQuery).then(function(links) {
-        var matrixIds = links.map(function(link) {
-            return link.matrix;
-        });
-        if (matrixIds.length === 0) {
-            return [];
-        }
-        return self.select({
-            type: "matrix",
-            id: { $in: matrixIds }
-        }, self.convertTo(function(doc) {
-            return new MatrixRoom(doc.id, doc.data);
-        }));
-    })
-};
-
-/**
- * Get remote rooms linked to the given matrix ID.
- * @param {string} matrixId The matrix room ID
- * @param {Object=} dataQuery Additional constraints to apply to the set of
- * returned rooms.
- * @return {Promise<RemoteRoom[],Error>} A list of remote rooms.
- */
-RoomBridgeStore.prototype.getLinkedRemoteRooms = function(matrixId, dataQuery) {
-    var self = this;
-    return this.getRemoteLinks(matrixId, dataQuery).then(function(links) {
-        var remoteIds = links.map(function(link) {
-            return link.remote;
-        });
-        if (remoteIds.length === 0) {
-            return [];
-        }
-        return self.select({
-            type: "remote",
-            id: { $in: remoteIds }
-        }, self.convertTo(function(doc) {
-            return new RemoteRoom(doc.id, doc.data);
-        }));
-    })
-};
-
-/**
- * Get remote rooms linked to the given list of matrix IDs.
- * @param {string[]} matrixIds The matrix room IDs to get remote rooms for.
- * @return {Promise<Map<string, RemoteRoom[]>,Error>} A map of room_id to
- * a list of remote rooms.
- */
-RoomBridgeStore.prototype.batchGetLinkedRemoteRooms = function(matrixIds) {
-    var self = this;
-    var remoteRoomMap = null;
-    return this.batchGetRemoteLinks(matrixIds).then(function(linkMap) {
-        remoteRoomMap = linkMap; // will clobber this later
-
-        // convert { mx_room_id: [Link] } into a Set<RemoteRoomID>
-        var remoteIdSet = {};
-        Object.keys(linkMap).forEach(function(roomId) {
-            linkMap[roomId].forEach(function(link) {
-                remoteIdSet[link.remote] = true;
-            });
-        });
-        var remoteIds = Object.keys(remoteIdSet);
-        if (remoteIds.length === 0) {
-            return [];
-        }
-        return self.select({
-            type: "remote",
-            id: { $in: remoteIds }
-        }, self.convertTo(function(doc) {
-            return new RemoteRoom(doc.id, doc.data);
-        }));
-    }).then(function(remoteRooms) {
-        // map the remotes into a hash map and then loop through the links
-        // (Nremote+Nmatrix ops vs Nremote * Nmatrix ops)
-        var remoteIdToRemoteRoom = {};
-        remoteRooms.forEach(function(remote) {
-            remoteIdToRemoteRoom[remote.getId()] = remote;
-        });
-        // Map { room_id : [Link] } to {room_id: [RemoteRoom]}
-        Object.keys(remoteRoomMap).forEach(function(roomId) { // room_id => [Link]
-            var links = remoteRoomMap[roomId];
-            for (var i = 0; i < links.length; i++) {
-                if (!remoteIdToRemoteRoom[links[i].remote]) {
-                    // link exists but no remote room, nuke entry
-                    links.splice(i, 1);
-                    i--;
-                    continue;
-                }
-                links[i] = remoteIdToRemoteRoom[links[i].remote];
-            }
-            remoteRoomMap[roomId] = links;
-        });
-        return remoteRoomMap;
-    });
-};
-
-function createLinkKey(matrixRoomId, remoteRoomId) {
-    return (matrixRoomId || "") + " " + (remoteRoomId || "");
+function Entry(doc) {
+    doc = doc || {};
+    this.id = doc.id;
+    this.matrix = doc.matrix_id ? new MatrixRoom(doc.matrix_id, doc.matrix) : undefined;
+    this.remote = doc.remote_id ? new RemoteRoom(doc.remote_id, doc.remote) : undefined;
+    this.data = doc.data;
 }
 
-function setRoom(instance, type, room, updateQuery) {
-    var query = {
-        type: type
-    };
-    if (updateQuery && typeof updateQuery === "object") {
-        Object.keys(updateQuery).forEach(function(key) {
-            query["data." + key] = updateQuery[key];
-        });
+// not a member function so callers can provide a POJO
+function serializeEntry(entry) {
+    return {
+        id: entry.id,
+        remote_id: entry.remote ? entry.remote.getId() : undefined,
+        matrix_id: entry.matrix ? entry.matrix.getId() : undefined,
+        remote: entry.remote ? entry.remote.serialize() : undefined,
+        matrix: entry.matrix ? entry.matrix.serialize() : undefined,
+        data: entry.data
     }
-    else {
-        query.id = room.getId();
-    }
-
-    return instance.upsert(query, {
-        type: type,
-        id: room.getId(),
-        data: room.serialize()
-    });
-}
-
-function getRoom(instance, type, Cls, idOrQuery, allowMultiple) {
-    var query = {
-        type: type
-    };
-    if (typeof idOrQuery === "object") {
-        Object.keys(idOrQuery).forEach(function(key) {
-            query["data." + key] = idOrQuery[key];
-        });
-    }
-    else {
-        query.id = idOrQuery;
-    }
-
-    var method = allowMultiple ? "select" : "selectOne";
-
-    return instance[method](query, instance.convertTo(function(doc) {
-        return new Cls(doc.id, doc.data);
-    }));
 }
 
 module.exports = RoomBridgeStore;
-
-/**
- * @typedef RoomBridgeStore~Link
- * @type {Object}
- * @property {string} matrix The matrix room ID
- * @property {string} remote The remote room ID
- * @property {string} link_key The unique key for this link.
- * @property {Object} data Information about this mapping, which may be an empty
- * object.
- */

--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -1,4 +1,4 @@
-/*
+/**
  * Room storage format:
  * {
  *   id: "matrix|remote|link_key",      // customisable
@@ -49,7 +49,25 @@ var RemoteRoom = require("../models/rooms/remote");
 var util = require("util");
 
 /**
- * Construct a store suitable for room bridging information.
+ * Construct a store suitable for room bridging information. Data is stored
+ * as {@link RoomBridgeStore~Entry}s which have the following
+ * <i>serialized</i> format:
+ * <pre>
+ * {
+ *   id: "unique_id",      // customisable
+ *   matrix_id: "room_id",
+ *   remote_id: "remote_room_id",
+ *   matrix: { serialised matrix room info },
+ *   remote: { serialised remote room info },
+ *   data: { ... any additional info ... }
+ * }
+ * </pre>
+ * <p>If a unique 'id' is not given, the store will generate one by concatenating
+ * the <code>matrix_id</code> and the <code>remote_id</code>. The delimiter
+ * used is a property on this store and can be modified.</p>
+ * <p>The structure of Entry objects means that it is efficient to select based
+ * off the 'id', 'matrix_id' or 'remote_id'. Additional indexes can be added
+ * manually.</p>
  * @constructor
  * @param {Datastore} db The connected NEDB database instance
  * @param {Object} opts Options for this store.
@@ -64,8 +82,9 @@ function RoomBridgeStore(db, opts) {
 util.inherits(RoomBridgeStore, BridgeStore);
 
 /**
- * Insert an entry, clobbering based on the ID.
+ * Insert an entry, clobbering based on the ID of the entry.
  * @param {RoomBridgeStore~Entry} entry
+ * @return {Promise}
  */
 RoomBridgeStore.prototype.upsertEntry = function(entry) {
     return this.upsert({
@@ -74,9 +93,9 @@ RoomBridgeStore.prototype.upsertEntry = function(entry) {
 }
 
 /**
- * Get an existing entry based on the provided ID.
- * @param {String} id
- * @return {?RoomBridgeStore~Entry}
+ * Get an existing entry based on the provided entry ID.
+ * @param {String} id The ID of the entry to retrieve.
+ * @return {?RoomBridgeStore~Entry} A promise which resolves to the entry or null.
  */
 RoomBridgeStore.prototype.getEntryById = function(id) {
     return this.selectOne({
@@ -89,7 +108,7 @@ RoomBridgeStore.prototype.getEntryById = function(id) {
 /**
  * Get a list of entries based on the matrix_id of each entry.
  * @param {string} matrixId
- * @return @return {RoomBridgeStore~Entry[]}
+ * @return {RoomBridgeStore~Entry[]}
  */
 RoomBridgeStore.prototype.getEntriesByMatrixId = function(matrixId) {
     return this.select({
@@ -102,7 +121,7 @@ RoomBridgeStore.prototype.getEntriesByMatrixId = function(matrixId) {
 /**
  * A batch version of <code>getEntriesByMatrixId</code>.
  * @param {String[]} ids
- * @return Promise<Map<string,RoomBridgeStore~Entry[]>, Error> Resolves
+ * @return {Object.<string,RoomBridgeStore~Entry[]>} Resolves
  * to a map of room_id => Entry[]
  */
 RoomBridgeStore.prototype.getEntriesByMatrixIds = function(ids) {
@@ -123,8 +142,9 @@ RoomBridgeStore.prototype.getEntriesByMatrixIds = function(ids) {
 };
 
 /**
- * Get entries based on their remote_id.
+ * Get a list of entries based on the remote_id of each entry.
  * @param {String} remoteId
+ * @return {RoomBridgeStore~Entry[]}
  */
 RoomBridgeStore.prototype.getEntriesByRemoteId = function(remoteId) {
     return this.select({
@@ -135,21 +155,30 @@ RoomBridgeStore.prototype.getEntriesByRemoteId = function(remoteId) {
 };
 
 /**
- * Create a link between a matrix room and remote room.
+ * Create a link between a matrix room and remote room. This will create an entry with:
+ * <ul>
+ * <li>The matrix_id set to the matrix room ID.</li>
+ * <li>The remote_id set to the remote room ID.</li>
+ * <li>The id set to the id value given OR a concatenation of the matrix and remote IDs
+ * if one is not provided.</li>
+ * </ul>
  * @param {MatrixRoom} matrixRoom The matrix room
  * @param {RemoteRoom} remoteRoom The remote room
  * @param {Object=} data Information about this mapping.
- * @param {string=} linkKey An additional unique key value.
+ * @param {string=} linkId The id value to set. If not given, a unique ID will be
+ * created from the matrix_id and remote_id.
  * @return {Promise}
  */
-RoomBridgeStore.prototype.linkRooms = function(matrixRoom, remoteRoom, data, linkKey) {
+RoomBridgeStore.prototype.linkRooms = function(matrixRoom, remoteRoom, data, linkId) {
     data = data || {};
-    linkKey = linkKey || createUniqueId(matrixRoom.getId(), remoteRoom.getId(), this.delimiter);
+    linkId = linkId || createUniqueId(
+        matrixRoom.getId(), remoteRoom.getId(), this.delimiter
+    );
     var self = this;
     return self.upsert({
-        id: linkKey
+        id: linkId
     }, {
-        id: linkKey,
+        id: linkId,
         remote_id: remoteRoom.getId(),
         matrix_id: matrixRoom.getId(),
         remote: remoteRoom.serialize(),
@@ -158,6 +187,15 @@ RoomBridgeStore.prototype.linkRooms = function(matrixRoom, remoteRoom, data, lin
     });
 };
 
+/**
+ * Create an entry with only a matrix room. Sets the 'id' of the entry to the
+ * Matrix room ID. If an entry already exists with this 'id', it will be replaced.
+ * This function is useful if you just want to store a room with some data and not
+ * worry about any mappings.
+ * @param {MatrixRoom} matrixRoom
+ * @return {Promise}
+ * @see RoomBridgeStore#getMatrixRoom
+ */
 RoomBridgeStore.prototype.setMatrixRoom = function(matrixRoom) {
     return this.upsertEntry({
         id: matrixRoom.getId(),
@@ -166,12 +204,25 @@ RoomBridgeStore.prototype.setMatrixRoom = function(matrixRoom) {
     });
 };
 
+/**
+ * Get an entry's Matrix room based on the provided room_id. The entry MUST have
+ * an 'id' of the room_id and there MUST be a Matrix room contained within the
+ * entry for this to return.
+ * @param {string} roomId
+ * @return {?MatrixRoom}
+ * @see RoomBridgeStore#setMatrixRoom
+ */
 RoomBridgeStore.prototype.getMatrixRoom = function(roomId) {
     return this.getEntryById(roomId).then(function(e) {
         return e ? e.matrix : null;
     });
 };
 
+/**
+ * Get all entries with the given remote_id which have a Matrix room within.
+ * @param {string} remoteId
+ * @return {MatrixRoom[]}
+ */
 RoomBridgeStore.prototype.getLinkedMatrixRooms = function(remoteId) {
     return this.getEntriesByRemoteId(remoteId).then(function(entries) {
         return entries.filter(function(e) {
@@ -182,6 +233,11 @@ RoomBridgeStore.prototype.getLinkedMatrixRooms = function(remoteId) {
     });
 };
 
+/**
+ * Get all entries with the given matrix_id which have a Remote room within.
+ * @param {string} matrixId
+ * @return {RemoteRoom[]}
+ */
 RoomBridgeStore.prototype.getLinkedRemoteRooms = function(matrixId) {
     return this.getEntriesByMatrixId(matrixId).then(function(entries) {
         return entries.filter(function(e) {
@@ -192,6 +248,12 @@ RoomBridgeStore.prototype.getLinkedRemoteRooms = function(matrixId) {
     });
 };
 
+/**
+ * A batched version of <code>getLinkedRemoteRooms</code>.
+ * @param {string[]} matrixIds
+ * @return {Object.<string, RemoteRoom>} A mapping of room_id to RemoteRoom.
+ * @see RoomBridgeStore#getLinkedRemoteRooms
+ */
 RoomBridgeStore.prototype.batchGetLinkedRemoteRooms = function(matrixIds) {
     return this.getEntriesByMatrixIds(matrixIds).then(function(entryMap) {
         Object.keys(entryMap).forEach(function(k) {
@@ -205,6 +267,18 @@ RoomBridgeStore.prototype.batchGetLinkedRemoteRooms = function(matrixIds) {
     });
 };
 
+
+/**
+ * Get a list of entries based on a RemoteRoom data value.
+ * @param {Object} data The data values to retrieve based from.
+ * @return {RoomBridgeStore~Entry[]} A list of entries
+ * @example
+ * remoteRoom.set("some_key", "some_val");
+ * // store remoteRoom and then:
+ * store.getEntriesByRemoteRoomData({
+ *     some_key: "some_val"
+ * });
+ */
 RoomBridgeStore.prototype.getEntriesByRemoteRoomData = function(data) {
     Object.keys(data).forEach(function(k) {
         var query = data[k];
@@ -216,6 +290,17 @@ RoomBridgeStore.prototype.getEntriesByRemoteRoomData = function(data) {
     }));
 };
 
+/**
+ * Get a list of entries based on a MatrixRoom data value.
+ * @param {Object} data The data values to retrieve based from.
+ * @return {RoomBridgeStore~Entry[]} A list of entries
+ * @example
+ * matrixRoom.set("some_key", "some_val");
+ * // store matrixRoom and then:
+ * store.getEntriesByMatrixRoomData({
+ *     some_key: "some_val"
+ * });
+ */
 RoomBridgeStore.prototype.getEntriesByMatrixRoomData = function(data) {
     Object.keys(data).forEach(function(k) {
         var query = data[k];
@@ -227,6 +312,17 @@ RoomBridgeStore.prototype.getEntriesByMatrixRoomData = function(data) {
     }));
 };
 
+/**
+ * Remove entries based on remote room data.
+ * @param {Object} data The data to match.
+ * @return {Promise}
+ * @example
+ * remoteRoom.set("a_key", "a_val");
+ * // store remoteRoom and then:
+ * store.removeEntriesByRemoteRoomData({
+ *     a_key: "a_val"
+ * });
+ */
 RoomBridgeStore.prototype.removeEntriesByRemoteRoomData = function(data) {
     Object.keys(data).forEach(function(k) {
         var query = data[k];
@@ -236,6 +332,18 @@ RoomBridgeStore.prototype.removeEntriesByRemoteRoomData = function(data) {
     return this.delete(data);
 };
 
+
+/**
+ * Remove entries based on matrix room data.
+ * @param {Object} data The data to match.
+ * @return {Promise}
+ * @example
+ * matrixRoom.set("a_key", "a_val");
+ * // store matrixRoom and then:
+ * store.removeEntriesByMatrixRoomData({
+ *     a_key: "a_val"
+ * });
+ */
 RoomBridgeStore.prototype.removeEntriesByMatrixRoomData = function(data) {
     Object.keys(data).forEach(function(k) {
         var query = data[k];

--- a/spec/integ/room-bridge-store.spec.js
+++ b/spec/integ/room-bridge-store.spec.js
@@ -154,7 +154,6 @@ describe("RoomBridgeStore", function() {
             }).done(function(results) {
                 expect(results["!foo:bar"].length).toEqual(2);
                 expect(results["!fizz:buzz"].length).toEqual(1);
-                
                 expect(results["!fizz:buzz"][0].remote.getId()).toEqual("#fizz");
                 expect(results["!foo:bar"].map(function(e) {
                     return e.remote.getId();

--- a/spec/integ/room-bridge-store.spec.js
+++ b/spec/integ/room-bridge-store.spec.js
@@ -39,394 +39,105 @@ describe("RoomBridgeStore", function() {
         }
     });
 
-    describe("setMatrixRoom", function() {
-        it("should be able to store a Matrix room, retrievable again via getMatrixRoom",
+    describe("upsertEntry", function() {
+        it("should insert an entry and should be retrievable by getEntryById",
         function(done) {
-            var room = new MatrixRoom("!foo:bar");
-            store.setMatrixRoom(room).then(function() {
-                return store.getMatrixRoom("!foo:bar");
-            }).done(function(r) {
-                expect(r.getId()).toEqual("!foo:bar");
+            var entry = {
+                id: "flibble",
+                matrix: new MatrixRoom("!foo:bar"),
+                remote: new RemoteRoom("#flibble"),
+            };
+            store.upsertEntry(entry).then(function() {
+                return store.getEntryById("flibble");
+            }).done(function(e) {
+                expect(e.id).toEqual(entry.id);
+                expect(e.matrix.getId()).toEqual("!foo:bar");
+                expect(e.remote.getId()).toEqual("#flibble");
+                done();
+            });
+        });
+
+        it("should update an entry if one with the same 'id' exists", function(done) {
+            var entry = {
+                id: "flibble",
+                matrix: new MatrixRoom("!foo:bar"),
+                remote: new RemoteRoom("#flibble"),
+            };
+            store.upsertEntry(entry).then(function() {
+                var entry2 = {
+                    id: "flibble",
+                    matrix: new MatrixRoom("!woo:bar"),
+                    remote: new RemoteRoom("#wibble"),
+                };
+                return store.upsertEntry(entry2);
+            }).then(function() {
+                return store.getEntryById("flibble");
+            }).done(function(e) {
+                expect(e.id).toEqual("flibble");
+                expect(e.matrix.getId()).toEqual("!woo:bar");
+                expect(e.remote.getId()).toEqual("#wibble");
                 done();
             });
         });
     });
 
-    describe("setRemoteRoom", function() {
-        it("should be able to store a Remote room, retrievable again via getRemoteRoom",
-        function(done) {
-            var room = new RemoteRoom("some id");
-            room.set("thing", "here");
-            room.set("nested", {
-                foo: "bar"
-            });
-            store.setRemoteRoom(room).then(function() {
-                return store.getRemoteRoom("some id");
-            }).done(function(r) {
-                expect(r.getId()).toEqual("some id");
-                expect(r.get("thing")).toEqual("here");
-                expect(r.get("nested")).toEqual({
-                    foo: "bar"
-                });
+    describe("getEntryById", function() {
+
+        it("should return nothing for matching matrix_id or remote_id", function(done) {
+            var entry = {
+                id: "flibble",
+                matrix: new MatrixRoom("!nothing:here"),
+                remote: new RemoteRoom("!nothing:here"),
+            };
+            store.upsertEntry(entry).then(function() {
+                return store.getEntryById("!nothing:here");
+            }).done(function(e) {
+                expect(e).toBeNull();
                 done();
             });
+        });
+    });
+
+    describe("getEntriesByMatrixId", function() {
+        it("should return for matching matrix_ids", function(done) {
+            var entry = {
+                id: "id1", matrix: new MatrixRoom("!foo:bar"),
+                remote: new RemoteRoom("#foo")
+            };
+            var entry2 = {
+                id: "id2", matrix: new MatrixRoom("!foo:bar"),
+                remote: new RemoteRoom("#bar")
+            };
+            Promise.all(
+                [store.upsertEntry(entry), store.upsertEntry(entry2)]
+            ).then(function() {
+                return store.getEntriesByMatrixId("!foo:bar");
+            }).done(function(results) {
+                expect(results.length).toEqual(2);
+                var remoteIds = results.map(function(res) {
+                    return res.remote.getId();
+                });
+                expect(remoteIds.sort()).toEqual(["#bar", "#foo"]);
+                done();
+            })
+        });
+    });
+
+    describe("getEntriesByMatrixIds", function() {
+        it("should return a map of room_id to entry", function(done) {
+            done();
+        });
+    });
+
+    describe("getEntriesByRemoteId", function() {
+        it("should return for matching remote_ids", function(done) {
+            done();
         });
     });
 
     describe("linkRooms", function() {
-        it("should create both rooms if they didn't exist previously",
-        function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("foo_bar");
-            store.linkRooms(matrixRoom, remoteRoom).then(function() {
-                return store.getMatrixRoom("!foo:bar");
-            }).then(function(m) {
-                expect(m.getId()).toEqual("!foo:bar");
-                return store.getRemoteRoom("foo_bar");
-            }).done(function(j) {
-                expect(j.getId()).toEqual("foo_bar");
-                done();
-            });
-        });
-
-        it("should create a matrix room if they didn't exist previously",
-        function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("foo_bar");
-            store.setRemoteRoom(remoteRoom).then(function() {
-                return store.linkRooms(matrixRoom, remoteRoom);
-            }).then(function() {
-                return store.getMatrixRoom("!foo:bar");
-            }).done(function(m) {
-                expect(m.getId()).toEqual("!foo:bar");
-                done();
-            });
-        });
-
-        it("should create a remote room if they didn't exist previously",
-        function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("foo_bar");
-            store.setMatrixRoom(matrixRoom).then(function() {
-                return store.linkRooms(matrixRoom, remoteRoom);
-            }).then(function() {
-                return store.getRemoteRoom("foo_bar");
-            }).done(function(j) {
-                expect(j.getId()).toEqual("foo_bar");
-                done();
-            });
-        });
-
-        it("should not clobber rooms if they exist",
-        function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var storedRemoteRoom = new RemoteRoom("foo_bar");
-            storedRemoteRoom.set("sentinel", 42);
-            store.setRemoteRoom(storedRemoteRoom).then(function() {
-                var newRemoteRoom = new RemoteRoom("foo_bar");
-                return store.linkRooms(matrixRoom, newRemoteRoom);
-            }).then(function() {
-                return store.getRemoteRoom("foo_bar");
-            }).done(function(j) {
-                expect(j.getId()).toEqual("foo_bar");
-                expect(j.get("sentinel")).toEqual(42);
-                done();
-            });
-        });
-
-        it("should support custom link keys", function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("foo_bar");
-            var linkKey = "flibble";
-            var data = { foo: "bar" };
-            store.linkRooms(matrixRoom, remoteRoom, data, linkKey).then(function() {
-                return store.getLinksByKey(linkKey);
-            }).done(function(links) {
-                expect(links.length).toEqual(1);
-                var link = links[0];
-                expect(link.link_key).toEqual(linkKey);
-                expect(link.matrix).toEqual(matrixRoom.getId());
-                expect(link.remote).toEqual(remoteRoom.getId());
-                expect(link.data).toEqual(data);
-                done();
-            });
-        });
-    });
-
-    describe("unlinkByData", function() {
-        it("should delete links which match the given data", function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("#foo_bar");
-            var data = { foo: "bar" };
-            store.linkRooms(matrixRoom, remoteRoom, data).then(function() {
-                return store.unlinkByData(data);
-            }).done(function(deleteNum) {
-                expect(deleteNum).toEqual(1);
-                done();
-            });
-        });
-
-        it("should delete links which partially match the given data", function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("#foo_bar");
-            var data = { foo: "bar", tar: 6 };
-            store.linkRooms(matrixRoom, remoteRoom, data).then(function() {
-                return store.unlinkByData({ foo: "bar" });
-            }).done(function(deleteNum) {
-                expect(deleteNum).toEqual(1);
-                done();
-            });
-        });
-
-        it("should NOT delete links which do not match the given data", function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("#foo_bar");
-            var data = { foo: "bar", tar: 6 };
-            store.linkRooms(matrixRoom, remoteRoom, data).then(function() {
-                return store.unlinkByData({ foo: "bar", tar: 99 });
-            }).done(function(deleteNum) {
-                expect(deleteNum).toEqual(0);
-                done();
-            });
-        });
-
-        it("should NOT delete links which have the same remote/matrix IDs",
-        function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("#foo_bar");
-            var data = { foo: "bar" };
-            var linkKey = "flibble";
-            store.linkRooms(matrixRoom, remoteRoom, data).then(function() {
-                return store.linkRooms(matrixRoom, remoteRoom, undefined, linkKey);
-            }).then(function() {
-                return store.unlinkByData(data);
-            }).done(function(deleteNum) {
-                expect(deleteNum).toEqual(1);
-                done();
-            });
-        });
-    });
-
-    describe("unlinkRooms", function() {
-        it("should delete a link made previously with linkRooms", function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("foo_bar");
-            store.linkRooms(matrixRoom, remoteRoom).then(function() {
-                return store.unlinkRooms(matrixRoom, remoteRoom);
-            }).then(function() {
-                return store.getMatrixLinks("foo_bar");
-            }).done(function(links) {
-                expect(links.length).toEqual(0);
-                done();
-            });
-        });
-    });
-
-    describe("getLinksByData", function() {
-        it("should be able to retrieve links based off nested data keys",
-        function(done) {
-            var matrixRoom = new MatrixRoom("!foo:bar");
-            var remoteRoom = new RemoteRoom("foo_bar");
-            var data = {
-                nested: {
-                    key: "value"
-                }
-            };
-            store.linkRooms(matrixRoom, remoteRoom, data).then(function() {
-                return store.getLinksByData({
-                    "nested.key": "value"
-                });
-            }).done(function(links) {
-                expect(links.length).toEqual(1);
-                expect(links[0].matrix).toEqual("!foo:bar");
-                expect(links[0].remote).toEqual("foo_bar");
-                expect(links[0].data).toEqual(data);
-                done();
-            });
-        });
-
-        it("should throw if the data query isn't an object", function() {
-            expect(function() {
-                store.getLinksByData("nested.key");
-            }).toThrow();
-        });
-    });
-
-    describe("getMatrixLinks", function() {
-        var matrixRoom = new MatrixRoom("!foo:bar");
-        var remoteRoom = new RemoteRoom("foo_bar");
-
-        beforeEach(function(done) {
-            store.linkRooms(matrixRoom, remoteRoom).done(function() {
-                done();
-            });
-        });
-
-        it("should return an empty list if there are no links", function(done) {
-            store.getMatrixLinks("nothing").done(function(links) {
-                expect(links.length).toEqual(0);
-                done();
-            });
-        });
-        it("should return a one element list for a single link", function(done) {
-            store.getMatrixLinks("foo_bar").done(function(links) {
-                expect(links.length).toEqual(1);
-                expect(links[0].matrix).toEqual("!foo:bar");
-                expect(links[0].remote).toEqual("foo_bar");
-                expect(links[0].data).toEqual({});
-                done();
-            })
-        });
-        it("should return a list for multiple links", function(done) {
-            var matrixTwo = new MatrixRoom("!baz:bar");
-            store.linkRooms(matrixTwo, remoteRoom).then(function() {
-                return store.getMatrixLinks("foo_bar");
-            }).done(function(links) {
-                expect(links.length).toEqual(2);
-                done();
-            });
-        });
-    });
-
-    describe("getRemoteLinks", function() {
-        var matrixRoom = new MatrixRoom("!foo:bar");
-        var remoteRoom = new RemoteRoom("foo_bar");
-
-        beforeEach(function(done) {
-            store.linkRooms(matrixRoom, remoteRoom).done(function() {
-                done();
-            });
-        });
-
-        it("should return an empty list if there are no links", function(done) {
-            store.getRemoteLinks("nothing").done(function(links) {
-                expect(links.length).toEqual(0);
-                done();
-            });
-        });
-        it("should return a one element list for a single link", function(done) {
-            store.getRemoteLinks("!foo:bar").done(function(links) {
-                expect(links.length).toEqual(1);
-                expect(links[0].matrix).toEqual("!foo:bar");
-                expect(links[0].remote).toEqual("foo_bar");
-                expect(links[0].data).toEqual({});
-                done();
-            })
-        });
-        it("should return a list for multiple links", function(done) {
-            var remoteTwo = new RemoteRoom("foo_bar_2");
-            store.linkRooms(matrixRoom, remoteTwo).then(function() {
-                return store.getRemoteLinks("!foo:bar");
-            }).done(function(links) {
-                expect(links.length).toEqual(2);
-                links.forEach(function(link) {
-                    expect(["foo_bar", "foo_bar_2"].indexOf(
-                        link.remote
-                    )).not.toEqual(-1, "Bad remote ID returned");
-                });
-                done();
-            });
-        });
-    });
-
-    describe("batchGetRemoteLinks", function() {
-        var entries = [
-            { mx: new MatrixRoom("!foo:bar"), r: new RemoteRoom("#foo_bar") },
-            // same remote mapping
-            { mx: new MatrixRoom("!foo_bar:bar"), r: new RemoteRoom("#foo_bar") },
-            { mx: new MatrixRoom("!fizz:buzz"), r: new RemoteRoom("#fizz_buzz") },
-            { mx: new MatrixRoom("!alpha:beta"), r: new RemoteRoom("#alpha_beta") },
-            // same matrix mapping
-            { mx: new MatrixRoom("!alpha:beta"), r: new RemoteRoom("#alpha_bet") }
-        ];
-        var expectedOutput = {
-            "!foo:bar": ["#foo_bar"],
-            "!foo_bar:bar": ["#foo_bar"],
-            "!fizz:buzz": ["#fizz_buzz"],
-            "!alpha:beta": ["#alpha_beta", "#alpha_bet"]
-        }
-
-        // persist the links
-        beforeEach(function(done) {
-            Promise.all(entries.map(function(e) {
-                return store.linkRooms(e.mx, e.r);
-            })).done(function() {
-                done();
-            });
-        });
-
-        it("should return a map of links", function(done) {
-            var mxIds = Object.keys(expectedOutput);
-            store.batchGetRemoteLinks(mxIds).done(function(outputMap) {
-                // make sure the keys are all there with the right links
-                mxIds.forEach(function(roomId) {
-                    var outputLinks = outputMap[roomId];
-                    expect(outputLinks).toBeDefined();
-                    if (!outputLinks) {
-                        return;
-                    }
-                    expect(outputLinks.length).toEqual(expectedOutput[roomId].length);
-                    var linkIds = outputLinks.map(function(l) {
-                        return l.remote;
-                    });
-                    expect(linkIds.sort()).toEqual(expectedOutput[roomId].sort());
-                });
-                done();
-            });
-        });
-
-        it("should return an empty list if there are no links", function(done) {
-            store.batchGetRemoteLinks(["!nada:here", "!more:na"]).done(function(links) {
-                expect(Object.keys(links).length).toEqual(0);
-                done();
-            });
-        });
-    });
-
-    describe("batchGetLinkedRemoteRooms", function() {
-        var entries = [
-            { mx: new MatrixRoom("!foo:bar"), r: new RemoteRoom("#foo_bar") },
-            // same remote mapping
-            { mx: new MatrixRoom("!foo_bar:bar"), r: new RemoteRoom("#foo_bar") },
-            { mx: new MatrixRoom("!fizz:buzz"), r: new RemoteRoom("#fizz_buzz") },
-            { mx: new MatrixRoom("!alpha:beta"), r: new RemoteRoom("#alpha_beta") },
-            // same matrix mapping
-            { mx: new MatrixRoom("!alpha:beta"), r: new RemoteRoom("#alpha_bet") }
-        ];
-        var expectedOutput = {
-            "!foo:bar": ["#foo_bar"],
-            "!foo_bar:bar": ["#foo_bar"],
-            "!fizz:buzz": ["#fizz_buzz"],
-            "!alpha:beta": ["#alpha_beta", "#alpha_bet"]
-        }
-
-        // persist the links
-        beforeEach(function(done) {
-            Promise.all(entries.map(function(e) {
-                return store.linkRooms(e.mx, e.r);
-            })).done(function() {
-                done();
-            });
-        });
-
-        it("should return a map of RemoteRooms", function(done) {
-            var mxIds = Object.keys(expectedOutput);
-            store.batchGetLinkedRemoteRooms(mxIds).done(function(outputMap) {
-                // make sure the keys are all there with the right links
-                mxIds.forEach(function(roomId) {
-                    var outRemoteRooms = outputMap[roomId];
-                    expect(outRemoteRooms).toBeDefined();
-                    if (!outRemoteRooms) {
-                        return;
-                    }
-                    expect(outRemoteRooms.length).toEqual(expectedOutput[roomId].length);
-                    var remoteIds = outRemoteRooms.map(function(r) {
-                        return r.getId();
-                    });
-                    expect(remoteIds.sort()).toEqual(expectedOutput[roomId].sort());
-                });
-                done();
-            });
+        it("should create a single entry", function(done) {
+            done();
         });
     });
 });

--- a/spec/integ/room-bridge-store.spec.js
+++ b/spec/integ/room-bridge-store.spec.js
@@ -98,6 +98,66 @@ describe("RoomBridgeStore", function() {
         });
     });
 
+    describe("getEntriesByRemoteRoomData", function() {
+
+        it("should return entries based on remote room data", function(done) {
+            var entry = {
+                id: "flibble",
+                matrix: new MatrixRoom("!nothing:here"),
+                remote: new RemoteRoom("#foo"),
+            };
+            entry.remote.set("custom", "abc123");
+            store.upsertEntry(entry).then(function() {
+                return store.getEntriesByRemoteRoomData({
+                    custom: "abc123"
+                });
+            }).done(function(e) {
+                expect(e).toBeDefined();
+                if (!e) {
+                    done();
+                    return;
+                }
+                expect(e.length).toEqual(1);
+                if (!e[0]) {
+                    done();
+                    return;
+                }
+                expect(e[0].remote.getId()).toEqual("#foo");
+                done();
+            });
+        });
+    });
+
+    describe("getEntriesByMatrixRoomData", function() {
+
+        it("should return entries based on matrix room data", function(done) {
+            var entry = {
+                id: "flibble",
+                matrix: new MatrixRoom("!nothing:here"),
+                remote: new RemoteRoom("#foo"),
+            };
+            entry.matrix.set("custom", "abc123");
+            store.upsertEntry(entry).then(function() {
+                return store.getEntriesByMatrixRoomData({
+                    custom: "abc123"
+                });
+            }).done(function(e) {
+                expect(e).toBeDefined();
+                if (!e) {
+                    done();
+                    return;
+                }
+                expect(e.length).toEqual(1);
+                if (!e[0]) {
+                    done();
+                    return;
+                }
+                expect(e[0].matrix.getId()).toEqual("!nothing:here");
+                done();
+            });
+        });
+    });
+
     describe("getEntriesByMatrixId", function() {
         it("should return for matching matrix_ids", function(done) {
             var entry = {


### PR DESCRIPTION
As per https://github.com/matrix-org/matrix-appservice-irc/issues/68 - this PR re-implements the room store to be much more efficient. It does this by:
 - Strictly having 1 entry per mapping, so fewer total documents are in the database.
 - Slightly de-normalising data for multi-mapped rooms to reduce the number of queries needed to retrieve mapped room data.

This format is **not compatible** with the current format, which means this is effectively a new MAJOR version of the library.