### PR TITLE
Intent: Handle not in room failures due to a stale cache

### DIFF
--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -189,9 +189,9 @@ Intent.prototype.sendEvent = function(roomId, type, content) {
     var self = this;
     return self._ensureJoined(roomId).then(function() {
         return self._ensureHasPowerLevelFor(roomId, type);
-    }).then(function() {
+    }).then(self._joinGuard(roomId, function() {
         return self.client.sendEvent(roomId, type, content);
-    });
+    }));
 };
 
 /**
@@ -209,9 +209,9 @@ Intent.prototype.sendStateEvent = function(roomId, type, skey, content) {
     var self = this;
     return self._ensureJoined(roomId).then(function() {
         return self._ensureHasPowerLevelFor(roomId, type);
-    }).then(function() {
+    }).then(self._joinGuard(roomId, function() {
         return self.client.sendStateEvent(roomId, type, content, skey);
-    });
+    }));
 };
 
 /**
@@ -425,8 +425,25 @@ Intent.prototype.onEvent = function(event) {
     }
 };
 
-Intent.prototype._ensureJoined = function(roomId) {
-    if (this._membershipStates[roomId] === "join") {
+// Guard a function which returns a promise which may reject if the user is not
+// in the room. If the promise rejects, join the room and retry the function.
+Intent.prototype._joinGuard = function(roomId, promiseFn) {
+    var self = this;
+    return function() {
+        return promiseFn().catch(function(err) {
+            if (err.errcode !== "M_FORBIDDEN") {
+                // not a guardable error
+                throw err;
+            }
+            return self._ensureJoined(roomId, true).then(function() {
+                return promiseFn();
+            })
+        });
+    };
+};
+
+Intent.prototype._ensureJoined = function(roomId, ignoreCache) {
+    if (this._membershipStates[roomId] === "join" && !ignoreCache) {
         return Promise.resolve();
     }
 

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -295,6 +295,7 @@ describe("Intent", function() {
                 expect(client.sendEvent).toHaveBeenCalledWith(
                     roomId, "m.room.message", content
                 );
+                expect(client.joinRoom).not.toHaveBeenCalled();
                 done();
             });
         });
@@ -308,6 +309,7 @@ describe("Intent", function() {
                 expect(client.sendEvent).toHaveBeenCalledWith(
                     roomId, "m.room.message", content
                 );
+                expect(client.joinRoom).not.toHaveBeenCalled();
                 done();
             });
         });


### PR DESCRIPTION
It is possible that Synapse will not send join/leave `m.room.member`
events to the bridge which were originally sent **by** the bridge.
This breaks an assumption in the `Intent` class whereby we maintain
a membership cache which is kept up-to-date by calls to `onEvent`.
This cache can now get out of sync.

To fix this, we now have "join guards" around the sending of
message and state events. This guard intercepts failures and checks
if the `errcode` is `M_FORBIDDEN`. If it is, it will perform another
call to `_ensureJoined` but with the `ignoreCache` flag set, forcing
an HTTP hit to join the room.

Fixes matrix-org/matrix-appservice-irc#343

With UTs.