### PR TITLE
Enable the default process-wide metrics in prom-client 9.0.0

### DIFF
--- a/lib/components/prometheusmetrics.js
+++ b/lib/components/prometheusmetrics.js
@@ -58,6 +58,9 @@ function PrometheusMetrics() {
     // Only attempt to load these dependencies if metrics are enabled
     this._client = require("prom-client");
 
+    // requires prom-client 9.0.0 or above
+    this._client.collectDefaultMetrics();
+
     this._collectors = []; // executed in order
     this._counters = {}; // counter metrics keyed by name
     this._timers = {}; // timer metrics (Histograms) keyed by name

--- a/lib/components/prometheusmetrics.js
+++ b/lib/components/prometheusmetrics.js
@@ -56,10 +56,11 @@
  */
 function PrometheusMetrics() {
     // Only attempt to load these dependencies if metrics are enabled
-    this._client = require("prom-client");
+    var client = this._client = require("prom-client");
 
-    // requires prom-client 9.0.0 or above
-    this._client.collectDefaultMetrics();
+    // prom-client 9.0.0 has to be asked explicitly; previous versions would
+    //   do this by default
+    if (client.collectDefaultMetrics) client.collectDefaultMetrics();
 
     this._collectors = []; // executed in order
     this._counters = {}; // counter metrics keyed by name


### PR DESCRIPTION
Since prom-client v9, the default process-wide metrics are not actually enabled by default. (Despite what you'd imagine by the name ;) ). So we have to explicitly enable them.