### PR TITLE
Provide wrapper for 3PE lookup APIs

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -268,7 +268,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
             });
         }
 
-        app.get("/_matrix/app/:ver/thirdparty/protocol/:protocol", (req, res) => {
+        app.get("/_matrix/app/:ver/thirdparty/protocol/:protocol", function(req, res) {
             if (req.params.ver != "unstable") {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
@@ -287,12 +287,12 @@ Bridge.prototype.customiseAppservice = function(appService) {
             }
 
             lookupController.getProtocol(protocol).then(
-                (result) => { res.status(200).json(result) },
-                (e)      => { res.status(e.code).json({error: e.err}) }
+                function(result) { res.status(200).json(result) },
+                function(e) { res.status(e.code).json({error: e.err}) }
             );
         });
 
-        app.get("/_matrix/app/:ver/thirdparty/location/:protocol", (req, res) => {
+        app.get("/_matrix/app/:ver/thirdparty/location/:protocol", function(req, res) {
             if (req.params.ver != "unstable") {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
@@ -311,12 +311,12 @@ Bridge.prototype.customiseAppservice = function(appService) {
             }
 
             lookupController.getLocation(protocol, req.query).then(
-                (result) => { res.status(200).json([result]) },
-                (e)      => { res.status(e.code).json({error: e.err}) }
+                function(result) { res.status(200).json(result) },
+                function(e) { res.status(e.code).json({error: e.err}) }
             );
         });
 
-        app.get("/_matrix/app/:ver/thirdparty/user/:protocol", (req, res) => {
+        app.get("/_matrix/app/:ver/thirdparty/user/:protocol", function(req, res) {
             if (req.params.ver != "unstable") {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
@@ -335,8 +335,8 @@ Bridge.prototype.customiseAppservice = function(appService) {
             }
 
             lookupController.getUser(protocol, req.query).then(
-                (result) => { res.status(200).json([result]) },
-                (e)      => { res.status(e.code).json({error: e.err}) }
+                function(result) { res.status(200).json(result) },
+                function(e) { res.status(e.code).json({error: e.err}) }
             );
         });
     }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -857,8 +857,8 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
   * Invoked on requests for 3PE query metadata
   * @callback Bridge~getProtocol
   * @param {string} protocol The name of the 3PE protocol to query
-  * @return {Bridge~thirdPartyProtocolResult} Metadata about 3PE queries that
-  * can be made for this protocol.
+  * @return {Promise<Bridge~thirdPartyProtocolResult>} A Promise of metadata
+  * about 3PE queries that can be made for this protocol.
   */
 
  /**
@@ -876,7 +876,8 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
   * @param {string} protocol The name of the 3PE protocol
   * @param {Object} fields The location query field data as specified by the
   * specific protocol.
-  * @return {Bridge~thirdPartyLocationResult} A 3PL lookup result
+  * @return {Promise<Bridge~thirdPartyLocationResult>} A Promise of a 3PL
+  * lookup result.
   */
 
  /**
@@ -895,7 +896,8 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
   * @param {string} protocol The name of the 3PE protocol
   * @param {Object} fields The user query field data as specified by the
   * specific protocol.
-  * @return {Bridge~thirdPartyUserResult} A 3PU lookup result
+  * @return {Promise<Bridge~thirdPartyUserResult>} A Promise of a 3PU lookup
+  * result.
   */
 
  /**

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -262,61 +262,73 @@ Bridge.prototype._customiseAppservice = function() {
             }
         }
 
-        this.addAppServicePath("GET", "/_matrix/app/:ver/thirdparty/protocol/:protocol", function(req, res) {
-            if (req.params.ver !== "unstable" || !lookupController.getProtocol) {
-                res.status(404).send("Cannot GET " + req.path + "\r\n");
-                return;
-            }
+        this.addAppServicePath({
+            method: "GET",
+            path: "/_matrix/app/:ver/thirdparty/protocol/:protocol",
+            handler: function(req, res) {
+                if (req.params.ver !== "unstable" || !lookupController.getProtocol) {
+                    res.status(404).send("Cannot GET " + req.path + "\r\n");
+                    return;
+                }
 
-            var protocol = req.params.protocol;
+                var protocol = req.params.protocol;
 
-            if (protocols.length && protocols.indexOf(protocol) === -1) {
-                res.status(404).json({err: "Unknown 3PN protocol " + protocol});
-                return;
-            }
+                if (protocols.length && protocols.indexOf(protocol) === -1) {
+                    res.status(404).json({err: "Unknown 3PN protocol " + protocol});
+                    return;
+                }
 
-            lookupController.getProtocol(protocol).then(
-                function(result) { res.status(200).json(result) },
-                function(e) { _respondErr(e, res) }
-            );
+                lookupController.getProtocol(protocol).then(
+                    function(result) { res.status(200).json(result) },
+                    function(e) { _respondErr(e, res) }
+                );
+            },
         });
 
-        this.addAppServicePath("GET", "/_matrix/app/:ver/thirdparty/location/:protocol", function(req, res) {
-            if (req.params.ver !== "unstable" || !lookupController.getLocation) {
-                res.status(404).send("Cannot GET " + req.path + "\r\n");
-                return;
-            }
+        this.addAppServicePath({
+            method: "GET",
+            path: "/_matrix/app/:ver/thirdparty/location/:protocol",
+            handler: function(req, res) {
+                if (req.params.ver !== "unstable" || !lookupController.getLocation) {
+                    res.status(404).send("Cannot GET " + req.path + "\r\n");
+                    return;
+                }
 
-            var protocol = req.params.protocol;
+                var protocol = req.params.protocol;
 
-            if (protocols.length && protocols.indexOf(protocol) === -1) {
-                res.status(404).json({err: "Unknown 3PN protocol " + protocol});
-                return;
-            }
+                if (protocols.length && protocols.indexOf(protocol) === -1) {
+                    res.status(404).json({err: "Unknown 3PN protocol " + protocol});
+                    return;
+                }
 
-            lookupController.getLocation(protocol, req.query).then(
-                function(result) { res.status(200).json(result) },
-                function(e) { _respondErr(e, res) }
-            );
+                lookupController.getLocation(protocol, req.query).then(
+                    function(result) { res.status(200).json(result) },
+                    function(e) { _respondErr(e, res) }
+                );
+            },
         });
 
-        this.addAppServicePath("GET", "/_matrix/app/:ver/thirdparty/user/:protocol", function(req, res) {
-            if (req.params.ver !== "unstable" || !lookupController.getUser) {
-                res.status(404).send("Cannot GET " + req.path + "\r\n");
-                return;
+        this.addAppServicePath({
+            method: "GET",
+            path: "/_matrix/app/:ver/thirdparty/user/:protocol",
+            handler: function(req, res) {
+                if (req.params.ver !== "unstable" || !lookupController.getUser) {
+                    res.status(404).send("Cannot GET " + req.path + "\r\n");
+                    return;
+                }
+
+                var protocol = req.params.protocol;
+
+                if (protocols.length && protocols.indexOf(protocol) === -1) {
+                    res.status(404).json({err: "Unknown 3PN protocol " + protocol});
+                    return;
+                }
+
+                lookupController.getUser(protocol, req.query).then(
+                    function(result) { res.status(200).json(result) },
+                    function(e) { _respondErr(e, res) }
+                );
             }
-
-            var protocol = req.params.protocol;
-
-            if (protocols.length && protocols.indexOf(protocol) === -1) {
-                res.status(404).json({err: "Unknown 3PN protocol " + protocol});
-                return;
-            }
-
-            lookupController.getUser(protocol, req.query).then(
-                function(result) { res.status(200).json(result) },
-                function(e) { _respondErr(e, res) }
-            );
         });
     }
 };
@@ -324,17 +336,18 @@ Bridge.prototype._customiseAppservice = function() {
 /**
  * Install a custom handler for an incoming HTTP API request. This allows
  * callers to add extra functionality, implement new APIs, etc...
- * @param {string} method The HTTP method name.
- * @param {string} path Path to the endpoint.
- * @param {Bridge~appServicePathHandler} handlerFn Function to handle requests
+ * @param {Object} opts Named options
+ * @param {string} opts.method The HTTP method name.
+ * @param {string} opts.path Path to the endpoint.
+ * @param {Bridge~appServicePathHandler} opts.handlerFn Function to handle requests
  * to this endpoint.
  */
-Bridge.prototype.addAppServicePath = function(method, path, handlerFn) {
+Bridge.prototype.addAppServicePath = function(opts) {
     // TODO(paul): This is gut-wrenching into the AppService instance itself.
     //   Maybe an API on that object would be good?
     var app = this.appService.app;
 
-    app[method.toLowerCase()](path, handlerFn);
+    app[opts.method.toLowerCase()](opts.path, opts.handlerFn);
 };
 
 /**

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -240,7 +240,7 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
         }
         self.opts.controller.onLog(line, false);
     });
-    this._customiseAppservice(this.appService);
+    this._customiseAppservice();
     this.appService.listen(port);
     return this.loadDatabases();
 };
@@ -248,16 +248,12 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
 /**
  * Apply any customisations required on the appService object.
  */
-Bridge.prototype._customiseAppservice = function(appService) {
-    // TODO(paul): This is gut-wrenching into the AppService instance itself.
-    //   Maybe an API on that object would be good?
-    var app = appService.app;
-
+Bridge.prototype._customiseAppservice = function() {
     if (this.opts.controller.thirdPartyLookup) {
         var lookupController = this.opts.controller.thirdPartyLookup;
         var protocols = lookupController.protocols || [];
 
-        app.get("/_matrix/app/:ver/thirdparty/protocol/:protocol", function(req, res) {
+        this.addAppServicePath("GET", "/_matrix/app/:ver/thirdparty/protocol/:protocol", function(req, res) {
             if (req.params.ver !== "unstable" || !lookupController.getProtocol) {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
@@ -276,7 +272,7 @@ Bridge.prototype._customiseAppservice = function(appService) {
             );
         });
 
-        app.get("/_matrix/app/:ver/thirdparty/location/:protocol", function(req, res) {
+        this.addAppServicePath("GET", "/_matrix/app/:ver/thirdparty/location/:protocol", function(req, res) {
             if (req.params.ver !== "unstable" || !lookupController.getLocation) {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
@@ -295,7 +291,7 @@ Bridge.prototype._customiseAppservice = function(appService) {
             );
         });
 
-        app.get("/_matrix/app/:ver/thirdparty/user/:protocol", function(req, res) {
+        this.addAppServicePath("GET", "/_matrix/app/:ver/thirdparty/user/:protocol", function(req, res) {
             if (req.params.ver !== "unstable" || !lookupController.getUser) {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
@@ -314,6 +310,22 @@ Bridge.prototype._customiseAppservice = function(appService) {
             );
         });
     }
+};
+
+/**
+ * Install a custom handler for an incoming HTTP API request. This allows
+ * callers to add extra functionality, implement new APIs, etc...
+ * @param {string} method The HTTP method name.
+ * @param {string} path Path to the endpoint.
+ * @param {Bridge~appServicePathHandler} handlerFn Function to handle requests
+ * to this endpoint.
+ */
+Bridge.prototype.addAppServicePath = function(method, path, handlerFn) {
+    // TODO(paul): This is gut-wrenching into the AppService instance itself.
+    //   Maybe an API on that object would be good?
+    var app = this.appService.app;
+
+    app[method.toLowerCase()](path, handlerFn);
 };
 
 /**
@@ -817,6 +829,16 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  * @param {string} line The text to be logged.
  * @param {boolean} isError True if this line should be treated as an error msg.
  */
+
+ /**
+  * Handler function for custom applied HTTP API request paths. This is invoked
+  * as defined by expressjs.
+  * @callback Bridge~appServicePathHandler
+  * @param {Request} req An expressjs Request object the handler can use to
+  * inspect the incoming request.
+  * @param {Response} res An expressjs Response object the handler can use to
+  * send the outgoing response.
+  */
 
  /**
   * @typedef Bridge~thirdPartyLookup

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -240,19 +240,15 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
         }
         self.opts.controller.onLog(line, false);
     });
-    this.customiseAppservice(this.appService);
+    this._customiseAppservice(this.appService);
     this.appService.listen(port);
     return this.loadDatabases();
 };
 
 /**
  * Apply any customisations required on the appService object.
- * Subclasses are intended to override this method where appropriate. If
- * overridden the subclass method will still have to call the one in this
- * class.
- * @param {AppService} the AppService instance of the object
  */
-Bridge.prototype.customiseAppservice = function(appService) {
+Bridge.prototype._customiseAppservice = function(appService) {
     // TODO(paul): This is gut-wrenching into the AppService instance itself.
     //   Maybe an API on that object would be good?
     var app = appService.app;

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -260,6 +260,14 @@ Bridge.prototype.customiseAppservice = function(appService) {
     if (this.opts.controller.thirdPartyLookup) {
         var lookupController = this.opts.controller.thirdPartyLookup;
 
+        var protocolFilter;
+        if ("protocols" in lookupController) {
+            protocolFilter = {};
+            lookupController.protocols.forEach(function (p) {
+                protocolFilter[p] = true;
+            });
+        }
+
         app.get("/_matrix/app/:ver/thirdparty/protocol/:protocol", (req, res) => {
             if (req.params.ver != "unstable") {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
@@ -271,7 +279,14 @@ Bridge.prototype.customiseAppservice = function(appService) {
                 return;
             }
 
-            lookupController.getProtocol(req.params.protocol).then(
+            var protocol = req.params.protocol;
+
+            if (protocolFilter && !(protocol in protocolFilter)) {
+                res.status(404).json({err: "Unknown 3PN protocol " + protocol});
+                return;
+            }
+
+            lookupController.getProtocol(protocol).then(
                 (result) => { res.status(200).json(result) },
                 (e)      => { res.status(e.code).json({error: e.err}) }
             );
@@ -288,7 +303,14 @@ Bridge.prototype.customiseAppservice = function(appService) {
                 return;
             }
 
-            lookupController.getLocation(req.params.protocol, req.query).then(
+            var protocol = req.params.protocol;
+
+            if (protocolFilter && !(protocol in protocolFilter)) {
+                res.status(404).json({err: "Unknown 3PN protocol " + protocol});
+                return;
+            }
+
+            lookupController.getLocation(protocol, req.query).then(
                 (result) => { res.status(200).json([result]) },
                 (e)      => { res.status(e.code).json({error: e.err}) }
             );
@@ -305,7 +327,14 @@ Bridge.prototype.customiseAppservice = function(appService) {
                 return;
             }
 
-            lookupController.getUser(req.params.protocol, req.query).then(
+            var protocol = req.params.protocol;
+
+            if (protocolFilter && !(protocol in protocolFilter)) {
+                res.status(404).json({err: "Unknown 3PN protocol " + protocol});
+                return;
+            }
+
+            lookupController.getUser(protocol, req.query).then(
                 (result) => { res.status(200).json([result]) },
                 (e)      => { res.status(e.code).json({error: e.err}) }
             );
@@ -818,6 +847,9 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  /**
   * @typedef Bridge~thirdPartyLookup
   * @type {Object}
+  * @property {string[]} protocols Optional list of recognised protocol names.
+  * If present, lookups for unrecognised protocols will be automatically
+  * rejected.
   * @property {Bridge~getProtocol} getProtocol Function. Called for requests
   * for 3PE query metadata.
   * @property {Bridge~getLocation} getLocation Function. Called for requests

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -253,7 +253,7 @@ Bridge.prototype._customiseAppservice = function() {
         var lookupController = this.opts.controller.thirdPartyLookup;
         var protocols = lookupController.protocols || [];
 
-        function _respondErr(e, res) {
+        var _respondErr = function(e, res) {
             if (typeof e === "object" && e.code && e.err) {
                 res.status(e.code).json({error: e.err});
             }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -259,14 +259,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
 
     if (this.opts.controller.thirdPartyLookup) {
         var lookupController = this.opts.controller.thirdPartyLookup;
-
-        var protocolFilter;
-        if ("protocols" in lookupController) {
-            protocolFilter = {};
-            lookupController.protocols.forEach(function (p) {
-                protocolFilter[p] = true;
-            });
-        }
+        var protocols = lookupController.protocols || [];
 
         app.get("/_matrix/app/:ver/thirdparty/protocol/:protocol", function(req, res) {
             if (req.params.ver !== "unstable" || !lookupController.getProtocol) {
@@ -276,7 +269,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
 
             var protocol = req.params.protocol;
 
-            if (protocolFilter && !(protocol in protocolFilter)) {
+            if (protocols.length && protocols.indexOf(protocol) === -1) {
                 res.status(404).json({err: "Unknown 3PN protocol " + protocol});
                 return;
             }
@@ -295,7 +288,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
 
             var protocol = req.params.protocol;
 
-            if (protocolFilter && !(protocol in protocolFilter)) {
+            if (protocols.length && protocols.indexOf(protocol) === -1) {
                 res.status(404).json({err: "Unknown 3PN protocol " + protocol});
                 return;
             }
@@ -314,7 +307,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
 
             var protocol = req.params.protocol;
 
-            if (protocolFilter && !(protocol in protocolFilter)) {
+            if (protocols.length && protocols.indexOf(protocol) === -1) {
                 res.status(404).json({err: "Unknown 3PN protocol " + protocol});
                 return;
             }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -253,6 +253,15 @@ Bridge.prototype._customiseAppservice = function() {
         var lookupController = this.opts.controller.thirdPartyLookup;
         var protocols = lookupController.protocols || [];
 
+        function _respondErr(e, res) {
+            if (typeof e === "object" && e.code && e.err) {
+                res.status(e.code).json({error: e.err});
+            }
+            else {
+                res.status(500).send("Failed: " + e);
+            }
+        }
+
         this.addAppServicePath("GET", "/_matrix/app/:ver/thirdparty/protocol/:protocol", function(req, res) {
             if (req.params.ver !== "unstable" || !lookupController.getProtocol) {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
@@ -268,7 +277,7 @@ Bridge.prototype._customiseAppservice = function() {
 
             lookupController.getProtocol(protocol).then(
                 function(result) { res.status(200).json(result) },
-                function(e) { res.status(e.code).json({error: e.err}) }
+                function(e) { _respondErr(e, res) }
             );
         });
 
@@ -287,7 +296,7 @@ Bridge.prototype._customiseAppservice = function() {
 
             lookupController.getLocation(protocol, req.query).then(
                 function(result) { res.status(200).json(result) },
-                function(e) { res.status(e.code).json({error: e.err}) }
+                function(e) { _respondErr(e, res) }
             );
         });
 
@@ -306,7 +315,7 @@ Bridge.prototype._customiseAppservice = function() {
 
             lookupController.getUser(protocol, req.query).then(
                 function(result) { res.status(200).json(result) },
-                function(e) { res.status(e.code).json({error: e.err}) }
+                function(e) { _respondErr(e, res) }
             );
         });
     }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -347,6 +347,11 @@ Bridge.prototype.addAppServicePath = function(opts) {
     //   Maybe an API on that object would be good?
     var app = this.appService.app;
 
+    // TODO(paul): Consider more options:
+    //   opts.versions - automatic version filtering and rejecting of
+    //     unrecognised API versions
+    // Consider automatic "/_matrix/app/:version" path prefix
+
     app[opts.method.toLowerCase()](opts.path, opts.handlerFn);
 };
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -41,6 +41,9 @@ var util = require("util");
  * via onAliasQuery.
  * @param {Bridge~onLog=} opts.controller.onLog Function. Invoked when
  * logging. Defaults to a function which logs to the console.
+ * @param {Bridge~onThirdPartyLookup=} opts.controller.onThirdPartyLookup Object.
+ * If supplied, the bridge will respond to third-party entity lookups using the
+ * contained helper functions.
  * @param {(RoomBridgeStore|string)=} opts.roomStore The room store instance to
  * use, or the path to the room .db file to load. A database will be created if
  * this is not specified.
@@ -811,3 +814,33 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  * @param {string} line The text to be logged.
  * @param {boolean} isError True if this line should be treated as an error msg.
  */
+
+ /**
+  * @typedef Bridge~onThirdPartyLookup
+  * @type {Object}
+  * @property {Bridge~getProtocol} getProtocol Function. Called for requests
+  * for 3PE query metadata.
+  * @property {Bridge~getLocation} getLocation Function. Called for requests
+  * for 3PLs.
+  * @property {Bridge~getUser} getUser Function. Called for requests for 3PUs.
+  */
+
+ /**
+  * Invoked on requests for 3PE query metadata
+  * @callback Bridge~getProtocol
+  * @param {string} protocol The name of the 3PE protocol to query
+  */
+
+ /**
+  * Invoked on requests for 3PLs
+  * @callback Bridge~getLocation
+  * @param {string} protocol The name of the 3PE protocol
+  * @param {Object} fields The location query field data
+  */
+
+ /**
+  * Invoked on requests for 3PUs
+  * @callback Bridge~getUser
+  * @param {string} protocol The name of the 3PE protocol
+  * @param {Object} fields The user query field data
+  */

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -41,8 +41,8 @@ var util = require("util");
  * via onAliasQuery.
  * @param {Bridge~onLog=} opts.controller.onLog Function. Invoked when
  * logging. Defaults to a function which logs to the console.
- * @param {Bridge~onThirdPartyLookup=} opts.controller.onThirdPartyLookup Object.
- * If supplied, the bridge will respond to third-party entity lookups using the
+ * @param {Bridge~thirdPartyLookup=} opts.controller.thirdPartyLookup Object. If
+ * supplied, the bridge will respond to third-party entity lookups using the
  * contained helper functions.
  * @param {(RoomBridgeStore|string)=} opts.roomStore The room store instance to
  * use, or the path to the room .db file to load. A database will be created if
@@ -257,8 +257,8 @@ Bridge.prototype.customiseAppservice = function(appService) {
     //   Maybe an API on that object would be good?
     var app = appService.app;
 
-    if (this.opts.controller.onThirdPartyLookup) {
-        var lookupController = this.opts.controller.onThirdPartyLookup;
+    if (this.opts.controller.thirdPartyLookup) {
+        var lookupController = this.opts.controller.thirdPartyLookup;
 
         app.get("/_matrix/app/:ver/thirdparty/protocol/:protocol", (req, res) => {
             if (req.params.ver != "unstable") {
@@ -816,7 +816,7 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  */
 
  /**
-  * @typedef Bridge~onThirdPartyLookup
+  * @typedef Bridge~thirdPartyLookup
   * @type {Object}
   * @property {Bridge~getProtocol} getProtocol Function. Called for requests
   * for 3PE query metadata.

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -237,8 +237,77 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
         }
         self.opts.controller.onLog(line, false);
     });
+    this.customiseAppservice(this.appService);
     this.appService.listen(port);
     return this.loadDatabases();
+};
+
+/**
+ * Apply any customisations required on the appService object.
+ * Subclasses are intended to override this method where appropriate. If
+ * overridden the subclass method will still have to call the one in this
+ * class.
+ * @param {AppService} the AppService instance of the object
+ */
+Bridge.prototype.customiseAppservice = function(appService) {
+    // TODO(paul): This is gut-wrenching into the AppService instance itself.
+    //   Maybe an API on that object would be good?
+    var app = appService.app;
+
+    if (this.opts.controller.onThirdPartyLookup) {
+        var lookupController = this.opts.controller.onThirdPartyLookup;
+
+        app.get("/_matrix/app/:ver/thirdparty/protocol/:protocol", (req, res) => {
+            if (req.params.ver != "unstable") {
+                res.status(404).send("Cannot GET " + req.path + "\r\n");
+                return;
+            }
+
+            if (!lookupController.getProtocol) {
+                res.status(404).send("Cannot GET " + req.path + "\r\n");
+                return;
+            }
+
+            lookupController.getProtocol(req.params.protocol).then(
+                (result) => { res.status(200).json(result) },
+                (e)      => { res.status(e.code).json({error: e.err}) }
+            );
+        });
+
+        app.get("/_matrix/app/:ver/thirdparty/location/:protocol", (req, res) => {
+            if (req.params.ver != "unstable") {
+                res.status(404).send("Cannot GET " + req.path + "\r\n");
+                return;
+            }
+
+            if (!lookupController.getLocation) {
+                res.status(404).send("Cannot GET " + req.path + "\r\n");
+                return;
+            }
+
+            lookupController.getLocation(req.params.protocol, req.query).then(
+                (result) => { res.status(200).json([result]) },
+                (e)      => { res.status(e.code).json({error: e.err}) }
+            );
+        });
+
+        app.get("/_matrix/app/:ver/thirdparty/user/:protocol", (req, res) => {
+            if (req.params.ver != "unstable") {
+                res.status(404).send("Cannot GET " + req.path + "\r\n");
+                return;
+            }
+
+            if (!lookupController.getUser) {
+                res.status(404).send("Cannot GET " + req.path + "\r\n");
+                return;
+            }
+
+            lookupController.getUser(req.params.protocol, req.query).then(
+                (result) => { res.status(200).json([result]) },
+                (e)      => { res.status(e.code).json({error: e.err}) }
+            );
+        });
+    }
 };
 
 /**

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -839,18 +839,53 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
   * Invoked on requests for 3PE query metadata
   * @callback Bridge~getProtocol
   * @param {string} protocol The name of the 3PE protocol to query
+  * @return {Bridge~thirdPartyProtocolResult} Metadata about 3PE queries that
+  * can be made for this protocol.
   */
+
+ /**
+  * Returned by getProtocol third-party query metadata requests
+  * @typedef Bridge~thirdPartyProtocolResult
+  * @type {Object}
+  * @property {string[]} [location_fields] Names of the fields required for
+  * location lookups if location queries are supported.
+  * @property {string[]} [user_fields] Names of the fields required for user
+  * lookups if user queries are supported.
 
  /**
   * Invoked on requests for 3PLs
   * @callback Bridge~getLocation
   * @param {string} protocol The name of the 3PE protocol
-  * @param {Object} fields The location query field data
+  * @param {Object} fields The location query field data as specified by the
+  * specific protocol.
+  * @return {Bridge~thirdPartyLocationResult} A 3PL lookup result
+  */
+
+ /**
+  * Returned by getLocation third-party location lookups
+  * @typedef Bridge~thirdPartyLocationResult
+  * @type {Object}
+  * @property {string} alias The Matrix room alias to the portal room
+  * representing this 3PL
+  * @property {string} protocol The name of the 3PE protocol
+  * @property {fields} The normalised values of the location query field data
   */
 
  /**
   * Invoked on requests for 3PUs
   * @callback Bridge~getUser
   * @param {string} protocol The name of the 3PE protocol
-  * @param {Object} fields The user query field data
+  * @param {Object} fields The user query field data as specified by the
+  * specific protocol.
+  * @return {Bridge~thirdPartyUserResult} A 3PU lookup result
+  */
+
+ /**
+  * Returned by getUser third-party user lookups
+  * @typedef Bridge~thirdPartyUserResult
+  * @type {Object}
+  * @property {string} userid The Matrix user ID for the ghost representing
+  * this 3PU
+  * @property {string} protocol The name of the 3PE protocol
+  * @property {fields} The normalised values of the user query field data
   */

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -269,7 +269,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
         }
 
         app.get("/_matrix/app/:ver/thirdparty/protocol/:protocol", function(req, res) {
-            if (req.params.ver != "unstable") {
+            if (req.params.ver !== "unstable") {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
             }
@@ -293,7 +293,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
         });
 
         app.get("/_matrix/app/:ver/thirdparty/location/:protocol", function(req, res) {
-            if (req.params.ver != "unstable") {
+            if (req.params.ver !== "unstable") {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
             }
@@ -317,7 +317,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
         });
 
         app.get("/_matrix/app/:ver/thirdparty/user/:protocol", function(req, res) {
-            if (req.params.ver != "unstable") {
+            if (req.params.ver !== "unstable") {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
             }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -269,12 +269,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
         }
 
         app.get("/_matrix/app/:ver/thirdparty/protocol/:protocol", function(req, res) {
-            if (req.params.ver !== "unstable") {
-                res.status(404).send("Cannot GET " + req.path + "\r\n");
-                return;
-            }
-
-            if (!lookupController.getProtocol) {
+            if (req.params.ver !== "unstable" || !lookupController.getProtocol) {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
             }
@@ -293,12 +288,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
         });
 
         app.get("/_matrix/app/:ver/thirdparty/location/:protocol", function(req, res) {
-            if (req.params.ver !== "unstable") {
-                res.status(404).send("Cannot GET " + req.path + "\r\n");
-                return;
-            }
-
-            if (!lookupController.getLocation) {
+            if (req.params.ver !== "unstable" || !lookupController.getLocation) {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
             }
@@ -317,12 +307,7 @@ Bridge.prototype.customiseAppservice = function(appService) {
         });
 
         app.get("/_matrix/app/:ver/thirdparty/user/:protocol", function(req, res) {
-            if (req.params.ver !== "unstable") {
-                res.status(404).send("Cannot GET " + req.path + "\r\n");
-                return;
-            }
-
-            if (!lookupController.getUser) {
+            if (req.params.ver !== "unstable" || !lookupController.getUser) {
                 res.status(404).send("Cannot GET " + req.path + "\r\n");
                 return;
             }


### PR DESCRIPTION
This PR adds a new `controller` feature, `onThirdPartyLookup` which helps bridges to implement the API defined in
  https://docs.google.com/document/d/13NGa46a_WWno-XYfe8mQrglQdtOYMFVZtxkPKXDC3ac/edit#heading=h.m0btedxhv6ao