### PR TITLE
Even with dontJoin set, still ensure that the user is registered

### DIFF
--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -446,10 +446,6 @@ Intent.prototype._joinGuard = function(roomId, promiseFn) {
 };
 
 Intent.prototype._ensureJoined = function(roomId, ignoreCache) {
-    if (this.opts.dontJoin) {
-        return Promise.resolve();
-    }
-
     if (this._membershipStates[roomId] === "join" && !ignoreCache) {
         return Promise.resolve();
     }
@@ -480,7 +476,14 @@ Intent.prototype._ensureJoined = function(roomId, ignoreCache) {
         }
     }
 
+    var dontJoin = this.opts.dontJoin;
+
     self._ensureRegistered().done(function() {
+        if (dontJoin) {
+            d.resolve();
+            return;
+        }
+
         self.client.joinRoom(roomId, { syncRoom: false }).then(function() {
             mark(roomId, "join");
         }, function(e) {


### PR DESCRIPTION
Move the early-exit if `dontJoin` is set until after we've at least registered the user