### PR TITLE
Implement a 'dontJoin' intent option

### DIFF
--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -23,6 +23,9 @@ var STATE_EVENT_TYPES = [
  * Default: false.
  * @param {boolean} opts.dontCheckPowerLevel True to not check for the right power
  * level before sending events. Default: false.
+ * @param {boolean} opts.dontJoin True to not attempt to join a room before
+ * sending messages into it. The surrounding code will have to ensure the correct
+ * membership state itself in this case. Default: false.
  */
 function Intent(client, botClient, opts) {
     this.client = client;
@@ -443,6 +446,10 @@ Intent.prototype._joinGuard = function(roomId, promiseFn) {
 };
 
 Intent.prototype._ensureJoined = function(roomId, ignoreCache) {
+    if (this.opts.dontJoin) {
+        return Promise.resolve();
+    }
+
     if (this._membershipStates[roomId] === "join" && !ignoreCache) {
         return Promise.resolve();
     }


### PR DESCRIPTION
If the bridge app itself is maintaining membership state then having the library set join events too might disrupt that. E.g. currently `matrix-appservice-tg` wants to keep a per-room displayname in membership events.