### PR TITLE
Remove roomId param from _isRemoteUser

### DIFF
--- a/lib/components/app-service-bot.js
+++ b/lib/components/app-service-bot.js
@@ -111,7 +111,7 @@ AppServiceBot.prototype._getRoomInfo = function(roomId, joinedRoom) {
         if (userId === self.getUserId()) {
             return;
         }
-        if (self._isRemoteUser(roomId, userId)) {
+        if (self._isRemoteUser(userId)) {
             roomInfo.remoteJoinedUsers.push(userId);
         }
         else {
@@ -121,7 +121,7 @@ AppServiceBot.prototype._getRoomInfo = function(roomId, joinedRoom) {
     return roomInfo;
 }
 
-AppServiceBot.prototype._isRemoteUser = function(roomId, userId) {
+AppServiceBot.prototype._isRemoteUser = function(userId) {
     for (var i = 0; i < this.exclusiveUserRegexes.length; i++) {
         var regex = new RegExp(this.exclusiveUserRegexes[i]);
         if (regex.test(userId)) {


### PR DESCRIPTION
Not sure why this was a param, so I removed it.