### PR TITLE
Room linking validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ the logger, which takes the following options:
 }
 ```
 
+
 You **MUST** configure the logger before anything will be emitted to the console.
 
 You can then use `const log = Logging.Get(ModuleName)` to start logging to the reporter,
@@ -132,6 +133,32 @@ automatically be seralized if they aren't strings.
 
 NOTE: ``opts.controller.onLog`` will override this, but if not set then the logging
 transport is used.
+
+## `RoomLinkValidator`
+This component validates if a room can be linked to a remote channel based on
+whether it conflicts with any rules given in a rule file. The filename is given
+in `opts` for `Bridge`, though you may also set the rules as an object instead.
+The format for the file (in YAML) or the object is as follows:
+```javascript
+{
+    // This rule checks the memberlist of a room to determine if it will let
+    // the bridge create a link to the room. This is useful for avoiding conflicts
+    // with other bridges.
+    "userIds": {
+        // Anyone in this set will be ALWAYS exempt from the conflicts rule.
+        // Here anyone who's localpart starts with nice is exempt.
+        "exempt": ["@nice+.:example.com"]
+        // This is a regex that will exclude anyone who has "guy" at the end of their localpart.
+        // evilbloke is also exempt.
+        "conflicts": ["@+.guy:example.com", "@evilbloke:example.com"]
+    }
+}
+```
+
+If you set `opts.roomLinkValidator.triggerEndpoint` to `true`, then you may use
+`/_bridge/roomLinkValidator/reload` to reload the config from file. This endpoint
+optionally takes the `filename` parameter if you want to reload the config from
+another location.
 
 ## Data Models
  * `MatrixRoom` - A representation of a matrix room.

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -760,9 +760,6 @@ Bridge.prototype._onEvent = function(event) {
 Bridge.prototype._onConsume = function(err, data) {
     if (!err) {
         this.opts.controller.onEvent(data.request, data.context);
-        if (this._roomLinkValidator) {
-            this._roomLinkValidator.onEvent(data.request, data.content);
-        }
         return;
     }
     if (!this.opts.controller.onLog) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -17,7 +17,8 @@ const yaml = require("js-yaml");
 const Promise = require("bluebird");
 const Datastore = require("nedb");
 const util = require("util");
-const MembershipCache = new require("./components/membership-cache");
+const MembershipCache = require("./components/membership-cache");
+const RoomLinkValidator = require("./components/room-link-validator").RoomLinkValidator;
 
 // The frequency at which we will check the list of accumulated Intent objects.
 const INTENT_CULL_CHECK_PERIOD_MS = 1000 * 60; // once per minute
@@ -163,6 +164,7 @@ function Bridge(opts) {
     this._queue = new EventQueue(this.opts.queue, this._onConsume.bind(this));
     this._prevRequestPromise = Promise.resolve();
     this._metrics = null; // an optional PrometheusMetrics instance
+    this._roomLinkValidator = null;
 }
 
 /**
@@ -231,6 +233,14 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
     this._appServiceBot = new AppServiceBot(
         this._botClient, self.opts.registration, this._membershipCache
     );
+
+    if (this.opts.roomLinkingRules !== undefined) {
+        this._roomLinkValidator = new RoomLinkValidator(
+            this.opts.roomLinkingRules,
+            this._appServiceBot
+        );
+    }
+
     this._requestFactory = new RequestFactory();
     if (this.opts.controller.onLog && this.opts.logRequestOutcome) {
         this._requestFactory.addDefaultResolveCallback(function(req, res) {
@@ -532,6 +542,10 @@ Bridge.prototype.getBot = function() {
     return this._appServiceBot;
 };
 
+Bridge.prototype.getRoomLinkValidator = function() {
+    return this._roomLinkValidator;
+}
+
 /**
  * Retrieve an Intent instance for the specified user ID. If no ID is given, an
  * instance for the bot itself is returned.
@@ -717,6 +731,9 @@ Bridge.prototype._onEvent = function(event) {
 Bridge.prototype._onConsume = function(err, data) {
     if (!err) {
         this.opts.controller.onEvent(data.request, data.context);
+        if (this._roomLinkValidator) {
+            this._roomLinkValidator.onEvent(data.request, data.content);
+        }
         return;
     }
     if (!this.opts.controller.onLog) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -62,7 +62,7 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * this is not specified.
  * @param {MembershipCache=} opts.membershipCache The membership cache instance
  * to use, which can be manually created by a bridge for greater control over
- * caching. By default a membership cache will be created internally. 
+ * caching. By default a membership cache will be created internally.
  * @param {boolean=} opts.suppressEcho True to stop receiving onEvent callbacks
  * for events which were sent by a bridge user. Default: true.
  * @param {ClientFactory=} opts.clientFactory The client factory instance to
@@ -97,9 +97,11 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * <code>context</code> parameter. Default: false.
  * @param {Object=} opts.roomLinkValidation Options to supply to the room link
  * validator. If not defined then all room links are accepted.
- * @param {Object=} opts.roomLinkValidation.ruleFile A file containing rules
+ * @param {string} opts.roomLinkValidation.ruleFile A file containing rules
  * on which matrix rooms can be bridged.
- * @param {Object=} opts.roomLinkValidation.watch Should the file be watched
+ * @param {Object=} opts.roomLinkValidation.rules A object containing rules
+ * on which matrix rooms can be bridged. This is used if ruleFile is undefined.
+ * @param {boolean=} opts.roomLinkValidation.watch Should the file be watched
  * for changes, so that rules can be updated without restarting the bridge.
  * Default: false
  */
@@ -556,7 +558,7 @@ Bridge.prototype.getBot = function() {
  * Can the room be provisioned based on the rules provided to the
  * bridge.
  * @param {string} roomId The room to check.
- * @param {boolean} noCache Should the validator check it's cache.
+ * @param {boolean} cache Should the validator check it's cache.
  * @returns {Promise} resolves if can and rejects if it cannot.
  *                    A status code is returned on both.
  */

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -102,8 +102,8 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * on which matrix rooms can be bridged.
  * @param {Object=} opts.roomLinkValidation.rules A object containing rules
  * on which matrix rooms can be bridged. This is used if ruleFile is undefined.
- * @param {boolean=} opts.roomLinkValidation.watch Should the file be watched
- * for changes, so that rules can be updated without restarting the bridge.
+ * @param {boolean=} opts.roomLinkValidation.triggerEndpoint Enable the endpoint
+ * to trigger a reload of the rules file.
  * Default: false
  */
 function Bridge(opts) {
@@ -312,6 +312,23 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
 Bridge.prototype._customiseAppservice = function() {
     if (this.opts.controller.thirdPartyLookup) {
         this._customiseAppserviceThirdPartyLookup(this.opts.controller.thirdPartyLookup);
+    }
+    if (this.opts.roomLinkValidation && this.opts.roomLinkValidation.triggerEndpoint) {
+        this.addAppServicePath({
+            method: "POST",
+            path: "/_bridge/roomLinkValidator/reload",
+            handler: function(req, res) {
+                try {
+                    // Will use filename if provided, or the config
+                    // one otherwised.
+                    this._roomLinkValidator.readRuleFile(req.query.filename);
+                    res.status(200).send("Success");
+                } catch (e) {
+                    res.status(500).send("Failed: " + e);
+                }
+
+            },
+        });
     }
 };
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -316,7 +316,10 @@ Bridge.prototype._customiseAppservice = function() {
         this.addAppServicePath({
             method: "POST",
             path: "/_bridge/roomLinkValidator/reload",
-            handler: function(req, res) {
+            handler: (req, res) => {
+                if (!this._requestCheckToken(req, res)) {
+                    return;
+                }
                 try {
                     // Will use filename if provided, or the config
                     // one otherwised.
@@ -325,7 +328,6 @@ Bridge.prototype._customiseAppservice = function() {
                 } catch (e) {
                     res.status(500).send("Failed: " + e);
                 }
-
             },
         });
     }
@@ -573,8 +575,9 @@ Bridge.prototype.getBot = function() {
 };
 
 /**
- * Can the room be provisioned based on the rules provided to the
- * bridge.
+ * Determines whether a room should be provisoned based on
+ * user provided rules and the room state. Will default to true
+ * if no rules have been provided.
  * @param {string} roomId The room to check.
  * @param {boolean} cache Should the validator check it's cache.
  * @returns {Promise} resolves if can and rejects if it cannot.
@@ -1022,6 +1025,17 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
         }
     });
 };
+
+BridgeContext.prototype._requestCheckToken = function(req, res) {
+    if (req.query.access_token !== this.opts.registration.hs_token) {
+        res.status(403).send({
+            errcode: "M_FORBIDDEN",
+            error: "Bad token supplied,"
+        });
+        return true;
+    }
+    return false;
+}
 
 /**
  * @typedef Bridge~BridgeContext

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -552,6 +552,21 @@ Bridge.prototype.getBot = function() {
     return this._appServiceBot;
 };
 
+/**
+ * Can the room be provisioned based on the rules provided to the
+ * bridge.
+ * @param {string} roomId The room to check.
+ * @param {boolean} noCache Should the validator check it's cache.
+ * @returns {Promise} resolves if can and rejects if it cannot.
+ *                    A status code is returned on both.
+ */
+Bridge.prototype.canProvisionRoom = function(roomId, noCache=false) {
+    if (this._roomLinkValidator === null) {
+        return Promise.resolve(RLVStatus.PASSED);
+    }
+    return this._roomLinkValidator.validateRoom(roomId, noCache);
+}
+
 Bridge.prototype.getRoomLinkValidator = function() {
     return this._roomLinkValidator;
 }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -250,8 +250,7 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
     if (this.opts.roomLinkValidation !== undefined) {
         this._roomLinkValidator = new RoomLinkValidator(
             this.opts.roomLinkValidation,
-            this._appServiceBot,
-            self.opts.controller.onLog
+            this._appServiceBot
         );
     }
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -19,6 +19,8 @@ const Datastore = require("nedb");
 const util = require("util");
 const MembershipCache = require("./components/membership-cache");
 const RoomLinkValidator = require("./components/room-link-validator").RoomLinkValidator;
+const RLVStatus = require("./components/room-link-validator").validationStatuses;
+
 
 // The frequency at which we will check the list of accumulated Intent objects.
 const INTENT_CULL_CHECK_PERIOD_MS = 1000 * 60; // once per minute
@@ -93,6 +95,13 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * parameters in {@link Bridge~onEvent}. Disabling the context makes the
  * bridge do fewer database lookups, but prevents there from being a
  * <code>context</code> parameter. Default: false.
+ * @param {Object=} opts.roomLinkValidation Options to supply to the room link
+ * validator. If not defined then all room links are accepted.
+ * @param {Object=} opts.roomLinkValidation.ruleFile A file containing rules
+ * on which matrix rooms can be bridged.
+ * @param {Object=} opts.roomLinkValidation.watch Should the file be watched
+ * for changes, so that rules can be updated without restarting the bridge.
+ * Default: false
  */
 function Bridge(opts) {
     if (typeof opts !== "object") {
@@ -234,10 +243,11 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
         this._botClient, self.opts.registration, this._membershipCache
     );
 
-    if (this.opts.roomLinkingRules !== undefined) {
+    if (this.opts.roomLinkValidation !== undefined) {
         this._roomLinkValidator = new RoomLinkValidator(
-            this.opts.roomLinkingRules,
-            this._appServiceBot
+            this.opts.roomLinkValidation,
+            this._appServiceBot,
+            self.opts.controller.onLog
         );
     }
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -562,11 +562,11 @@ Bridge.prototype.getBot = function() {
  * @returns {Promise} resolves if can and rejects if it cannot.
  *                    A status code is returned on both.
  */
-Bridge.prototype.canProvisionRoom = function(roomId, noCache=false) {
+Bridge.prototype.canProvisionRoom = function(roomId, cache=true) {
     if (this._roomLinkValidator === null) {
         return Promise.resolve(RLVStatus.PASSED);
     }
-    return this._roomLinkValidator.validateRoom(roomId, noCache);
+    return this._roomLinkValidator.validateRoom(roomId, cache);
 }
 
 Bridge.prototype.getRoomLinkValidator = function() {

--- a/lib/components/config-validator.js
+++ b/lib/components/config-validator.js
@@ -11,6 +11,7 @@ var extend = require("extend");
  */
 function ConfigValidator(schema) {
     this.schema = schema;
+    this.watcher = null;
     if (typeof schema === "string") {
         this.schema = this._loadFromFile(schema);
     }
@@ -48,6 +49,18 @@ ConfigValidator.prototype.validate = function(inputConfig, defaultConfig) {
     }
     // mux in the default config
     return extend(true, defaultConfig, inputConfig);
+}
+
+ConfigValidator.prototype.watchForChanges = function(filename, cb) {
+    this.watcher = fs.watch(filename, { encoding: 'utf8' });
+    this.watcher.on("change", cb);
+}
+
+ConfigValidator.prototype.stopWatching = function() {
+    if (this.watcher) {
+        this.watcher.close();
+        this.watcher = null;
+    }
 }
 
 ConfigValidator.prototype._loadFromFile = function(filename) {

--- a/lib/components/config-validator.js
+++ b/lib/components/config-validator.js
@@ -11,7 +11,6 @@ const extend = require("extend");
  */
 function ConfigValidator(schema) {
     this.schema = schema;
-    this.watcher = null;
     if (typeof schema === "string") {
         this.schema = this._loadFromFile(schema);
     }
@@ -48,17 +47,6 @@ ConfigValidator.prototype.validate = function(inputConfig, defaultConfig) {
     return extend(true, defaultConfig, inputConfig);
 }
 
-ConfigValidator.prototype.watchForChanges = function(filename, cb) {
-    this.watcher = fs.watch(filename, { encoding: 'utf8' });
-    this.watcher.on("change", cb);
-}
-
-ConfigValidator.prototype.stopWatching = function() {
-    if (this.watcher) {
-        this.watcher.close();
-        this.watcher = null;
-    }
-}
 
 ConfigValidator.prototype._loadFromFile = function(filename) {
     return yaml.safeLoad(fs.readFileSync(filename, 'utf8'));

--- a/lib/components/config-validator.js
+++ b/lib/components/config-validator.js
@@ -47,7 +47,6 @@ ConfigValidator.prototype.validate = function(inputConfig, defaultConfig) {
     return extend(true, defaultConfig, inputConfig);
 }
 
-
 ConfigValidator.prototype._loadFromFile = function(filename) {
     return yaml.safeLoad(fs.readFileSync(filename, 'utf8'));
 };

--- a/lib/components/logging.js
+++ b/lib/components/logging.js
@@ -191,13 +191,13 @@ if (winston) {
 else {
     // We don't have winston, so just log to the console.
     instance = {
-        get: (name) => {
+        Get: (name) => {
             const logWrapper = new LogWrapper();
             // Console has all the functions already.
             logWrapper.setLogger(console);
             return logWrapper;
         },
-        configure: () => {
+        Configure: () => {
             // No-op this.
         },
     };
@@ -205,10 +205,10 @@ else {
 
 module.exports = {
     get: (name) => {
-        return instance.get(name);
+        return instance.Get(name);
     },
     configure: (config) => {
-        instance.configure(config);
+        instance.Configure(config);
         configured = true;
     },
     configured: () => {

--- a/lib/components/logging.js
+++ b/lib/components/logging.js
@@ -205,10 +205,10 @@ else {
 
 module.exports = {
     get: (name) => {
-        return instance.Get(name);
+        return instance.get(name);
     },
     configure: (config) => {
-        instance.Configure(config);
+        instance.configure(config);
         configured = true;
     },
     configured: () => {

--- a/lib/components/logging.js
+++ b/lib/components/logging.js
@@ -99,7 +99,7 @@ class Logging {
         }
         maxFiles: 5
     */
-    Configure(config={}) {
+    configure(config={}) {
         if (!config.fileDatePattern) {
             config.fileDatePattern = "YYYY-MM-DD";
         }
@@ -155,7 +155,7 @@ class Logging {
         });
     }
 
-    Get(name) {
+    get(name) {
         if (!this.loggers.has(name)) {
             const wrapper = new LogWrapper()
             this.loggers.set(name, wrapper);
@@ -191,13 +191,13 @@ if (winston) {
 else {
     // We don't have winston, so just log to the console.
     instance = {
-        Get: (name) => {
+        get: (name) => {
             const logWrapper = new LogWrapper();
             // Console has all the functions already.
             logWrapper.setLogger(console);
             return logWrapper;
         },
-        Configure: () => {
+        configure: () => {
             // No-op this.
         },
     };
@@ -205,10 +205,10 @@ else {
 
 module.exports = {
     get: (name) => {
-        return instance.Get(name);
+        return instance.get(name);
     },
     configure: (config) => {
-        instance.Configure(config);
+        instance.configure(config);
         configured = true;
     },
     configured: () => {

--- a/lib/components/room-link-validator.js
+++ b/lib/components/room-link-validator.js
@@ -2,7 +2,7 @@
  * The room link validator is used to determine if a room can be bridged.
  */
 const ConfigValidator = require("./config-validator");
-
+const log = require("./logging").get("room-link-validator");
 const VALIDATION_CACHE_LIFETIME = 30 * 60 * 1000;
 const PASSED = "RLV_PASSED";
 const ERROR = "RVL_ERROR";

--- a/lib/components/room-link-validator.js
+++ b/lib/components/room-link-validator.js
@@ -10,7 +10,27 @@ const ERROR_USER_CONFLICT = "RVL_USER_CONFLICT";
 const ERROR_CACHED = "RVL_ERROR_CACHED";
 
 const RULE_SCHEMA = {
-
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    type: "object",
+    properties: {
+        userIds: {
+            type: "object",
+            properties: {
+                exempt: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                conflict: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            }
+        }
+    }
 };
 
 class RoomLinkValidator {

--- a/lib/components/room-link-validator.js
+++ b/lib/components/room-link-validator.js
@@ -1,0 +1,68 @@
+/**
+ * The room link validator is used to determine if a room can be bridged
+ * 
+ */
+
+const VALIDATION_CACHE_LIFETIME = 30 * 60 * 1000;
+const STATUS_PASSED = "RLV_PASSED";
+const STATUS_ERROR = "RVL_ERROR";
+const STATUS_ERROR_CACHED = "RVL_ERROR_CACHED";
+
+class RoomLinkValidator {
+    /**
+     * 
+     * @param {object} rules A set of rules for the linked rooms to follow.
+     * @param {string[]} rules.userIds.conflict An array of userid regexes that this bridge will conflict with.
+     * @param {string[]} rules.userIds.exempt An array of userid regexes that will never conflict.
+     * @param {AppServiceBot} asBot The AS bot.
+     * @param {*} onEventCb Callback for onEvent.
+     */
+    constructor (rules, asBot, onEventCb) {
+        this.rules = rules;
+        if (!this.rules.userIds) {
+            this.rules.userIds = {
+
+            };
+        }
+        if (!this.rules.userIds.conflicting) { 
+            this.rules.userIds.conflict = [];
+        }
+        if (!this.rules.userIds.exempt) { 
+            this.rules.userIds.exempt = [];
+        }
+        this.conflictCache = new Map(); // roomId => checktime
+        this.waitingRooms = new Map(); // roomId => Promise;
+    }
+
+    validateRoom (roomId) {
+        let status = this._checkConflictCache(roomId);
+        if (status !== undefined) {
+            return Promise.reject(status);
+        }
+        // Get all users in the room.
+        return this.asBot.getJoinedMembers(roomId).then((res) => {
+            Object.keys(res.joined).forEach((userId) => {
+                this.rules.userIds.conflicting.
+            });
+        });
+    }
+
+    _checkConflictCache(roomId) {
+        if (this.conflictCache.has(roomId)) {
+            if (this.conflictCache.get(roomId) > (Date.now() - VALIDATION_CACHE_LIFETIME)) {
+                return {status: STATUS_ERROR_CACHED, msg: "Room is cached as conflicting"};
+            }
+            this.conflictCache.delete(roomId);
+        }
+    }
+
+    _checkUserIdAgainstRules() {
+
+    }
+}
+module.exports = {
+    STATUS_PASSED,
+    STATUS_ERROR_CACHED,
+    STATUS_ERROR,
+    RoomLinkValidator
+}

--- a/lib/components/room-link-validator.js
+++ b/lib/components/room-link-validator.js
@@ -33,17 +33,21 @@ const RULE_SCHEMA = {
     }
 };
 
+/**
+ * The RoomLinkValidator checks if a room should be linked to a remote
+ * channel, given a set of rules supplied in a config. The ruleset is maintained
+ * in a seperate config from the bridge config. It can be reloaded by triggering
+ * an endpoint specified in the {@link Bridge} class.
+ */
 class RoomLinkValidator {
     /**
      * @param {string} config Config for the validator.
      * @param {string} config.ruleFile Filename for the rule file.
      * @param {string} config.rules Rules if not using a rule file, will be
      *                              overwritten if both is set.
-     * @param {boolean} config.watch If true, watch a rule file for changes.
      * @param {AppServiceBot} asBot The AS bot.
      */
-    constructor (config, asBot, log) {
-        this.log = log;
+    constructor (config, asBot) {
         this.conflictCache = new Map(); // roomId => number
         this.waitingRooms = new Map(); // roomId => Promise
         this.asBot = asBot;
@@ -51,17 +55,6 @@ class RoomLinkValidator {
         if (config.ruleFile) {
             this.config = new ConfigValidator(RULE_SCHEMA);
             this.readRuleFile(config.ruleFile);
-            if (config.watch) {
-                this.log(`Watching for rule changes on ${config.ruleFile}`);
-                this.config.watchForChanges(config.ruleFile, () => {
-                    try {
-                        this.readRuleFile(config.ruleFile);
-                    }
-                    catch (e) {
-                        // Catch these because we don't want to blow up in here.
-                    }
-                });
-            }
         }
         else if (config.rules) {
             this.rules = this.evaulateRules(config.rules);
@@ -71,25 +64,23 @@ class RoomLinkValidator {
         }
     }
 
-    readRuleFile(filename) {
-        try {
-            this.log(`Detected rule config change..`);
-            const rules = this.config.validate(filename);
-            if (rules === undefined) {
-                throw Error("Rule file contents was undefined");
-            }
-            this.log(`Rule file ok, checking rules..`);
-            this.rules = this.evaulateRules(rules);
-            this.log(`Applied new ruleset`);
-            this.conflictCache.clear();
+    readRuleFile (filename) {
+        filename = filename || this.config.ruleFile;
+        if (!filename) {
+            throw new Error("No filename given and config is not using a file");
         }
-        catch (e) {
-            this.log("Failed to apply new rules:", e.message, true);
-            throw e;
+        log.info(`Detected rule config change...`);
+        const rules = this.config.validate(filename);
+        if (rules === undefined) {
+            throw Error("Rule file contents was undefined");
         }
+        log.info(`Rule file ok, checking rules...`);
+        this.rules = this.evaulateRules(rules);
+        log.info(`Applied new ruleset`);
+        this.conflictCache.clear();
     }
 
-    evaulateRules(rules) {
+    evaulateRules (rules) {
         let newRules = {userIds: {}};
         if (!rules || !rules.userIds) {
             rules = {userIds: {}};
@@ -130,7 +121,6 @@ class RoomLinkValidator {
                 }
                 for (rule of this.rules.userIds.conflict) {
                     if (rule.exec(userId) !== null) {
-                        console.log(userId);
                         return false;
                     }
                 }
@@ -145,7 +135,7 @@ class RoomLinkValidator {
         });
     }
 
-    _checkConflictCache(roomId) {
+    _checkConflictCache (roomId) {
         if (this.conflictCache.has(roomId)) {
             if (
                 this.conflictCache.get(roomId) > (Date.now() - VALIDATION_CACHE_LIFETIME)

--- a/lib/components/room-link-validator.js
+++ b/lib/components/room-link-validator.js
@@ -50,12 +50,12 @@ class RoomLinkValidator {
 
         if (config.ruleFile) {
             this.config = new ConfigValidator(RULE_SCHEMA);
-            this.readRuleFile();
+            this.readRuleFile(config.ruleFile);
             if (config.watch) {
-                this.log(`Watching for rule changes on ${ruleFile}`);
+                this.log(`Watching for rule changes on ${config.ruleFile}`);
                 this.config.watchForChanges(config.ruleFile, () => {
                     try {
-                        readRuleFile(config.ruleFile);
+                        this.readRuleFile(config.ruleFile);
                     }
                     catch (e) {
                         // Catch these because we don't want to blow up in here.

--- a/lib/components/room-link-validator.js
+++ b/lib/components/room-link-validator.js
@@ -1,6 +1,5 @@
 /**
- * The room link validator is used to determine if a room can be bridged
- * 
+ * The room link validator is used to determine if a room can be bridged.
  */
 const ConfigValidator = require("./config-validator");
 
@@ -35,12 +34,17 @@ class RoomLinkValidator {
             if (config.watch) {
                 this.log(`Watching for rule changes on ${ruleFile}`);
                 this.config.watchForChanges(config.ruleFile, () => {
-                    readRuleFile(config.ruleFile);
+                    try {
+                        readRuleFile(config.ruleFile);
+                    }
+                    catch (e) {
+                        // Catch these because we don't want to blow up in here.
+                    }
                 });
             }
         }
         else if (config.rules) {
-            this.rules = this.reEvaulateRules(config.rules);
+            this.rules = this.evaulateRules(config.rules);
         }
         else {
             throw new Error("Either config.ruleFile or config.rules must be set");
@@ -51,34 +55,42 @@ class RoomLinkValidator {
         try {
             this.log(`Detected rule config change..`);
             const rules = this.config.validate(filename);
+            if (rules === undefined) {
+                throw Error("Rule file contents was undefined");
+            }
             this.log(`Rule file ok, checking rules..`);
-            this.rules = reEvaulateRules(rules);
+            this.rules = this.evaulateRules(rules);
             this.log(`Applied new ruleset`);
             this.conflictCache.clear();
         }
         catch (e) {
             this.log("Failed to apply new rules:", e.message, true);
+            throw e;
         }
     }
 
-    reEvaulateRules(rules) {
+    evaulateRules(rules) {
         let newRules = {userIds: {}};
         if (!rules || !rules.userIds) {
             rules = {userIds: {}};
         }
-        if (!rules.userIds.conflicting) {
+        if (!rules.userIds.conflict) {
             rules.userIds.conflict = [];
         }
         if (!rules.userIds.exempt) {
             rules.userIds.exempt = [];
         }
-        newRules.userIds.conflict = rules.userIds.conflict.map((regexStr) => new RegExp(regexStr));
-        newRules.userIds.exempt = rules.userIds.exempt.map((regexStr) => new RegExp(regexStr));
+        newRules.userIds.conflict = rules.userIds.conflict.map(
+            (regexStr) => new RegExp(regexStr)
+        );
+        newRules.userIds.exempt = rules.userIds.exempt.map(
+            (regexStr) => new RegExp(regexStr)
+        );
         return newRules;
     }
 
-    validateRoom (roomId) {
-        let status = this._checkConflictCache(roomId);
+    validateRoom (roomId, cache=true) {
+        const status = cache ? this._checkConflictCache(roomId) : undefined;
         if (status !== undefined) {
             return Promise.reject(status);
         }
@@ -86,21 +98,29 @@ class RoomLinkValidator {
         return this.asBot.getJoinedMembers(roomId).then((res) => {
             for (const userId of Object.keys(res.joined)) {
                 let rule;
+                let ignoreUser = false;
                 for (rule of this.rules.userIds.exempt) {
-                    if (rule.exec(userId)) {
-                        return true;
+                    if (rule.exec(userId) !== null) {
+                        ignoreUser = true;
+                        break;
                     }
                 }
-                for (rule of this.rules.userIds.conflicting) {
-                    if (rule.exec(userId)) {
+                if (ignoreUser) {
+                    break;
+                }
+                for (rule of this.rules.userIds.conflict) {
+                    if (rule.exec(userId) !== null) {
+                        console.log(userId);
                         return false;
                     }
                 }
             }
+            return true;
         }).then((isValid) => {
             if (isValid) {
                 return PASSED;
             }
+            this.conflictCache.set(roomId, Date.now());
             throw ERROR_USER_CONFLICT;
         });
     }
@@ -125,4 +145,4 @@ module.exports = {
         ERROR,
     },
     RoomLinkValidator
-}
+};

--- a/lib/components/room-link-validator.js
+++ b/lib/components/room-link-validator.js
@@ -2,36 +2,79 @@
  * The room link validator is used to determine if a room can be bridged
  * 
  */
+const ConfigValidator = require("./config-validator");
 
 const VALIDATION_CACHE_LIFETIME = 30 * 60 * 1000;
-const STATUS_PASSED = "RLV_PASSED";
-const STATUS_ERROR = "RVL_ERROR";
-const STATUS_ERROR_CACHED = "RVL_ERROR_CACHED";
+const PASSED = "RLV_PASSED";
+const ERROR = "RVL_ERROR";
+const ERROR_USER_CONFLICT = "RVL_USER_CONFLICT";
+const ERROR_CACHED = "RVL_ERROR_CACHED";
+
+const RULE_SCHEMA = {
+
+};
 
 class RoomLinkValidator {
     /**
-     * 
-     * @param {object} rules A set of rules for the linked rooms to follow.
-     * @param {string[]} rules.userIds.conflict An array of userid regexes that this bridge will conflict with.
-     * @param {string[]} rules.userIds.exempt An array of userid regexes that will never conflict.
+     * @param {string} config Config for the validator.
+     * @param {string} config.ruleFile Filename for the rule file.
+     * @param {string} config.rules Rules if not using a rule file, will be
+     *                              overwritten if both is set.
+     * @param {boolean} config.watch If true, watch a rule file for changes.
      * @param {AppServiceBot} asBot The AS bot.
-     * @param {*} onEventCb Callback for onEvent.
      */
-    constructor (rules, asBot, onEventCb) {
-        this.rules = rules;
-        if (!this.rules.userIds) {
-            this.rules.userIds = {
+    constructor (config, asBot, log) {
+        this.log = log;
+        this.conflictCache = new Map(); // roomId => number
+        this.waitingRooms = new Map(); // roomId => Promise
+        this.asBot = asBot;
 
-            };
+        if (config.ruleFile) {
+            this.config = new ConfigValidator(RULE_SCHEMA);
+            this.readRuleFile();
+            if (config.watch) {
+                this.log(`Watching for rule changes on ${ruleFile}`);
+                this.config.watchForChanges(config.ruleFile, () => {
+                    readRuleFile(config.ruleFile);
+                });
+            }
         }
-        if (!this.rules.userIds.conflicting) { 
-            this.rules.userIds.conflict = [];
+        else if (config.rules) {
+            this.rules = this.reEvaulateRules(config.rules);
         }
-        if (!this.rules.userIds.exempt) { 
-            this.rules.userIds.exempt = [];
+        else {
+            throw new Error("Either config.ruleFile or config.rules must be set");
         }
-        this.conflictCache = new Map(); // roomId => checktime
-        this.waitingRooms = new Map(); // roomId => Promise;
+    }
+
+    readRuleFile(filename) {
+        try {
+            this.log(`Detected rule config change..`);
+            const rules = this.config.validate(filename);
+            this.log(`Rule file ok, checking rules..`);
+            this.rules = reEvaulateRules(rules);
+            this.log(`Applied new ruleset`);
+            this.conflictCache.clear();
+        }
+        catch (e) {
+            this.log("Failed to apply new rules:", e.message, true);
+        }
+    }
+
+    reEvaulateRules(rules) {
+        let newRules = {userIds: {}};
+        if (!rules || !rules.userIds) {
+            rules = {userIds: {}};
+        }
+        if (!rules.userIds.conflicting) {
+            rules.userIds.conflict = [];
+        }
+        if (!rules.userIds.exempt) {
+            rules.userIds.exempt = [];
+        }
+        newRules.userIds.conflict = rules.userIds.conflict.map((regexStr) => new RegExp(regexStr));
+        newRules.userIds.exempt = rules.userIds.exempt.map((regexStr) => new RegExp(regexStr));
+        return newRules;
     }
 
     validateRoom (roomId) {
@@ -41,28 +84,45 @@ class RoomLinkValidator {
         }
         // Get all users in the room.
         return this.asBot.getJoinedMembers(roomId).then((res) => {
-            Object.keys(res.joined).forEach((userId) => {
-                this.rules.userIds.conflicting.
-            });
+            for (const userId of Object.keys(res.joined)) {
+                let rule;
+                for (rule of this.rules.userIds.exempt) {
+                    if (rule.exec(userId)) {
+                        return true;
+                    }
+                }
+                for (rule of this.rules.userIds.conflicting) {
+                    if (rule.exec(userId)) {
+                        return false;
+                    }
+                }
+            }
+        }).then((isValid) => {
+            if (isValid) {
+                return PASSED;
+            }
+            throw ERROR_USER_CONFLICT;
         });
     }
 
     _checkConflictCache(roomId) {
         if (this.conflictCache.has(roomId)) {
-            if (this.conflictCache.get(roomId) > (Date.now() - VALIDATION_CACHE_LIFETIME)) {
-                return {status: STATUS_ERROR_CACHED, msg: "Room is cached as conflicting"};
+            if (
+                this.conflictCache.get(roomId) > (Date.now() - VALIDATION_CACHE_LIFETIME)
+            ) {
+                return ERROR_CACHED;
             }
             this.conflictCache.delete(roomId);
         }
     }
-
-    _checkUserIdAgainstRules() {
-
-    }
 }
+
 module.exports = {
-    STATUS_PASSED,
-    STATUS_ERROR_CACHED,
-    STATUS_ERROR,
+    validationStatuses: {
+        PASSED,
+        ERROR_USER_CONFLICT,
+        ERROR_CACHED,
+        ERROR,
+    },
     RoomLinkValidator
 }

--- a/lib/components/room-link-validator.js
+++ b/lib/components/room-link-validator.js
@@ -115,8 +115,8 @@ class RoomLinkValidator {
             return Promise.reject(status);
         }
         // Get all users in the room.
-        return this.asBot.getJoinedMembers(roomId).then((res) => {
-            for (const userId of Object.keys(res.joined)) {
+        return this.asBot.getJoinedMembers(roomId).then((joined) => {
+            for (const userId of Object.keys(joined)) {
                 let rule;
                 let ignoreUser = false;
                 for (rule of this.rules.userIds.exempt) {

--- a/spec/unit/room-link-validator.spec.js
+++ b/spec/unit/room-link-validator.spec.js
@@ -1,0 +1,157 @@
+const RVL = require("../../lib/components/room-link-validator")
+const RoomLinkValidator = RVL.RoomLinkValidator;
+const Statuses = RVL.validationStatuses;
+
+const AsBotMock = {
+    cachedCalled: false,
+    getJoinedMembers: (roomId) => {
+        switch (roomId) {
+            case "!empty:localhost":
+                return Promise.resolve({
+                    joined: {}
+                });
+            case "!noconflict:localhost":
+                return Promise.resolve({
+                    joined: {
+                        "@test2-u1:localhost": true,
+                        "@test2-u2:localhost": true,
+                        "@test2-u3:localhost": true,
+                        "@test2-u4:localhost": true,
+                    }
+                });
+            case "!conflictexempt:localhost":
+                return Promise.resolve({
+                    joined: {
+                        "@test3-u1:localhost": true,
+                        "@test3-u11:localhost": true,
+                        "@test3-u111:localhost": true,
+                        "@test3-u1111:localhost": true,
+                    }
+                });
+            case "!conflicts:localhost":
+                return Promise.resolve({
+                    joined: {
+                        "@test4-u1:localhost": true,
+                        "@test4-u2:localhost": true,
+                        "@test4-u3:localhost": true,
+                        "@test4-u4:localhost": true,
+                    }
+                });
+            case "!cached:localhost":
+                if (AsBotMock.cachedCalled) {
+                    return Promise.resolve({
+                        joined: {}
+                    });
+                }
+                AsBotMock.cachedCalled = true;
+                return Promise.resolve({
+                    joined: {
+                        "@test5-u1:localhost": true,
+                        "@test5-u2:localhost": true,
+                        "@test5-u3:localhost": true,
+                        "@test5-u4:localhost": true,
+                    }
+                });
+            default:
+                throw Error("unexpected roomid for test");
+        }
+    }
+};
+
+describe("RoomLinkValidator", function() {
+    describe("constructor", function() {
+        it("should construct with ruleset", () => {
+            const validator = new RoomLinkValidator({
+                rules: { }
+            }, AsBotMock, () => {});
+            expect(validator.rules).toEqual({userIds:{
+                conflict: [],
+                exempt: [],
+            }});
+        });
+        /* eslint-disable no-new */
+        it("should throw if not given any args", () => {
+            expect(() => {
+                new RoomLinkValidator({
+                }, AsBotMock, () => {});
+            }).toThrowError("Either config.ruleFile or config.rules must be set");
+        });
+        /* eslint-enable no-new */
+    });
+    describe("reEvaulateRules", function() {
+        it("should construct some regexes", () => {
+            const validator = new RoomLinkValidator({
+                rules: {
+                    userIds: {
+                        conflict: [
+                            "@bad-bridge:localhost",
+                            "@bad-.+:localhost"
+                        ],
+                        exempt: [
+                            "@good-bridge:localhost",
+                            "@good-.+:localhost"
+                        ]
+                    }
+                }
+            }, AsBotMock, () => {});
+            expect(validator.rules).toEqual({userIds:{
+                conflict: [
+                    /@bad-bridge:localhost/,
+                    /@bad-.+:localhost/
+                ],
+                exempt: [
+                    /@good-bridge:localhost/,
+                    /@good-.+:localhost/
+                ],
+            }});
+        });
+    });
+    describe("validateRoom", function() {
+        let validator;
+        beforeEach(() => {
+            validator = new RoomLinkValidator({
+                rules: {
+                    userIds: {
+                        conflict: [
+                            "@test3-.*",
+                            "@test4-.*",
+                            "@test5-.*"
+                        ],
+                        exempt: [
+                            "@test3-u1.*"
+                        ]
+                    }
+                }
+            }, AsBotMock, () => {});
+            AsBotMock.cachedCalled = false;
+        });
+        it("should pass an empty room", function() {
+            return validator.validateRoom("!empty:localhost").then((status) => {
+                expect(status).toBe(Statuses.PASSED);
+            })
+        });
+        it("should pass a room that doesn't conflict", function() {
+            return validator.validateRoom("!noconflict:localhost").then((status) => {
+                expect(status).toBe(Statuses.PASSED);
+            })
+        });
+        it("should pass a room that conflicts but has exemptions", function() {
+            return validator.validateRoom("!conflictexempt:localhost").then((status) => {
+                expect(status).toBe(Statuses.PASSED);
+            })
+        });
+        it("should reject a room that conflicts", function() {
+            return validator.validateRoom("!conflicts:localhost").catch((status) => {
+                expect(status).toBe(Statuses.ERROR_USER_CONFLICT);
+            })
+        });
+        it("should continue to reject a room when it's cached", function() {
+            return validator.validateRoom("!cached:localhost").catch((status) => {
+                expect(status).toBe(Statuses.ERROR_USER_CONFLICT);
+                return validator.validateRoom("!cached:localhost");
+            }).catch((status) => {
+                expect(status).toBe(Statuses.ERROR_CACHED);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This change adds a new class, the RoomLinkValidator. This is a rather bruteforced method of avoiding double bridged rooms by creating a rule file and setting rules about what can and can't be bridged by checking what userIds are present in the room.

~~The rule file can optionally be watched for changes, and valid changes will be applied on the fly.~~

The rule file can be reloaded by hitting the ``/_bridge/roomLinkValidator/reload`` endpoint.