### PR TITLE
Provide an option for bridges to auto-group users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+package-lock.json
+.idea/
+
 .jsdoc
 ci-lint.xml
 reports

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -170,6 +170,7 @@ function Bridge(opts) {
     this._queue = new EventQueue(this.opts.queue, this._onConsume.bind(this));
     this._prevRequestPromise = Promise.resolve();
     this._metrics = null; // an optional PrometheusMetrics instance
+    this._groupExists = false; // assumption; we'll update this on our first call
 }
 
 /**
@@ -585,11 +586,17 @@ Bridge.prototype.getIntentFromLocalpart = function(localpart, request) {
 
 Bridge.prototype._createGroupIfNotExists = function() {
     var self = this;
+    if (self._groupExists) {
+        // Don't hit the homeserver unless we're unsure about the group's state
+        return;
+    }
     return self._botClient.getGroupSummary(self.groupId).error(function() {
         return self._botClient.createGroup({
             localpart: self.opts.groupLocalpart,
             profile: {}
         });
+    }).then(function() {
+        self._groupExists = true;
     });
 };
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -593,9 +593,8 @@ Bridge.prototype._getOrCreateGroup = function() {
         }).then(function(createdGroupId) {
             return self._botClient.getGroup(createdGroupId);
         });
-    } else {
-        return Promise.resolve(group);
     }
+    return Promise.resolve(group);
 };
 
 /**
@@ -644,9 +643,8 @@ Bridge.prototype.provisionUser = function(matrixUser, provisionedUser) {
                         // Advertise flair for the user by default
                         return newUser.setGroupPublicity(group.groupId, true);
                     });
-            } else {
-                throw new Error("Failed to get or create group " + self.groupId);
             }
+            throw new Error("Failed to get or create group " + self.groupId);
         });
     }
     return promise;

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -88,6 +88,10 @@ var INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * parameters in {@link Bridge~onEvent}. Disabling the context makes the
  * bridge do fewer database lookups, but prevents there from being a
  * <code>context</code> parameter. Default: false.
+ * @param {string=} opts.groupLocalpart If supplied, users and rooms will be associated
+ * with the group. If the group does not exist, a default one will be created prior to
+ * use. Users and rooms will not be migrated automatically - that is a task left up to
+ * the individual bridge.
  */
 function Bridge(opts) {
     if (typeof opts !== "object") {
@@ -131,6 +135,11 @@ function Bridge(opts) {
     }
     if (opts.disableContext === undefined) {
         opts.disableContext = false;
+    }
+
+    // define a group ID we can use as a reference
+    if (opts.groupLocalpart) {
+        this.groupId = "+" + opts.groupLocalpart + ":" + opts.domain;
     }
 
     // we'll init these at runtime
@@ -574,6 +583,16 @@ Bridge.prototype.getIntentFromLocalpart = function(localpart, request) {
     );
 };
 
+Bridge.prototype._getOrCreateGroup = function() {
+    var self = this;
+    var group = self._botClient.getGroup(self.groupId);
+    if (!group) {
+        return self._botClient.createGroup({localpart: self.opts.groupLocalpart, profile: {}}).then(function(createdGroupId) {
+            return self._botClient.getGroup(createdGroupId);
+        });
+    } else return Promise.resolve(group);
+};
+
 /**
  * Provision a user on the homeserver.
  * @param {MatrixUser} matrixUser The virtual user to be provisioned.
@@ -607,6 +626,21 @@ Bridge.prototype.provisionUser = function(matrixUser, provisionedUser) {
             return newUser.setAvatarUrl(provisionedUser.url);
         });
     }
+    if (!provisionedUser.dontJoinGroup && self.groupId) {
+        promise = promise.then(function() {
+            return self._getOrCreateGroup();
+        }).then(function(group) {
+            if (group) {
+                // Auto-join the new user by inviting them, then impersonating the acceptance.
+                return self._botClient.inviteUserToGroup(group.groupId, matrixUser.getId()).then(function() {
+                    return newUser.acceptGroupInvite(group.groupId);
+                }).then(function () {
+                    // Advertise flair for the user by default
+                    return newUser.setGroupPublicity(group.groupId, true);
+                });
+            } else throw new Error("Failed to get or create group " + self.groupId);
+        });
+    }
     return promise;
 };
 
@@ -629,6 +663,7 @@ Bridge.prototype._onUserQuery = function(userId) {
 Bridge.prototype._onAliasQuery = function(alias) {
     var self = this;
     var remoteRoom = null;
+    var dontAdvertiseGroup = false;
     var roomId;
     if (self.opts.controller.onAliasQuery) {
         return Promise.resolve(
@@ -637,6 +672,7 @@ Bridge.prototype._onAliasQuery = function(alias) {
             if (!provisionedRoom) {
                 throw new Error("Not provisioning room for this alias");
             }
+            dontAdvertiseGroup = provisionedRoom.dontAdvertiseGroup;
             // do the HTTP hit
             remoteRoom = provisionedRoom.remote;
             return self._botClient.createRoom(
@@ -651,6 +687,15 @@ Bridge.prototype._onAliasQuery = function(alias) {
             }
             // store the matrix room only
             return self._roomStore.setMatrixRoom(matrixRoom);
+        }).then(function () {
+            // Process group-related functions, if we need to.
+            if (!dontAdvertiseGroup && self.groupId) {
+                var group = self._getOrCreateGroup(); // make sure it is created
+                if (!group) throw new Error("Failed to get or create group " + self.groupId);
+                return self._botClient.sendStateEvent(roomId, "m.room.related_groups", {
+                    groups: [group.groupId]
+                }, "");
+            }
         }).then(function() {
             if (self.opts.controller.onAliasQueried) {
                 self.opts.controller.onAliasQueried(alias, roomId);
@@ -998,6 +1043,8 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  * @type {Object}
  * @property {string=} name The display name to set for the provisioned user.
  * @property {string=} url The avatar URL to set for the provisioned user.
+ * @property {boolean=} dontJoinGroup If true, the user won't be added to the group
+ * defined for this bridge. If no group is defined, this will not do anything.
  * @property {RemoteUser=} remote The remote user to link to the provisioned user.
  */
 
@@ -1006,6 +1053,8 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  * @type {Object}
  * @property {Object} creationOpts Room creation options to use when creating the
  * room. Required.
+ * @property {boolean=} dontAdvertiseGroup If true, the room will not advertise flair
+ * for members of the bridge's group. If no gorup is defined, this does nothing.
  * @property {RemoteRoom=} remote The remote room to link to the provisioned room.
  */
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -88,10 +88,13 @@ var INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * parameters in {@link Bridge~onEvent}. Disabling the context makes the
  * bridge do fewer database lookups, but prevents there from being a
  * <code>context</code> parameter. Default: false.
- * @param {string=} opts.groupLocalpart If supplied, users and rooms will be associated
- * with the group. If the group does not exist, a default one will be created prior to
- * use. Users and rooms will not be migrated automatically - that is a task left up to
- * the individual bridge.
+ * @param {Object=} opts.group If supplied, users and rooms created by this bridge
+ * will be associated with the group. For users, this means joining the group after
+ * being queried through the controller. For rooms, this means associating the group
+ * through m.room.related_groups after the alias has been queried. Existing users
+ * and rooms are not automatically migrated. The group will be created if it does not
+ * exist.
+ * @param {string]} opts.group.localpart The localpart for the group.
  */
 function Bridge(opts) {
     if (typeof opts !== "object") {
@@ -138,8 +141,8 @@ function Bridge(opts) {
     }
 
     // define a group ID we can use as a reference
-    if (opts.groupLocalpart) {
-        this.groupId = "+" + opts.groupLocalpart + ":" + opts.domain;
+    if (opts.group) {
+        this.groupId = "+" + opts.group.localpart + ":" + opts.domain;
     }
 
     // we'll init these at runtime
@@ -592,7 +595,7 @@ Bridge.prototype._createGroupIfNotExists = function() {
     }
     return self._botClient.getGroupSummary(self.groupId).error(function() {
         return self._botClient.createGroup({
-            localpart: self.opts.groupLocalpart,
+            localpart: self.opts.group.localpart,
             profile: {}
         });
     }).then(function() {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -636,7 +636,13 @@ Bridge.prototype.provisionUser = function(matrixUser, provisionedUser) {
             return newUser.setAvatarUrl(provisionedUser.url);
         });
     }
-    if (provisionedUser.shouldJoinGroup !== false && self.groupId) {
+
+    var shouldJoinGroup = true;
+    if (provisionedUser.shouldJoinGroup === false) {
+        shouldJoinGroup = false;
+    }
+
+    if (shouldJoinGroup && self.groupId) {
         promise = promise.then(function() {
             return self._createGroupIfNotExists();
         }).then(function() {
@@ -704,7 +710,7 @@ Bridge.prototype._onAliasQuery = function(alias) {
                     return self._botClient.getStateEvent(roomId, "m.room.related_groups", "");
                 }).then(function(relatedGroupsContent) {
                     var groups = [];
-                    if (relatedGroupsContent && relatedGroupsContent.groups) {
+                    if (relatedGroupsContent && Array.isArray(relatedGroupsContent.groups)) {
                         groups = relatedGroupsContent.groups;
                     }
                     groups.push(self.groupId);

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -583,18 +583,14 @@ Bridge.prototype.getIntentFromLocalpart = function(localpart, request) {
     );
 };
 
-Bridge.prototype._getOrCreateGroup = function() {
+Bridge.prototype._createGroupIfNotExists = function() {
     var self = this;
-    var group = self._botClient.getGroup(self.groupId);
-    if (!group) {
+    return self._botClient.getGroupSummary(self.groupId).error(function() {
         return self._botClient.createGroup({
             localpart: self.opts.groupLocalpart,
             profile: {}
-        }).then(function(createdGroupId) {
-            return self._botClient.getGroup(createdGroupId);
         });
-    }
-    return Promise.resolve(group);
+    });
 };
 
 /**
@@ -632,19 +628,15 @@ Bridge.prototype.provisionUser = function(matrixUser, provisionedUser) {
     }
     if (!provisionedUser.dontJoinGroup && self.groupId) {
         promise = promise.then(function() {
-            return self._getOrCreateGroup();
-        }).then(function(group) {
-            if (group) {
-                var groupId = group.groupId;
-                return self._botClient.inviteUserToGroup(groupId, matrixUser.getId())
-                    .then(function() {
-                        return newUser.acceptGroupInvite(groupId);
-                    }).then(function () {
-                        // Advertise flair for the user by default
-                        return newUser.setGroupPublicity(group.groupId, true);
-                    });
-            }
-            throw new Error("Failed to get or create group " + self.groupId);
+            return self._createGroupIfNotExists();
+        }).then(function() {
+            return self._botClient.inviteUserToGroup(self.groupId, matrixUser.getId())
+                .then(function() {
+                    return newUser.acceptGroupInvite(self.groupId);
+                }).then(function () {
+                    // Advertise flair for the user by default
+                    return newUser.setGroupPublicity(self.groupId, true);
+                });
         });
     }
     return promise;
@@ -696,13 +688,11 @@ Bridge.prototype._onAliasQuery = function(alias) {
         }).then(function () {
             // Process group-related functions, if we need to.
             if (!dontAdvertiseGroup && self.groupId) {
-                var group = self._getOrCreateGroup(); // make sure it is created
-                if (!group) {
-                    throw new Error("Failed to get or create group " + self.groupId);
-                }
-                return self._botClient.sendStateEvent(roomId, "m.room.related_groups", {
-                    groups: [group.groupId]
-                }, "");
+                return self._createGroupIfNotExists().then(function() {
+                    return self._botClient.sendStateEvent(roomId, "m.room.related_groups", {
+                        groups: [self.groupId]
+                    }, "");
+                });
             }
         }).then(function() {
             if (self.opts.controller.onAliasQueried) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -636,7 +636,7 @@ Bridge.prototype.provisionUser = function(matrixUser, provisionedUser) {
             return newUser.setAvatarUrl(provisionedUser.url);
         });
     }
-    if (!provisionedUser.dontJoinGroup && self.groupId) {
+    if (provisionedUser.shouldJoinGroup !== false && self.groupId) {
         promise = promise.then(function() {
             return self._createGroupIfNotExists();
         }).then(function() {
@@ -671,7 +671,7 @@ Bridge.prototype._onUserQuery = function(userId) {
 Bridge.prototype._onAliasQuery = function(alias) {
     var self = this;
     var remoteRoom = null;
-    var dontAdvertiseGroup = false;
+    var shouldAdvertiseGroup = true;
     var roomId;
     if (self.opts.controller.onAliasQuery) {
         return Promise.resolve(
@@ -680,7 +680,9 @@ Bridge.prototype._onAliasQuery = function(alias) {
             if (!provisionedRoom) {
                 throw new Error("Not provisioning room for this alias");
             }
-            dontAdvertiseGroup = provisionedRoom.dontAdvertiseGroup;
+            if (provisionedRoom.shouldAdvertiseGroup === false) {
+                shouldAdvertiseGroup = false;
+            }
             // do the HTTP hit
             remoteRoom = provisionedRoom.remote;
             return self._botClient.createRoom(
@@ -697,7 +699,7 @@ Bridge.prototype._onAliasQuery = function(alias) {
             return self._roomStore.setMatrixRoom(matrixRoom);
         }).then(function () {
             // Process group-related functions, if we need to.
-            if (!dontAdvertiseGroup && self.groupId) {
+            if (shouldAdvertiseGroup && self.groupId) {
                 return self._createGroupIfNotExists().then(function() {
                     return self._botClient.sendStateEvent(roomId, "m.room.related_groups", {
                         groups: [self.groupId]
@@ -1051,7 +1053,7 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  * @type {Object}
  * @property {string=} name The display name to set for the provisioned user.
  * @property {string=} url The avatar URL to set for the provisioned user.
- * @property {boolean=} dontJoinGroup If true, the user won't be added to the group
+ * @property {boolean=} shouldJoinGroup If false, the user won't be added to the group
  * defined for this bridge. If no group is defined, this will not do anything.
  * @property {RemoteUser=} remote The remote user to link to the provisioned user.
  */
@@ -1061,7 +1063,7 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  * @type {Object}
  * @property {Object} creationOpts Room creation options to use when creating the
  * room. Required.
- * @property {boolean=} dontAdvertiseGroup If true, the room will not advertise flair
+ * @property {boolean=} shouldAdvertiseGroup If false, the room will not advertise flair
  * for members of the bridge's group. If no gorup is defined, this does nothing.
  * @property {RemoteRoom=} remote The remote room to link to the provisioned room.
  */

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -147,7 +147,9 @@ function Bridge(opts) {
     if (opts.group) {
         this.groupId = "+" + opts.group.localpart + ":" + opts.domain;
 
-        if (!opts.group.memberVisibility) opts.group.memberVisibility = "public";
+        if (!opts.group.memberVisibility) {
+            opts.group.memberVisibility = "public";
+        }
         if (opts.group.memberVisibility !== "public"
             && opts.group.memberVisibility !== "private") {
             throw new Error("Group member visibility must be 'public' or 'private'");
@@ -600,7 +602,7 @@ Bridge.prototype._createGroupIfNotExists = function() {
     var self = this;
     if (self._groupExists) {
         // Don't hit the homeserver unless we're unsure about the group's state
-        return;
+        return Promise.resolve();
     }
     return self._botClient.getGroupSummary(self.groupId).error(function() {
         return self._botClient.createGroup({
@@ -723,17 +725,21 @@ Bridge.prototype._onAliasQuery = function(alias) {
             // Process group-related functions, if we need to.
             if (shouldAdvertiseGroup && self.groupId) {
                 return self._createGroupIfNotExists().then(function() {
-                    return self._botClient.getStateEvent(roomId, "m.room.related_groups", "");
+                    return self._botClient.getStateEvent(
+                        roomId, "m.room.related_groups", "");
                 }).then(function(relatedGroupsContent) {
                     var groups = [];
-                    if (relatedGroupsContent && Array.isArray(relatedGroupsContent.groups)) {
+                    if (relatedGroupsContent
+                        && Array.isArray(relatedGroupsContent.groups)) {
                         groups = relatedGroupsContent.groups;
                     }
                     groups.push(self.groupId);
 
-                    return self._botClient.sendStateEvent(roomId, "m.room.related_groups", {
-                        groups: groups
-                    }, "");
+                    return self._botClient.sendStateEvent(
+                        roomId,
+                        "m.room.related_groups",
+                        { groups: groups },
+                        "");
                 });
             }
         }).then(function() {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -587,10 +587,15 @@ Bridge.prototype._getOrCreateGroup = function() {
     var self = this;
     var group = self._botClient.getGroup(self.groupId);
     if (!group) {
-        return self._botClient.createGroup({localpart: self.opts.groupLocalpart, profile: {}}).then(function(createdGroupId) {
+        return self._botClient.createGroup({
+            localpart: self.opts.groupLocalpart,
+            profile: {}
+        }).then(function(createdGroupId) {
             return self._botClient.getGroup(createdGroupId);
         });
-    } else return Promise.resolve(group);
+    } else {
+        return Promise.resolve(group);
+    }
 };
 
 /**
@@ -631,14 +636,17 @@ Bridge.prototype.provisionUser = function(matrixUser, provisionedUser) {
             return self._getOrCreateGroup();
         }).then(function(group) {
             if (group) {
-                // Auto-join the new user by inviting them, then impersonating the acceptance.
-                return self._botClient.inviteUserToGroup(group.groupId, matrixUser.getId()).then(function() {
-                    return newUser.acceptGroupInvite(group.groupId);
-                }).then(function () {
-                    // Advertise flair for the user by default
-                    return newUser.setGroupPublicity(group.groupId, true);
-                });
-            } else throw new Error("Failed to get or create group " + self.groupId);
+                var groupId = group.groupId;
+                return self._botClient.inviteUserToGroup(groupId, matrixUser.getId())
+                    .then(function() {
+                        return newUser.acceptGroupInvite(groupId);
+                    }).then(function () {
+                        // Advertise flair for the user by default
+                        return newUser.setGroupPublicity(group.groupId, true);
+                    });
+            } else {
+                throw new Error("Failed to get or create group " + self.groupId);
+            }
         });
     }
     return promise;
@@ -691,7 +699,9 @@ Bridge.prototype._onAliasQuery = function(alias) {
             // Process group-related functions, if we need to.
             if (!dontAdvertiseGroup && self.groupId) {
                 var group = self._getOrCreateGroup(); // make sure it is created
-                if (!group) throw new Error("Failed to get or create group " + self.groupId);
+                if (!group) {
+                    throw new Error("Failed to get or create group " + self.groupId);
+                }
                 return self._botClient.sendStateEvent(roomId, "m.room.related_groups", {
                     groups: [group.groupId]
                 }, "");

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -94,7 +94,10 @@ var INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * through m.room.related_groups after the alias has been queried. Existing users
  * and rooms are not automatically migrated. The group will be created if it does not
  * exist.
- * @param {string]} opts.group.localpart The localpart for the group.
+ * @param {string=} opts.group.memberVisibility When "private", members added to the group
+ * will be added without being visible to non-members of the group. The default value,
+ * "public", causes members of the group to be visible to non-members.
+ * @param {string=} opts.group.localpart The localpart for the group.
  */
 function Bridge(opts) {
     if (typeof opts !== "object") {
@@ -143,6 +146,12 @@ function Bridge(opts) {
     // define a group ID we can use as a reference
     if (opts.group) {
         this.groupId = "+" + opts.group.localpart + ":" + opts.domain;
+
+        if (!opts.group.memberVisibility) opts.group.memberVisibility = "public";
+        if (opts.group.memberVisibility !== "public"
+            && opts.group.memberVisibility !== "private") {
+            throw new Error("Group member visibility must be 'public' or 'private'");
+        }
     }
 
     // we'll init these at runtime
@@ -642,13 +651,20 @@ Bridge.prototype.provisionUser = function(matrixUser, provisionedUser) {
         shouldJoinGroup = false;
     }
 
+    var groupVisibility = self.opts.group.memberVisibility;
+    if (provisionedUser.groupMemberVisibility) {
+        groupVisibility = provisionedUser.groupMemberVisibility;
+    }
+
     if (shouldJoinGroup && self.groupId) {
         promise = promise.then(function() {
             return self._createGroupIfNotExists();
         }).then(function() {
             return self._botClient.inviteUserToGroup(self.groupId, matrixUser.getId())
                 .then(function() {
-                    return newUser.acceptGroupInvite(self.groupId);
+                    return newUser.acceptGroupInvite(self.groupId, {
+                        "m.visibility": { type: groupVisibility }
+                    });
                 }).then(function () {
                     // Advertise flair for the user by default
                     return newUser.setGroupPublicity(self.groupId, true);
@@ -1069,6 +1085,8 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  * @property {string=} url The avatar URL to set for the provisioned user.
  * @property {boolean=} shouldJoinGroup If false, the user won't be added to the group
  * defined for this bridge. If no group is defined, this will not do anything.
+ * @property {string=} groupMemberVisibility If set, the value provided here will be used
+ * for the member's group visibility. If no group is defined, this does nothing.
  * @property {RemoteUser=} remote The remote user to link to the provisioned user.
  */
 
@@ -1078,7 +1096,7 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  * @property {Object} creationOpts Room creation options to use when creating the
  * room. Required.
  * @property {boolean=} shouldAdvertiseGroup If false, the room will not advertise flair
- * for members of the bridge's group. If no gorup is defined, this does nothing.
+ * for members of the bridge's group. If no group is defined, this does nothing.
  * @property {RemoteRoom=} remote The remote room to link to the provisioned room.
  */
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -702,10 +702,10 @@ Bridge.prototype._onAliasQuery = function(alias) {
             if (shouldAdvertiseGroup && self.groupId) {
                 return self._createGroupIfNotExists().then(function() {
                     return self._botClient.getStateEvent(roomId, "m.room.related_groups", "");
-                }).then(function(currentState) {
+                }).then(function(relatedGroupsContent) {
                     var groups = [];
-                    if (currentState && currentState.getContent()) {
-                        groups = currentState.getContent().groups || [];
+                    if (relatedGroupsContent && relatedGroupsContent.groups) {
+                        groups = relatedGroupsContent.groups;
                     }
                     groups.push(self.groupId);
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -701,8 +701,16 @@ Bridge.prototype._onAliasQuery = function(alias) {
             // Process group-related functions, if we need to.
             if (shouldAdvertiseGroup && self.groupId) {
                 return self._createGroupIfNotExists().then(function() {
+                    return self._botClient.getStateEvent(roomId, "m.room.related_groups", "");
+                }).then(function(currentState) {
+                    var groups = [];
+                    if (currentState && currentState.getContent()) {
+                        groups = currentState.getContent().groups || [];
+                    }
+                    groups.push(self.groupId);
+
                     return self._botClient.sendStateEvent(roomId, "m.room.related_groups", {
-                        groups: [self.groupId]
+                        groups: groups
                     }, "");
                 });
             }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -651,17 +651,17 @@ Bridge.prototype.provisionUser = function(matrixUser, provisionedUser) {
         shouldJoinGroup = false;
     }
 
-    var groupVisibility = self.opts.group.memberVisibility;
-    if (provisionedUser.groupMemberVisibility) {
-        groupVisibility = provisionedUser.groupMemberVisibility;
-    }
-
     if (shouldJoinGroup && self.groupId) {
         promise = promise.then(function() {
             return self._createGroupIfNotExists();
         }).then(function() {
             return self._botClient.inviteUserToGroup(self.groupId, matrixUser.getId())
                 .then(function() {
+                    var groupVisibility = self.opts.group.memberVisibility;
+                    if (provisionedUser.groupMemberVisibility) {
+                        groupVisibility = provisionedUser.groupMemberVisibility;
+                    }
+
                     return newUser.acceptGroupInvite(self.groupId, {
                         "m.visibility": { type: groupVisibility }
                     });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jayschema": "^0.3.1",
     "js-yaml": "^3.4.0",
     "matrix-appservice": "^0.3.3",
-    "matrix-js-sdk": "0.7.3",
+    "matrix-js-sdk": "0.8.5",
     "nedb": "^1.1.3",
     "nopt": "^3.0.3",
     "request": "^2.61.0"


### PR DESCRIPTION
## Required PRs
* https://github.com/matrix-org/matrix-js-sdk/pull/570 - for the visibility component

## Overview
Many bridges may wish to group their users into a single community, making it abundantly clear in their portal rooms that the users are from a different network. A single flag (`groupLocalpart`) has been exposed as part of the `Bridge` constructor to enable this functionality. Bridges may also provide `dontJoinGroup` or `dontAdvertiseGroup` for users and rooms (respectively) to bypass the groups functionality on that particular entity.

## Migrating a bridge to use this
This PR does not add in the functionality to automatically join any created users to the group, as each bridge is different in how it accomplishes storing known users. This task is left up to the individual bridge. Below is an example startup routine for bridges that wish to do the migration automatically; some assumptions have been made about imports, naming, and structure.
```js
var bridge = new Bridge({ groupLocalpart: "irc", /* other options */ });
bridge.run(port).then(() => {
    var botClient = bridge.getBot().getClient();
    var userIds = /* a list of user IDs to add to the group */
    var group = botClient.getGroup("+irc:" + homeserverDomain);
    var promise = Promise.resolve(group);
    if (!group) {
        promise = botClient.createGroup("+irc:" + homeserverDomain);
    }

    return promise.then(group => {
        var chain = Promise.resolve();
        userIds.map(user => chain = chain.then(() => {
            return botClient.inviteUserToGroup("+irc:" + homeserverDomain, user);
        }.then(() => {
            var userClient = bridge.getIntent(user).getClient();
            return userClient.acceptGroupInvite("+irc:" + homeserverDomain);
        })));
        return chain;
    });
}).then(() => {
    var botClient = bridge.getBot().getClient();
    var roomIds = /* a list of room IDs to advertise flair in */

    var chain = Promise.resolve();
    roomIds.map(roomId => chain = chain.then(() => botClient.sendStateEvent(roomId, "m.room.related_groups", {groups: ["+irc:" + homeserverDomain]}, "")));
    return chain;
});
```
