### PR TITLE
ConfigValidator throws validate error with validation errors

### DIFF
--- a/lib/components/config-validator.js
+++ b/lib/components/config-validator.js
@@ -42,7 +42,9 @@ ConfigValidator.prototype.validate = function(inputConfig, defaultConfig) {
                 );
             }
         });
-        throw new Error("Failed to validate file");
+        var e = new Error("Failed to validate file");
+        e._validationErrors = errors;
+        throw e;
     }
     // mux in the default config
     return extend(true, defaultConfig, inputConfig);


### PR DESCRIPTION
Validation errors thrown by ConfigValidator have a ```_validationErrors``` property which is set to the internal errors that occurred during validation, giving a more detailed report as to what failed to validate. This is useful for showing errors to users inputting data.