### PR TITLE
One MatrixScheduler for every client

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -191,7 +191,7 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
             "@" + self.opts.registration.sender_localpart + ":" + self.opts.domain
         ),
         clientSchedulerBuilder: function() {
-            new MatrixScheduler(retryAlgorithm, queueAlgorithm)
+            return new MatrixScheduler(retryAlgorithm, queueAlgorithm)
         },
     });
     this._clientFactory.setLogFunction(function(text, isErr) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -190,7 +190,9 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
         appServiceUserId: (
             "@" + self.opts.registration.sender_localpart + ":" + self.opts.domain
         ),
-        clientScheduler: new MatrixScheduler(retryAlgorithm, queueAlgorithm)
+        clientSchedulerBuilder: function() {
+            new MatrixScheduler(retryAlgorithm, queueAlgorithm)
+        },
     });
     this._clientFactory.setLogFunction(function(text, isErr) {
         if (!self.opts.controller.onLog) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -191,7 +191,7 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
             "@" + self.opts.registration.sender_localpart + ":" + self.opts.domain
         ),
         clientSchedulerBuilder: function() {
-            return new MatrixScheduler(retryAlgorithm, queueAlgorithm)
+            return new MatrixScheduler(retryAlgorithm, queueAlgorithm);
         },
     });
     this._clientFactory.setLogFunction(function(text, isErr) {

--- a/lib/components/client-factory.js
+++ b/lib/components/client-factory.js
@@ -13,9 +13,9 @@ var requestModule = require("request");
  * @param {string=} opts.appServiceUserId The application service's user ID. Must
  * be set prior to calling getClientAs(). See configure() to set this after
  * instantiation.
- * @param {MatrixScheduler} opts.clientScheduler Optional. The client scheduler to
- * use in place of the default event scheduler that schedules events to be sent to
- * the HS.
+ * @param {function=} opts.clientSchedulerBuilder Optional. A function that
+ * returns a new client scheduler to use in place of the default event
+ * scheduler that schedules events to be sent to the HS.
  */
 function ClientFactory(opts) {
     opts = opts || {};
@@ -25,7 +25,7 @@ function ClientFactory(opts) {
     //      user_id: Client
     //  }
     };
-    this._clientScheduler = opts.clientScheduler;
+    this._clientSchedulerBuilder = opts.clientSchedulerBuilder;
     this.configure(opts.url, opts.token, opts.appServiceUserId);
 }
 
@@ -111,7 +111,7 @@ ClientFactory.prototype.getClientAs = function(userId, request) {
         baseUrl: this._url,
         userId: userId || this._botUserId, // NB: no clobber so we don't set ?user_id=BOT
         queryParams: queryParams,
-        scheduler: this._clientScheduler
+        scheduler: this._clientSchedulerBuilder(),
     };
     client = this._sdk.createClient(clientOpts);
     client._http.opts._reqId = reqId; // FIXME gut wrenching

--- a/lib/components/client-factory.js
+++ b/lib/components/client-factory.js
@@ -25,7 +25,7 @@ function ClientFactory(opts) {
     //      user_id: Client
     //  }
     };
-    this._clientSchedulerBuilder = opts.clientSchedulerBuilder;
+    this._clientSchedulerBuilder = opts.clientSchedulerBuilder || function() {};
     this.configure(opts.url, opts.token, opts.appServiceUserId);
 }
 


### PR DESCRIPTION
Pass a scheduler builder function in to client factory rather than a single scheduler directly

Fixes #18 