### PR TITLE
Share Intent data structures created by Bridge

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -18,6 +18,11 @@ var Promise = require("bluebird");
 var Datastore = require("nedb");
 var util = require("util");
 
+// The frequency at which we will check the list of accumulated Intent objects.
+var INTENT_CULL_CHECK_PERIOD_MS = 1000 * 60; // once per minute
+// How long a given Intent object can hang around unused for.
+var INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
+
 /**
  * @constructor
  * @param {Object} opts Options to pass to the bridge
@@ -140,6 +145,9 @@ function Bridge(opts) {
         // user_id + request_id : Intent
     };
     this._intents["bot"] = null;
+    // _intent key => timestamp
+    this._intentLastAccessed = Object.create(null);
+    this._intentLastAccessedTimeout = null;
     this._membershipMap = {
         // room_id: { user_id: "join|invite|leave|ban|null" }   null=unknown
     };
@@ -262,6 +270,7 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
         self.opts.controller.onLog(line, false);
     });
     this._customiseAppservice();
+    this._setupIntentCulling();
 
     if (this._metrics) {
         this._metrics.addAppServicePath(this);
@@ -279,6 +288,29 @@ Bridge.prototype._customiseAppservice = function() {
         this._customiseAppserviceThirdPartyLookup(this.opts.controller.thirdPartyLookup);
     }
 };
+
+// Set a timer going which will periodically remove Intent objects to prevent
+// them from accumulating too much. Removal is based on access time (calls to
+// getIntent).
+Bridge.prototype._setupIntentCulling = function() {
+    if (this._intentLastAccessedTimeout) {
+        clearTimeout(this._intentLastAccessedTimeout);
+    }
+    var self = this;
+    this._intentLastAccessedTimeout = setTimeout(function() {
+        var now = Date.now();
+        Object.keys(self._intentLastAccessed).forEach(function(key) {
+            if ((self._intentLastAccessed[key] + INTENT_CULL_EVICT_AFTER_MS) < now) {
+                delete self._intentLastAccessed[key];
+                delete self._intents[key];
+            }
+        });
+        self._intentLastAccessedTimeout = null;
+        // repeat forever. We have no cancellation mechanism but we don't expect
+        // Bridge objects to be continually recycled so this is fine.
+        self._setupIntentCulling();
+    }, INTENT_CULL_CHECK_PERIOD_MS);
+}
 
 Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupController) {
     var protocols = lookupController.protocols || [];
@@ -524,6 +556,7 @@ Bridge.prototype.getIntent = function(userId, request) {
         }
         this._intents[key] = new Intent(client, this._botClient, clientIntentOpts);
     }
+    this._intentLastAccessed[key] = Date.now();
     return this._intents[key];
 };
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -140,6 +140,18 @@ function Bridge(opts) {
         // user_id + request_id : Intent
     };
     this._intents["bot"] = null;
+    this._membershipMap = {
+        // room_id: { user_id: "join|invite|leave|ban|null" }   null=unknown
+    };
+    this._powerLevelMap = {
+        // room_id: event.content
+    };
+    this._intentBackingStore = {
+        setMembership: this._setMemberEntry.bind(this),
+        setPowerLevelContent: this._setPowerLevelEntry.bind(this),
+        getMembership: this._getMemberEntry.bind(this),
+        getPowerLevelContent: this._getPowerLevelEntry.bind(this)
+    };
     this._queue = new EventQueue(this.opts.queue, this._onConsume.bind(this));
     this._prevRequestPromise = Promise.resolve();
     this._metrics = null; // an optional PrometheusMetrics instance
@@ -502,7 +514,9 @@ Bridge.prototype.getIntent = function(userId, request) {
     var key = userId + (request ? request.getId() : "");
     if (!this._intents[key]) {
         var client = this._clientFactory.getClientAs(userId, request);
-        var clientIntentOpts = {};
+        var clientIntentOpts = {
+            backingStore: this._intentBackingStore
+        };
         if (this.opts.intentOptions.clients) {
             Object.keys(this.opts.intentOptions.clients).forEach(function(k) {
                 clientIntentOpts[k] = self.opts.intentOptions.clients[k];
@@ -678,10 +692,38 @@ Bridge.prototype._onConsume = function(err, data) {
 };
 
 Bridge.prototype._updateIntents = function(event) {
-    var self = this;
-    Object.keys(this._intents).forEach(function(key) {
-        self._intents[key].onEvent(event);
-    });
+    if (event.type === "m.room.member") {
+        this._setMemberEntry(
+            event.room_id,
+            event.state_key,
+            event.content ? event.content.membership : null
+        );
+    }
+    else if (event.type === "m.room.power_levels") {
+        this._setPowerLevelEntry(event.room_id, event.content);
+    }
+};
+
+Bridge.prototype._setMemberEntry = function(roomId, userId, membership) {
+    if (!this._membershipMap[roomId]) {
+        this._membershipMap[roomId] = {};
+    }
+    this._membershipMap[roomId][userId] = membership;
+};
+
+Bridge.prototype._setPowerLevelEntry = function(roomId, content) {
+    this._powerLevelMap[roomId] = content;
+};
+
+Bridge.prototype._getMemberEntry = function(roomId, userId) {
+    if (!this._membershipMap[roomId]) {
+        return null;
+    }
+    return this._membershipMap[roomId][userId];
+};
+
+Bridge.prototype._getPowerLevelEntry = function(roomId) {
+    return this._powerLevelMap[roomId];
 };
 
 /**

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -145,8 +145,7 @@ function Bridge(opts) {
         // user_id + request_id : Intent
     };
     this._intents["bot"] = null;
-    // _intent key => timestamp
-    this._intentLastAccessed = Object.create(null);
+    this._intentLastAccessed = Object.create(null); // user_id + request_id : timestamp
     this._intentLastAccessedTimeout = null;
     this._membershipMap = {
         // room_id: { user_id: "join|invite|leave|ban|null" }   null=unknown
@@ -291,7 +290,7 @@ Bridge.prototype._customiseAppservice = function() {
 
 // Set a timer going which will periodically remove Intent objects to prevent
 // them from accumulating too much. Removal is based on access time (calls to
-// getIntent).
+// getIntent). Intents expire after INTENT_CULL_EVICT_AFTER_MS of not being called.
 Bridge.prototype._setupIntentCulling = function() {
     if (this._intentLastAccessedTimeout) {
         clearTimeout(this._intentLastAccessedTimeout);

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -23,17 +23,73 @@ var STATE_EVENT_TYPES = [
  * Default: false.
  * @param {boolean} opts.dontCheckPowerLevel True to not check for the right power
  * level before sending events. Default: false.
+ *
+ * @param {Object=} opts.backingStore An object with 4 functions, outlined below.
+ * If this Object is supplied, ALL 4 functions must be supplied. If this Object
+ * is not supplied, the Intent will maintain its own backing store for membership
+ * and power levels, which may scale badly for lots of users.
+ *
+ * @param {Function} opts.backingStore.getMembership A function which is called with a
+ * room ID and user ID which should return the membership status of this user as
+ * a string e.g "join". `null` should be returned if the membership is unknown.
+ *
+ * @param {Function} opts.backingStore.getPowerLevelContent A function which is called
+ * with a room ID which should return the power level content for this room, as an Object.
+ * `null` should be returned if there is no known content.
+ *
+ * @param {Function} opts.backingStore.setMembership A function with the signature:
+ * function(roomId, userId, membership) which will set the membership of the given user in
+ * the given room. This has no return value.
+ *
+ * @param {Function} opts.backingStore.setPowerLevelContent A function with the signature:
+ * function(roomId, content) which will set the power level content in the given room.
+ * This has no return value.
  */
 function Intent(client, botClient, opts) {
     this.client = client;
     this.botClient = botClient;
-    this._membershipStates = {
-    //  room_id : "join|invite|leave|null"   null=unknown
-    };
-    this._powerLevels = {
-    //  room_id: event.content
-    };
-    this.opts = opts || {};
+    opts = opts || {};
+
+    if (opts.backingStore) {
+        if (!opts.backingStore.setPowerLevelContent ||
+                !opts.backingStore.getPowerLevelContent ||
+                !opts.backingStore.setMembership ||
+                !opts.backingStore.getMembership) {
+            throw new Error("Intent backingStore missing required functions");
+        }
+    }
+    else {
+        this._membershipStates = {
+        //  room_id : "join|invite|leave|null"   null=unknown
+        };
+        this._powerLevels = {
+        //  room_id: event.content
+        };
+        var self = this;
+
+        opts.backingStore = {
+            getMembership: function(roomId, userId) {
+                if (userId !== self.client.credentials.userId) {
+                    return null;
+                }
+                return self._membershipStates[roomId];
+            },
+            setMembership: function(roomId, userId, membership) {
+                if (userId !== self.client.credentials.userId) {
+                    return;
+                }
+                self._membershipStates[roomId] = membership;
+            },
+            setPowerLevelContent: function(roomId, content) {
+                self._powerLevels[roomId] = content;
+            },
+            getPowerLevelContent: function(roomId) {
+                return self._powerLevels[roomId];
+            }
+        }
+    }
+
+    this.opts = opts;
 }
 
 /**
@@ -259,17 +315,18 @@ Intent.prototype.createRoom = function(opts) {
     }).then(function(res) {
         // create a fake power level event to give the room creator ops if we
         // don't yet have a power level event.
-        if (self._powerLevels[res.room_id]) {
+        if (self.opts.backingStore.getPowerLevelContent(res.room_id)) {
             return res;
         }
-        self._powerLevels[res.room_id] = {
+        var users = {};
+        users[cli.credentials.userId] = 100;
+        self.opts.backingStore.setPowerLevelContent(res.room_id, {
             users_default: 0,
             events_default: 0,
             state_default: 50,
-            users: {},
+            users: users,
             events: {}
-        };
-        self._powerLevels[res.room_id].users[cli.credentials.userId] = 100;
+        });
         return res;
     });
 };
@@ -412,10 +469,14 @@ Intent.prototype.createAlias = function(alias, roomId) {
 /**
  * Inform this Intent class of an incoming event. Various optimisations will be
  * done if this is provided. For example, a /join request won't be sent out if
- * it knows you've already been joined to the room.
+ * it knows you've already been joined to the room. This function does nothing
+ * if a backing store was provided to the Intent.
  * @param {Object} event The incoming event JSON
  */
 Intent.prototype.onEvent = function(event) {
+    if (!this._membershipStates || !this._powerLevels) {
+        return;
+    }
     if (event.type === "m.room.member" &&
             event.state_key === this.client.credentials.userId) {
         this._membershipStates[event.room_id] = event.content.membership;
@@ -443,7 +504,9 @@ Intent.prototype._joinGuard = function(roomId, promiseFn) {
 };
 
 Intent.prototype._ensureJoined = function(roomId, ignoreCache) {
-    if (this._membershipStates[roomId] === "join" && !ignoreCache) {
+    var self = this;
+    var userId = self.client.credentials.userId;
+    if (this.opts.backingStore.getMembership(roomId, userId) === "join" && !ignoreCache) {
         return Promise.resolve();
     }
 
@@ -463,11 +526,11 @@ Intent.prototype._ensureJoined = function(roomId, ignoreCache) {
     else:
       FAIL (bot can't get into the room)
     */
-    var self = this;
+
     var d = new Promise.defer();
-    var userId = self.client.credentials.userId;
+
     function mark(r, state) {
-        self._membershipStates[r] = state;
+        self.opts.backingStore.setMembership(r, userId, state);
         if (state === "join") {
             d.resolve();
         }
@@ -513,12 +576,13 @@ Intent.prototype._ensureHasPowerLevelFor = function(roomId, eventType) {
     }
     var self = this;
     var userId = this.client.credentials.userId;
-    var promise = Promise.resolve(this._powerLevels[roomId]);
-    if (!this._powerLevels[roomId]) {
+    var plContent = this.opts.backingStore.getPowerLevelContent(roomId);
+    var promise = Promise.resolve(plContent);
+    if (!plContent) {
         promise = this.client.getStateEvent(roomId, "m.room.power_levels", "");
     }
     return promise.then(function(eventContent) {
-        self._powerLevels[roomId] = eventContent;
+        self.opts.backingStore.setPowerLevelContent(roomId, eventContent);
         var event = {
             content: eventContent,
             room_id: roomId,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint lib/ spec/",
     "test": "BLUEBIRD_DEBUG=1 jasmine --stop-on-failure=true",
     "check": "npm run lint && npm test",
-    "ci-test": "BLUEBIRD_DEBUG=1 istanbul cover -x \"**/spec/**\" --report text -i \"lib/**/*.js\" jasmine"
+    "ci-test": "BLUEBIRD_DEBUG=1 istanbul cover -x \"**/spec/**\" --report text jasmine"
   },
   "repository": {
     "type": "git",

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -538,6 +538,11 @@ describe("Bridge", function() {
         });
 
         it("should keep culled Intents up-to-date with incoming events", function(done) {
+            // We tell the bridge that @foo:bar is joined to the room.
+            // Therefore, we expect that intent.join() should NOT call the SDK's join
+            // method. This should still be the case even if the Intent object is culled
+            // and we try to join using a new intent, in addition to if we use the old
+            // stale Intent.
             var client = mkMockMatrixClient("@foo:bar");
             client.joinRoom.and.returnValue(Promise.resolve({})); // shouldn't be called
             clients["@foo:bar"] = client;

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -471,11 +471,26 @@ describe("Bridge", function() {
             });
         });
 
-        it("should return the same intent on multiple invokations", function() {
+        it("should return the same intent on multiple invokations within the cull time",
+        function() {
             var intent = bridge.getIntent("@foo:bar");
             intent._test = 42; // sentinel
             var intent2 = bridge.getIntent("@foo:bar");
             expect(intent).toEqual(intent2);
+        });
+
+        it(
+        "should not return the same intent on multiple invokations outside the cull time",
+        function() {
+            // TODO
+        });
+
+        it("should not cull intents which are accessed again via getIntent", function() {
+            // TODO
+        });
+
+        it("should keep culled Intents up-to-date with incoming events", function() {
+            // TODO
         });
 
         it("should keep the Intent up-to-date with incoming events", function(done) {

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -8,14 +8,14 @@ describe("Intent", function() {
     var userId = "@alice:bar";
     var botUserId = "@bot:user";
     var roomId = "!foo:bar";
-    var alreadyRegistered = {
-        registered: true
-    };
 
     beforeEach(
     /** @this */
     function() {
         log.beforeEach(this);
+        var alreadyRegistered = {
+            registered: true
+        };
         var clientFields = [
             "credentials", "joinRoom", "invite", "leave", "ban", "unban",
             "kick", "getStateEvent", "setPowerLevel", "sendTyping", "sendEvent",


### PR DESCRIPTION
This has 2 notable performance implications wrt the IRC bridge:
 - Prevents unbounded memory expansion as we now cull `Intent` objects.
 - Prevents CPU spins that happen when all `Intent` objects are looped over when updating `m.room.member` or `m.room.power_levels` events.

Requires #54 for Jasmine 2, so is based off that PR. With tests to assert that:
 - Culls happen.
 - Culling doesn't result in missing state when they get remade.