### PR TITLE
Switch from `prometheus-client` to `prom-client`

### DIFF
--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -104,8 +104,8 @@ Intent.prototype.setRoomAvatar = function(roomId, avatar, info) {
     var content = {
         url: avatar
     };
-    if(info){
-        content.info = info;   
+    if (info) {
+        content.info = info;
     }
     return this.sendStateEvent(roomId, "m.room.avatar", "", content);
 };

--- a/lib/components/prometheusmetrics.js
+++ b/lib/components/prometheusmetrics.js
@@ -212,7 +212,7 @@ PrometheusMetrics.prototype.addCollector = function(func) {
  * new metric. Default: <code>"bridge"</code>.
  * @param {string} opts.name The variable name for the new metric.
  * @param {string} opts.help Descriptive help text for the new metric.
- * @param {string[]=} opts.labels An optional list of string label names
+ * @param {Array<string>=} opts.labels An optional list of string label names
  * @param {Function=} opts.refresh An optional function to invoke to generate a
  * new value for the gauge.
  * If a refresh function is provided, it is invoked with the gauge as its only
@@ -242,7 +242,7 @@ PrometheusMetrics.prototype.addGauge = function(opts) {
  * @param {string} opts.help Descriptive help text for the new metric.
  * Once created, the value of this metric can be incremented with the
  * <code>incCounter</code> method.
- * @param {string[]=} opts.labels An optional list of string label names
+ * @param {Array<string>=} opts.labels An optional list of string label names
  * @return {Counter} A counter metric.
  */
 PrometheusMetrics.prototype.addCounter = function(opts) {
@@ -274,7 +274,7 @@ PrometheusMetrics.prototype.incCounter = function(name, labels) {
  * new metric. Default: <code>"bridge"</code>.
  * @param {string} opts.name The variable name for the new metric.
  * @param {string} opts.help Descriptive help text for the new metric.
- * @param {string[]=} opts.labels An optional list of string label names
+ * @param {Array<string>=} opts.labels An optional list of string label names
  * @return {Histogram} A histogram metric.
  * Once created, the value of this metric can be incremented with the
  * <code>startTimer</code> method.

--- a/lib/components/prometheusmetrics.js
+++ b/lib/components/prometheusmetrics.js
@@ -60,6 +60,7 @@ function PrometheusMetrics() {
 
     this._collectors = []; // executed in order
     this._counters = {}; // counter metrics keyed by name
+    this._timers = {}; // timer metrics (Histograms) keyed by name
 }
 
 /**
@@ -264,6 +265,42 @@ PrometheusMetrics.prototype.incCounter = function(name, labels) {
     }
 
     this._counters[name].inc(labels);
+};
+
+/**
+ * Adds a new timer metric, represented by a prometheus Histogram.
+ * @param {Object} opts Options
+ * @param {string} opts.namespace An optional toplevel namespace name for the
+ * new metric. Default: <code>"bridge"</code>.
+ * @param {string} opts.name The variable name for the new metric.
+ * @param {string} opts.help Descriptive help text for the new metric.
+ * @param {[string]=} opts.labels An optional list of string label names
+ * @return {Histogram} A histogram metric.
+ * Once created, the value of this metric can be incremented with the
+ * <code>startTimer</code> method.
+ */
+PrometheusMetrics.prototype.addTimer = function(opts) {
+    var name = [opts.namespace || "bridge", opts.name].join("_");
+
+    var timer = this._timers[opts.name] =
+        new this._client.Histogram(name, opts.help, opts.labels || []);
+
+    return timer;
+};
+
+/**
+ * Begins a new timer observation for a timer metric.
+ * @param{string} name The name the metric was previously registered as.
+ * @param{Object} labels Optional object containing additional label values.
+ * @return {function} A function to be called to end the timer and report the
+ * observation.
+ */
+PrometheusMetrics.prototype.startTimer = function(name, labels) {
+    if (!this._timers[name]) {
+        throw new Error("Unrecognised timer metric name '" + name + "'");
+    }
+
+    return this._timers[name].startTimer(labels);
 };
 
 /**

--- a/lib/components/prometheusmetrics.js
+++ b/lib/components/prometheusmetrics.js
@@ -19,20 +19,7 @@ var TICKS_PER_SEC = 100; // TODO(paul): look this up via sysconf(_SC_CLK_TCK)
  * This class provides a central location to register gauge and counter metrics
  * used to generate the <code>/metrics</code> page.
  *
- * It also contains collector code to generate the standard
- * <code>process_</code> and <code>nodejs_</code> metrics, which depends on a
- * working <code>/proc</code> filesystem and therefore is only active on Linux.
- * The standard metrics exported in this case are:
- *   process_resident_memory_bytes
- *   process_virtual_memory_bytes
- *   process_heap_bytes
- *   process_cpu_seconds_total
- *   process_open_fds
- *   process_max_fds
- *   process_start_time_seconds
- *   nodejs_heap_used_bytes
- *
- * This class depends on having <code>prometheus-client</code> installed. It
+ * This class depends on having <code>prome-client</code> installed. It
  * will attempt to load this module when the constructor is invoked.
  *
  * @example <caption>A simple metric that counts the keys in an object:</caption>
@@ -83,9 +70,7 @@ var TICKS_PER_SEC = 100; // TODO(paul): look this up via sysconf(_SC_CLK_TCK)
  */
 function PrometheusMetrics() {
     // Only attempt to load these dependencies if metrics are enabled
-    var Prometheus = require("prometheus-client");
-
-    this._client = new Prometheus();
+    var client = this._client = require("prom-client");
 
     this._collectors = []; // executed in order
     this._counters = {}; // counter metrics keyed by name
@@ -97,15 +82,6 @@ function PrometheusMetrics() {
     }
     catch (e) {
         // ignore
-    }
-
-    if (have_proc_stat) {
-        this._register_process_metrics();
-    }
-    else {
-        console.log("Unable to access /proc/self/stat; standard process " +
-            "metrics are disabled"
-        );
     }
 }
 
@@ -223,6 +199,7 @@ PrometheusMetrics.prototype.registerMatrixSdkMetrics = function() {
     var callCounts = this.addCounter({
         name: "matrix_api_calls",
         help: "Count of the number of Matrix client API calls made",
+        labels: ["method"],
     });
 
     /*
@@ -265,11 +242,11 @@ PrometheusMetrics.prototype.registerMatrixSdkMetrics = function() {
     ];
 
     CLIENT_METHODS.forEach(function(method) {
-        callCounts.increment({method: method}, 0); // initialise the count to zero
+        callCounts.inc({method: method}, 0); // initialise the count to zero
 
         var orig = matrixClientPrototype[method];
         matrixClientPrototype[method] = function() {
-            callCounts.increment({method: method});
+            callCounts.inc({method: method});
             return orig.apply(this, arguments);
         }
     });
@@ -303,29 +280,33 @@ PrometheusMetrics.prototype.registerBridgeGauges = function(counterFunc) {
     var matrixRoomsByAgeGauge = this.addGauge({
         name: "matrix_rooms_by_age",
         help: "Current count of matrix rooms partitioned by activity age",
+        labels: ["age"],
     });
     var remoteRoomsByAgeGauge = this.addGauge({
         name: "remote_rooms_by_age",
         help: "Current count of remote rooms partitioned by activity age",
+        labels: ["age"],
     });
 
     var matrixUsersByAgeGauge = this.addGauge({
         name: "matrix_users_by_age",
         help: "Current count of matrix users partitioned by activity age",
+        labels: ["age"],
     });
     var remoteUsersByAgeGauge = this.addGauge({
         name: "remote_users_by_age",
         help: "Current count of remote users partitioned by activity age",
+        labels: ["age"],
     });
 
     this.addCollector(function () {
         var counts = counterFunc();
 
-        matrixRoomsGauge.set({}, counts.matrixRoomConfigs);
-        remoteRoomsGauge.set({}, counts.remoteRoomConfigs);
+        matrixRoomsGauge.set(counts.matrixRoomConfigs);
+        remoteRoomsGauge.set(counts.remoteRoomConfigs);
 
-        matrixGhostsGauge.set({}, counts.matrixGhosts);
-        remoteGhostsGauge.set({}, counts.remoteGhosts);
+        matrixGhostsGauge.set(counts.matrixGhosts);
+        remoteGhostsGauge.set(counts.remoteGhosts);
 
         counts.matrixRoomsByAge.setGauge(matrixRoomsByAgeGauge);
         counts.remoteRoomsByAge.setGauge(remoteRoomsByAgeGauge);
@@ -378,6 +359,7 @@ PrometheusMetrics.prototype.addCollector = function(func) {
  * new metric. Default: <code>"bridge"</code>.
  * @param {string} opts.name The variable name for the new metric.
  * @param {string} opts.help Descriptive help text for the new metric.
+ * @param {[string]=} opts.labels An optional list of string label names
  * @param {Function=} opts.refresh An optional function to invoke to generate a
  * new value for the gauge.
  * If a refresh function is provided, it is invoked with the gauge as its only
@@ -387,11 +369,9 @@ PrometheusMetrics.prototype.addCollector = function(func) {
  */
 PrometheusMetrics.prototype.addGauge = function(opts) {
     var refresh = opts.refresh;
-    var gauge = this._client.newGauge({
-        namespace: opts.namespace || "bridge",
-        name: opts.name,
-        help: opts.help,
-    });
+    var name = [opts.namespace || "bridge", opts.name].join("_");
+
+    var gauge = new this._client.Gauge(name, opts.help, opts.labels || []);
 
     if (opts.refresh) {
         this._collectors.push(function() { refresh(gauge); });
@@ -409,14 +389,14 @@ PrometheusMetrics.prototype.addGauge = function(opts) {
  * @param {string} opts.help Descriptive help text for the new metric.
  * Once created, the value of this metric can be incremented with the
  * <code>incCounter</code> method.
+ * @param {[string]=} opts.labels An optional list of string label names
  * @return {Counter} A counter metric.
  */
 PrometheusMetrics.prototype.addCounter = function(opts) {
-    var counter = this._counters[opts.name] = this._client.newCounter({
-        namespace: opts.namespace || "bridge",
-        name: opts.name,
-        help: opts.help,
-    });
+    var name = [opts.namespace || "bridge", opts.name].join("_");
+
+    var counter = this._counters[opts.name] =
+        new this._client.Counter(name, opts.help, opts.labels || []);
 
     return counter;
 };
@@ -431,7 +411,7 @@ PrometheusMetrics.prototype.incCounter = function(name, labels) {
         throw new Error("Unrecognised counter metric name '" + name + "'");
     }
 
-    this._counters[name].increment(labels);
+    this._counters[name].inc(labels);
 };
 
 /**
@@ -440,14 +420,26 @@ PrometheusMetrics.prototype.incCounter = function(name, labels) {
  * @param {Bridge} bridge The containing Bridge instance.
  */
 PrometheusMetrics.prototype.addAppServicePath = function(bridge) {
-    var metricsFunc = this._client.metricsFunc();
+    var register = this._client.register;
 
     bridge.addAppServicePath({
         method: "GET",
         path: "/metrics",
         handler: function(req, res) {
             this.refresh();
-            return metricsFunc(req, res);
+
+            try {
+                var exposition = register.metrics();
+
+                res.set("Content-Type", "text/plain");
+                res.send(exposition);
+            }
+            catch (e) {
+                res.status(500);
+
+                res.set("Content-Type", "text/plain");
+                res.send(e.toString());
+            }
         }.bind(this),
     });
 };

--- a/lib/components/prometheusmetrics.js
+++ b/lib/components/prometheusmetrics.js
@@ -5,7 +5,7 @@
  * This class provides a central location to register gauge and counter metrics
  * used to generate the <code>/metrics</code> page.
  *
- * This class depends on having <code>prome-client</code> installed. It
+ * This class depends on having <code>prom-client</code> installed. It
  * will attempt to load this module when the constructor is invoked.
  *
  * @example <caption>A simple metric that counts the keys in an object:</caption>

--- a/lib/components/prometheusmetrics.js
+++ b/lib/components/prometheusmetrics.js
@@ -56,7 +56,7 @@
  */
 function PrometheusMetrics() {
     // Only attempt to load these dependencies if metrics are enabled
-    var client = this._client = require("prom-client");
+    this._client = require("prom-client");
 
     this._collectors = []; // executed in order
     this._counters = {}; // counter metrics keyed by name

--- a/lib/components/prometheusmetrics.js
+++ b/lib/components/prometheusmetrics.js
@@ -1,19 +1,5 @@
 "use strict";
 
-var fs = require("fs");
-
-var TICKS_PER_SEC = 100; // TODO(paul): look this up via sysconf(_SC_CLK_TCK)
-
-/*
- * This class uses fs.fileReadSync() to read statistics out of the /proc
- * filesystem. Using the async form wouldn't actually make any difference to
- * its behaviour. The /proc/self/ introspection API in the kernel is
- * implemented in an interesting way that doesn't play nicely with aio, so
- * libuv's async versions of file reading won't be any different on those.
- * In any case, the /proc entries won't block on reading; they're designed to
- * be fast and lightweight to respond
- */
-
 /**
  * Prometheus-style /metrics gathering and exporting.
  * This class provides a central location to register gauge and counter metrics
@@ -74,121 +60,7 @@ function PrometheusMetrics() {
 
     this._collectors = []; // executed in order
     this._counters = {}; // counter metrics keyed by name
-
-    var have_proc_stat = false;
-    try {
-        fs.readFileSync("/proc/self/stat");
-        have_proc_stat = true;
-    }
-    catch (e) {
-        // ignore
-    }
 }
-
-PrometheusMetrics.prototype._register_process_metrics = function() {
-    // Register some built-in process-wide metrics
-    // See also
-    //   https://prometheus.io/docs/instrumenting/writing_clientlibs/
-    //     #standard-and-runtime-collectors
-
-    var rss_gauge = this.addGauge({
-        namespace: "process",
-        name: "resident_memory_bytes",
-        help: "Resident memory size in bytes",
-    });
-    var vsz_gauge = this.addGauge({
-        namespace: "process",
-        name: "virtual_memory_bytes",
-        help: "Virtual memory size in bytes",
-    });
-
-    var heap_size_gauge = this.addGauge({
-        namespace: "process",
-        name: "heap_bytes",
-        help: "Total size of Node.js heap in bytes",
-    });
-    var heap_used_gauge = this.addGauge({
-        namespace: "nodejs",
-        name: "heap_used_bytes",
-        help: "Used size of Node.js heap in bytes",
-    });
-
-    var cpu_gauge = this.addGauge({
-        namespace: "process",
-        name: "cpu_seconds_total",
-        help: "Total user and system CPU time spent in seconds",
-    });
-
-    var cpu_user_gauge = this.addGauge({
-        namespace: "process",
-        name: "cpu_user_seconds_total",
-        help: "Total user CPU time spent in seconds",
-    });
-    var cpu_system_gauge = this.addGauge({
-        namespace: "process",
-        name: "cpu_system_seconds_total",
-        help: "Total system CPU time spent in seconds",
-    });
-
-    this.addCollector(function() {
-        var usage = process.memoryUsage();
-
-        rss_gauge.set({}, usage.rss);
-        heap_size_gauge.set({}, usage.heapTotal);
-        heap_used_gauge.set({}, usage.heapUsed);
-
-        var stats = _read_proc_self_stat();
-
-        // CPU times in ticks
-        var utime_secs = stats[11] / TICKS_PER_SEC;
-        var stime_secs = stats[12] / TICKS_PER_SEC;
-
-        cpu_gauge.set({}, utime_secs + stime_secs);
-        cpu_user_gauge.set({}, utime_secs);
-        cpu_system_gauge.set({}, stime_secs);
-
-        // Virtual memory size
-        vsz_gauge.set({}, stats[20]);
-    });
-
-    this.addGauge({
-        namespace: "process",
-        name: "open_fds",
-        help: "Number of open file descriptors",
-        refresh: function(gauge) {
-            var fds = fs.readdirSync("/proc/self/fd");
-
-            // subtract 1 due to readdir handle itself
-            gauge.set(null, fds.length - 1);
-        }
-    });
-
-    this.addGauge({
-        namespace: "process",
-        name: "max_fds",
-        help: "Maximum number of open file descriptors allowed",
-        refresh: function(gauge) {
-            var limits = fs.readFileSync("/proc/self/limits");
-            limits.toString().split(/\n/).forEach(function(line) {
-                if (!line.match(/^Max open files /)) {
-                    return;
-                }
-
-                // "Max", "open", "files", $SOFT, $HARD, "files"
-                gauge.set({}, line.split(/\s+/)[3]);
-            });
-        }
-    });
-
-    // This value will be constant for the lifetime of the process
-    this.addGauge({
-        namespace: "process",
-        name: "start_time_seconds",
-        help: "Start time of the process since unix epoch in seconds",
-    }).set({}, _calculate_process_start_time());
-
-    this.refresh();
-};
 
 /**
  * Registers some exported metrics that relate to operations of the embedded
@@ -315,26 +187,6 @@ PrometheusMetrics.prototype.registerBridgeGauges = function(counterFunc) {
         counts.remoteUsersByAge.setGauge(remoteUsersByAgeGauge);
     });
 };
-
-function _read_proc_self_stat() {
-    var stat_line = fs.readFileSync("/proc/self/stat")
-        .toString().split(/\n/)[0];
-    // Line contains PID (exec_name) bunch of stats here...
-    return stat_line.match(/\) +(.*)$/)[1].split(" ");
-}
-
-function _calculate_process_start_time() {
-    // The 'starttime' field in /proc/self/stat gives the number of CPU ticks
-    //   since machine boot time that this process started.
-    var stats = _read_proc_self_stat();
-    var starttime_sec = stats[19] / TICKS_PER_SEC;
-
-    var btime_line = fs.readFileSync("/proc/stat")
-        .toString().split(/\n/).filter(function(l) { return l.match(/^btime /); })[0];
-    var btime = Number(btime_line.split(" ")[1]);
-
-    return btime + starttime_sec;
-}
 
 PrometheusMetrics.prototype.refresh = function() {
     this._collectors.forEach(function(f) { f(); });

--- a/lib/components/prometheusmetrics.js
+++ b/lib/components/prometheusmetrics.js
@@ -212,7 +212,7 @@ PrometheusMetrics.prototype.addCollector = function(func) {
  * new metric. Default: <code>"bridge"</code>.
  * @param {string} opts.name The variable name for the new metric.
  * @param {string} opts.help Descriptive help text for the new metric.
- * @param {[string]=} opts.labels An optional list of string label names
+ * @param {string[]=} opts.labels An optional list of string label names
  * @param {Function=} opts.refresh An optional function to invoke to generate a
  * new value for the gauge.
  * If a refresh function is provided, it is invoked with the gauge as its only
@@ -242,7 +242,7 @@ PrometheusMetrics.prototype.addGauge = function(opts) {
  * @param {string} opts.help Descriptive help text for the new metric.
  * Once created, the value of this metric can be incremented with the
  * <code>incCounter</code> method.
- * @param {[string]=} opts.labels An optional list of string label names
+ * @param {string[]=} opts.labels An optional list of string label names
  * @return {Counter} A counter metric.
  */
 PrometheusMetrics.prototype.addCounter = function(opts) {
@@ -274,7 +274,7 @@ PrometheusMetrics.prototype.incCounter = function(name, labels) {
  * new metric. Default: <code>"bridge"</code>.
  * @param {string} opts.name The variable name for the new metric.
  * @param {string} opts.help Descriptive help text for the new metric.
- * @param {[string]=} opts.labels An optional list of string label names
+ * @param {string[]=} opts.labels An optional list of string label names
  * @return {Histogram} A histogram metric.
  * Once created, the value of this metric can be incremented with the
  * <code>startTimer</code> method.

--- a/lib/components/state-lookup.js
+++ b/lib/components/state-lookup.js
@@ -148,13 +148,13 @@ StateLookup.prototype.onEvent = function(event) {
         // event and always use the pushed events we should remain in sync.
         // we'll add our own listener for the sync promise and then update this
         // value.
-        r.syncPromise.then(function(r) {
+        r.syncPromise.then(function(r_) {
             // We get 'r' passed back in from the resolve() call so we don't
             // have to capture it here; thus avoiding a memory reference cycle
-            if (!r.events[event.type]) {
-                r.events[event.type] = {};
+            if (!r_.events[event.type]) {
+                r_.events[event.type] = {};
             }
-            r.events[event.type][event.state_key] = event;
+            r_.events[event.type][event.state_key] = event;
         });
         return;
     }

--- a/spec/unit/app-service-bot.spec.js
+++ b/spec/unit/app-service-bot.spec.js
@@ -39,14 +39,19 @@ describe("AppServiceBot", function() {
 
         it("should return joined members only from initial sync", function(done) {
             client._http.authedRequestWithPrefix.andReturn(Promise.resolve({
-                rooms: [{
-                    room_id: "!foo:bar",
-                    state: [
-                        memberEvent("!foo:bar", "@alice:bar", "join"),
-                        memberEvent("!foo:bar", "@bob:bar", "invite"),
-                        memberEvent("!foo:bar", "@charlie:bar", "leave")
-                    ]
-                }]
+                rooms: {
+                    join: {
+                        "!foo:bar": {
+                            state: {
+                                events: [
+                                memberEvent("!foo:bar", "@alice:bar", "join"),
+                                memberEvent("!foo:bar", "@bob:bar", "invite"),
+                                memberEvent("!foo:bar", "@charlie:bar", "leave")
+                                ]
+                            }
+                        }
+                    }
+                } 
             }));
             bot.getMemberLists().done(function(result) {
                 expect(result["!foo:bar"].realJoinedUsers).toEqual([
@@ -60,13 +65,18 @@ describe("AppServiceBot", function() {
 
         it("should not return the bot itself as a remote user", function(done) {
             client._http.authedRequestWithPrefix.andReturn(Promise.resolve({
-                rooms: [{
-                    room_id: "!foo:bar",
-                    state: [
-                        memberEvent("!foo:bar", "@test_alice:bar", "join"),
-                        memberEvent("!foo:bar", botUserId, "join")
-                    ]
-                }]
+                rooms: {
+                    join: {
+                        "!foo:bar": {
+                            state: {
+                                events: [
+                                memberEvent("!foo:bar", "@test_alice:bar", "join"),
+                                memberEvent("!foo:bar", botUserId, "join")
+                                ]
+                            }
+                        }
+                    }
+                } 
             }));
             bot.getMemberLists().done(function(result) {
                 expect(result["!foo:bar"].remoteJoinedUsers).toEqual([
@@ -81,13 +91,18 @@ describe("AppServiceBot", function() {
         it("should return remote users which match the registration regex",
         function(done) {
             client._http.authedRequestWithPrefix.andReturn(Promise.resolve({
-                rooms: [{
-                    room_id: "!foo:bar",
-                    state: [
-                        memberEvent("!foo:bar", "@test_alice:bar", "join"),
-                        memberEvent("!foo:bar", "@alice:bar", "join")
-                    ]
-                }]
+                rooms: {
+                    join: {
+                        "!foo:bar": {
+                            state: {
+                                events: [
+                                memberEvent("!foo:bar", "@test_alice:bar", "join"),
+                                memberEvent("!foo:bar", "@alice:bar", "join")
+                                ]
+                            }
+                        }
+                    }
+                }
             }));
             bot.getMemberLists().done(function(result) {
                 expect(result["!foo:bar"].remoteJoinedUsers).toEqual([

--- a/spec/unit/app-service-bot.spec.js
+++ b/spec/unit/app-service-bot.spec.js
@@ -51,7 +51,7 @@ describe("AppServiceBot", function() {
                             }
                         }
                     }
-                } 
+                }
             }));
             bot.getMemberLists().done(function(result) {
                 expect(result["!foo:bar"].realJoinedUsers).toEqual([
@@ -76,7 +76,7 @@ describe("AppServiceBot", function() {
                             }
                         }
                     }
-                } 
+                }
             }));
             bot.getMemberLists().done(function(result) {
                 expect(result["!foo:bar"].remoteJoinedUsers).toEqual([


### PR DESCRIPTION
Main reason being that `prom-client` supports both Histograms and Summaries; old `prometheus-client` does neither.

Also, `prom-client` does its own implementation of the standard process-wide metrics, so we can delete *aaaall* the code relating to that here.

See also #43