### PR TITLE
Add intent.sendReadReceipt()

### DIFF
--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -108,6 +108,25 @@ Intent.prototype.sendTyping = function(roomId, isTyping) {
 };
 
 /**
+ * <p>Send a read receipt to a room.</p>
+ * This will automatically make the client join the room so they can send the
+ * receipt event if they are not already joined.
+ * @param{string} roomId The room to send to.
+ * @param{string} eventId The event ID to set the receipt mark to.
+ * @return {Promise}
+ */
+Intent.prototype.sendReadReceipt = function(roomId, eventId) {
+    var self = this;
+    var event = new MatrixEvent({
+        room_id: roomId,
+        event_id: eventId,
+    });
+    return self._ensureJoined(roomId).then(function() {
+        return self.client.sendReadReceipt(event);
+    });
+}
+
+/**
  * Set the power level of the given target.
  * @param {string} roomId The room to set the power level in.
  * @param {string} target The target user ID


### PR DESCRIPTION
I'd like bridges to send read receipts for the times when we get that information from the third-party network (gitter and slack for example).