### PR TITLE
Better scheduling of events sent to HS

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -3,6 +3,7 @@
 var AppServiceRegistration = require("matrix-appservice").AppServiceRegistration;
 var AppService = require("matrix-appservice").AppService;
 var ClientFactory = require("./components/client-factory");
+var MatrixScheduler = require("matrix-js-sdk").MatrixScheduler;
 var AppServiceBot = require("./components/app-service-bot");
 var RequestFactory = require("./components/request-factory");
 var Intent = require("./components/intent");
@@ -185,7 +186,8 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
         token: self.opts.registration.as_token,
         appServiceUserId: (
             "@" + self.opts.registration.sender_localpart + ":" + self.opts.domain
-        )
+        ),
+        clientScheduler: new MatrixScheduler(retryAlgorithm, queueAlgorithm)
     });
     this._clientFactory.setLogFunction(function(text, isErr) {
         if (!self.opts.controller.onLog) {
@@ -494,6 +496,38 @@ function loadDatabase(path, Cls) {
         }
     });
     return defer.promise;
+}
+
+function retryAlgorithm(event, attempts, err) {
+    if (err.httpStatus === 400 || err.httpStatus === 403 || err.httpStatus === 401) {
+        // client error; no amount of retrying with save you now.
+        return -1;
+    }
+    // we ship with browser-request which returns { cors: rejected } when trying
+    // with no connection, so if we match that, give up since they have no conn.
+    if (err.cors === "rejected") {
+        return -1;
+    }
+
+    if (err.name === "M_LIMIT_EXCEEDED") {
+        var waitTime = err.data.retry_after_ms;
+        if (waitTime) {
+            return waitTime;
+        }
+    }
+    if (attempts > 4) {
+        return -1; // give up
+    }
+    return 1000 + (1000 * attempts);
+}
+
+function queueAlgorithm(event) {
+    if (event.getType() === "m.room.message") {
+        // use a separate queue for each room ID
+        return "message_" + event.getRoomId();
+    }
+    // allow all other events continue concurrently.
+    return null;
 }
 
 function EventQueue(opts, consumeFn) {

--- a/lib/components/client-factory.js
+++ b/lib/components/client-factory.js
@@ -13,6 +13,9 @@ var requestModule = require("request");
  * @param {string=} opts.appServiceUserId The application service's user ID. Must
  * be set prior to calling getClientAs(). See configure() to set this after
  * instantiation.
+ * @param {MatrixScheduler} opts.clientScheduler Optional. The client scheduler to
+ * use in place of the default event scheduler that schedules events to be sent to
+ * the HS.
  */
 function ClientFactory(opts) {
     opts = opts || {};

--- a/lib/components/client-factory.js
+++ b/lib/components/client-factory.js
@@ -22,6 +22,7 @@ function ClientFactory(opts) {
     //      user_id: Client
     //  }
     };
+    this._clientScheduler = opts.clientScheduler;
     this.configure(opts.url, opts.token, opts.appServiceUserId);
 }
 
@@ -102,12 +103,14 @@ ClientFactory.prototype.getClientAs = function(userId, request) {
     }
     // force set access_token= so it is used when /register'ing
     queryParams.access_token = this._token;
-    client = this._sdk.createClient({
+    var clientOpts = {
         accessToken: this._token,
         baseUrl: this._url,
         userId: userId || this._botUserId, // NB: no clobber so we don't set ?user_id=BOT
-        queryParams: queryParams
-    });
+        queryParams: queryParams,
+        scheduler: this._clientScheduler
+    };
+    client = this._sdk.createClient(clientOpts);
     client._http.opts._reqId = reqId; // FIXME gut wrenching
 
     // add a listener for the completion of this request so we can cleanup


### PR DESCRIPTION
Previously, the bridge bot may become head-of-line blocked by it's own event scheduling back-off. This has been made less aggressive; the delay between each request to send a previously failed sending of event increases linearly now.

Also, the queuing algorithm separates queues by room ID.

Fix for https://github.com/matrix-org/matrix-appservice-irc/issues/122