### PR TITLE
Add Intent.setPresence

### DIFF
--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -48,11 +48,15 @@ var STATE_EVENT_TYPES = [
  * @param {boolean} opts.dontJoin True to not attempt to join a room before
  * sending messages into it. The surrounding code will have to ensure the correct
  * membership state itself in this case. Default: false.
+ * 
+ * @param {boolean} [opts.enablePresence=true] True to send presence, false to no-op.
  */
 function Intent(client, botClient, opts) {
     this.client = client;
     this.botClient = botClient;
     opts = opts || {};
+
+    opts.enablePresence = !(opts.enablePresence !== false);
 
     if (opts.backingStore) {
         if (!opts.backingStore.setPowerLevelContent ||
@@ -467,6 +471,22 @@ Intent.prototype.createAlias = function(alias, roomId) {
     var self = this;
     return self._ensureRegistered().then(function() {
         return self.client.createAlias(alias, roomId);
+    });
+};
+
+/**
+ * Set the presence of this user.
+ * @param {string} presence One of "online", "offline" or "unavailable".
+ * @param {string} status_msg The status message to attach.
+ * @return {Promise}
+ */
+Intent.prototype.setPresence = function(presence, status=undefined) {
+    if (!this.opts.enablePresence) {
+        return Promise.resolve();
+    }
+
+    return this._ensureRegistered().then(() => {
+        return this.client.setPresence({presence, status});
     });
 };
 

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -56,7 +56,7 @@ function Intent(client, botClient, opts) {
     this.botClient = botClient;
     opts = opts || {};
 
-    opts.enablePresence = !(opts.enablePresence !== false);
+    opts.enablePresence = !!opts.enablePresence;
 
     if (opts.backingStore) {
         if (!opts.backingStore.setPowerLevelContent ||
@@ -478,7 +478,7 @@ Intent.prototype.createAlias = function(alias, roomId) {
  * Set the presence of this user.
  * @param {string} presence One of "online", "offline" or "unavailable".
  * @param {string} status_msg The status message to attach.
- * @return {Promise}
+ * @return {Promise} Resolves if the presence was set or no-oped, rejects otherwise. 
  */
 Intent.prototype.setPresence = function(presence, status=undefined) {
     if (!this.opts.enablePresence) {

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -480,13 +480,13 @@ Intent.prototype.createAlias = function(alias, roomId) {
  * @param {string} status_msg The status message to attach.
  * @return {Promise} Resolves if the presence was set or no-oped, rejects otherwise. 
  */
-Intent.prototype.setPresence = function(presence, status=undefined) {
+Intent.prototype.setPresence = function(presence, status_msg=undefined) {
     if (!this.opts.enablePresence) {
         return Promise.resolve();
     }
 
     return this._ensureRegistered().then(() => {
-        return this.client.setPresence({presence, status});
+        return this.client.setPresence({presence, status_msg});
     });
 };
 


### PR DESCRIPTION
Also adds a ``Intent`` opt ``enablePresence`` which is true by default. Useful for bridges who want to disable presence support without having to go through all the presence code.