### PR TITLE
Support room upgrades

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,7 +53,7 @@
     "valid-typeof": 2,
 
     "array-bracket-spacing": [1, "never"],
-    "max-len": [1, 90],
+    "max-len": [1, 120],
     "brace-style": [1, "stroustrup", { "allowSingleLine": true }],
     "comma-spacing": [1, {"before": false, "after": true}],
     "comma-style": [1, "last"],

--- a/README.md
+++ b/README.md
@@ -161,6 +161,19 @@ If you set `opts.roomLinkValidation.triggerEndpoint` to `true`, then you may use
 optionally takes the `filename` parameter if you want to reload the config from
 another location.
 
+
+## `RoomUpgradeHandler`
+This component automatically handles [Room Upgrades](https://matrix.org/docs/spec/client_server/unstable.html#post-matrix-client-r0-rooms-roomid-upgrade)
+by changing all associated room entries to use the new room id as well as leaving
+and joining ghosts. It can also be hooked into so you can manually adjust entries,
+or do an action once the upgrade is over.
+
+This component is disabled by default but can enabled by simply defining `roomUpgradeOpts`
+in the options given to the bridge (simply `{}` (empty object)). By default, users
+will be copied on upgrade. Upgrade events will also be consumed by the bridge, and
+will not be emitted by `onEvent`. For more information, see the docs.
+
+
 ## Data Models
  * `MatrixRoom` - A representation of a matrix room.
  * `RemoteRoom` - A representation of a third-party room.

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -741,7 +741,7 @@ Bridge.prototype._onEvent = function(event) {
             this.opts.registration.isUserMatch(event.user_id, true)) {
         return Promise.resolve();
     }
-
+    // m.room.tombstone is the event that signals a room upgrade.
     if (event.type === "m.room.tombstone" && this._roomUpgradeHandler) {
         this._roomUpgradeHandler.onTombstone(ev);
         if (this.opts.RoomUpgradeHandler.consumeEvent) {
@@ -751,7 +751,10 @@ Bridge.prototype._onEvent = function(event) {
     else if (event.type === "m.room.member" &&
                event.state_key === this._appServiceBot.getUserId() &&
                event.content.membership === "invite") {
-        if (this._roomUpgradeHandler.onInvite(event) &&
+        // A invite-only room that has been upgraded won't have been joinable,
+        // so we are listening for any invites to the new room.
+        const isUpgradeInvite = this._roomUpgradeHandler.onInvite(event);
+        if (isUpgradeInvite &&
             this.opts.RoomUpgradeHandler.consumeEvent) {
             return Promise.resolve();
         }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -743,7 +743,7 @@ Bridge.prototype._onEvent = function(event) {
     }
 
     if (event.type === "m.room.tombstone" && this._roomUpgradeHandler) {
-        return this._roomUpgradeHandler.onTombstone(ev);
+        this._roomUpgradeHandler.onTombstone(ev);
         if (this.opts.RoomUpgradeHandler.consumeEvent) {
             return Promise.resolve();
         }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -184,8 +184,12 @@ function Bridge(opts) {
     this._prevRequestPromise = Promise.resolve();
     this._metrics = null; // an optional PrometheusMetrics instance
     this._roomLinkValidator = null;
-    this._roomUpgradeHandler = opts.roomUpgradeOpts ?
-        new RoomUpgradeHandler(opts.roomUpgradeOpts, this) : null;
+    if (opts.roomUpgradeOpts) {
+        this.opts.roomUpgradeOpts.consumeEvent = opts.roomUpgradeOpts.consumeEvent !== false ? true : false;
+        this._roomUpgradeHandler = new RoomUpgradeHandler(opts.roomUpgradeOpts, this);
+    } else {
+        this._roomUpgradeHandler = null;
+    }
 }
 
 /**

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -20,6 +20,7 @@ const util = require("util");
 const MembershipCache = require("./components/membership-cache");
 const RoomLinkValidator = require("./components/room-link-validator").RoomLinkValidator;
 const RLVStatus = require("./components/room-link-validator").validationStatuses;
+const RoomUpgradeHandler = require("./components/room-upgrade-handler");
 
 const log = require("./components/logging").get("bridge");
 
@@ -55,6 +56,9 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * @param {Bridge~thirdPartyLookup=} opts.controller.thirdPartyLookup Object. If
  * supplied, the bridge will respond to third-party entity lookups using the
  * contained helper functions.
+ * @param {Bridge~onRoomUpgrade=} opts.controller.onRoomUpgrade Function. If
+ * supplied, the bridge will invoke this function when it sees an upgrade event
+ * for a room.
  * @param {(RoomBridgeStore|string)=} opts.roomStore The room store instance to
  * use, or the path to the room .db file to load. A database will be created if
  * this is not specified.
@@ -105,6 +109,8 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * @param {boolean=} opts.roomLinkValidation.triggerEndpoint Enable the endpoint
  * to trigger a reload of the rules file.
  * Default: false
+ * @param {RoomUpgradeHandler~Options} opts.roomUpgradeOpts Options to supply to
+ * the room upgrade  handler. If not defined then no upgrades are performed.
  */
 function Bridge(opts) {
     if (typeof opts !== "object") {
@@ -178,6 +184,8 @@ function Bridge(opts) {
     this._prevRequestPromise = Promise.resolve();
     this._metrics = null; // an optional PrometheusMetrics instance
     this._roomLinkValidator = null;
+    this._roomUpgradeHandler = opts.roomUpgradeOpts ?
+        new RoomUpgradeHandler(opts.roomUpgradeOpts, this) : null;
 }
 
 /**
@@ -325,7 +333,8 @@ Bridge.prototype._customiseAppservice = function() {
                     // one otherwised.
                     this._roomLinkValidator.readRuleFile(req.query.filename);
                     res.status(200).send("Success");
-                } catch (e) {
+                }
+                catch (e) {
                     res.status(500).send("Failed: " + e);
                 }
             },
@@ -733,7 +742,21 @@ Bridge.prototype._onEvent = function(event) {
         return Promise.resolve();
     }
 
-    var self = this;
+    if (event.type === "m.room.tombstone" && this._roomUpgradeHandler) {
+        return this._roomUpgradeHandler.onTombstone(ev);
+        if (this.opts.RoomUpgradeHandler.consumeEvent) {
+            return Promise.resolve();
+        }
+    }
+    else if (event.type === "m.room.member" &&
+               event.state_key === this._appServiceBot.getUserId() &&
+               event.content.membership === "invite") {
+        if (this._roomUpgradeHandler.onInvite(event) &&
+            this.opts.RoomUpgradeHandler.consumeEvent) {
+            return Promise.resolve();
+        }
+   }
+
     var request = this._requestFactory.newRequest({ data: event });
     var context = new BridgeContext({
         sender: event.user_id,
@@ -755,10 +778,10 @@ Bridge.prototype._onEvent = function(event) {
     }
 
     if (this.opts.queue.type === "none") { // consume as soon as we have context
-        promise.done(function() {
-            self._onConsume(null, data);
-        }, function(err) {
-            self._onConsume(err);
+        promise.done(() => {
+            this._onConsume(null, data);
+        }, (err) => {
+            this._onConsume(err);
         });
         return request.getPromise();
     }
@@ -1127,6 +1150,15 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
   * @callback Bridge~onAliasQueried
   * @param {string} alias The alias queried.
   * @param {string} roomId The parsed localpart of the alias.
+  */
+
+
+ /**
+  * @callback Bridge~onRoomUpgrade
+  * @param {string} oldRoomId The roomId of the old room.
+  * @param {string} newRoomId The roomId of the new room.
+  * @param {string} newVersion The new room version.
+  * @param {Bridge~BridgeContext} context Context for the upgrade event.
   */
 
  /**

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -187,7 +187,8 @@ function Bridge(opts) {
     if (opts.roomUpgradeOpts) {
         this.opts.roomUpgradeOpts.consumeEvent = opts.roomUpgradeOpts.consumeEvent !== false ? true : false;
         this._roomUpgradeHandler = new RoomUpgradeHandler(opts.roomUpgradeOpts, this);
-    } else {
+    }
+    else {
         this._roomUpgradeHandler = null;
     }
 }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -110,7 +110,7 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * to trigger a reload of the rules file.
  * Default: false
  * @param {RoomUpgradeHandler~Options} opts.roomUpgradeOpts Options to supply to
- * the room upgrade  handler. If not defined then no upgrades are performed.
+ * the room upgrade handler. If not defined then upgrades are NOT handled by the bridge.
  */
 function Bridge(opts) {
     if (typeof opts !== "object") {

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -445,10 +445,12 @@ Intent.prototype.unban = function(roomId, target) {
  * This will automatically send an invite from the bot if it is an invite-only
  * room, which may make the bot attempt to join the room if it isn't already.
  * @param {string} roomId The room to join.
+ * @param {string[]} viaServers The server names to try and join through in
+ * addition to those that are automatically chosen.
  * @return {Promise}
  */
-Intent.prototype.join = function(roomId) {
-    return this._ensureJoined(roomId);
+Intent.prototype.join = function(roomId, viaServers) {
+    return this._ensureJoined(roomId, false, viaServers);
 };
 
 /**
@@ -466,7 +468,7 @@ Intent.prototype.leave = function(roomId) {
  * @param {string} userId The ID of the user whose profile to return
  * @param {string} info The profile field name to retrieve (e.g. 'displayname'
  * or 'avatar_url'), or null to fetch the entire profile information.
- * @param {boolean} [uuserIdseCache=true] Should the request attempt to lookup
+ * @param {boolean} [useCache=true] Should the request attempt to lookup
  * state from the cache.
  * @return {Promise} A Promise that resolves with the requested user's profile
  * information
@@ -603,9 +605,17 @@ Intent.prototype._joinGuard = function(roomId, promiseFn) {
     };
 };
 
-Intent.prototype._ensureJoined = function(roomId, ignoreCache, passthroughError = false) {
+Intent.prototype._ensureJoined = function(
+    roomId, ignoreCache = false, viaServers = undefined, passthroughError = false
+) {
     var self = this;
     var userId = self.client.credentials.userId;
+    const opts = {
+        syncRoom: false,
+    };
+    if (viaServers) {
+        opts.viaServers = viaServers;
+    }
     if (this.opts.backingStore.getMembership(roomId, userId) === "join" && !ignoreCache) {
         return Promise.resolve();
     }
@@ -644,7 +654,7 @@ Intent.prototype._ensureJoined = function(roomId, ignoreCache, passthroughError 
             return;
         }
 
-        self.client.joinRoom(roomId, { syncRoom: false }).then(function() {
+        self.client.joinRoom(roomId, opts).then(function() {
             mark(roomId, "join");
         }, function(e) {
             if (e.errcode !== "M_FORBIDDEN" || self.botClient === self) {
@@ -654,15 +664,16 @@ Intent.prototype._ensureJoined = function(roomId, ignoreCache, passthroughError 
 
             // Try bot inviting client
             self.botClient.invite(roomId, userId).then(function() {
-                return self.client.joinRoom(roomId, { syncRoom: false });
+                return self.client.joinRoom(roomId, opts);
             }).done(function() {
                 mark(roomId, "join");
             }, function(invErr) {
                 // Try bot joining
-                self.botClient.joinRoom(roomId, { syncRoom: false }).then(function() {
+                self.botClient.joinRoom(roomId, opts)
+                .then(function() {
                     return self.botClient.invite(roomId, userId);
                 }).then(function() {
-                    return self.client.joinRoom(roomId, { syncRoom: false });
+                    return self.client.joinRoom(roomId, opts);
                 }).done(function() {
                     mark(roomId, "join");
                 }, function(finalErr) {

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -51,9 +51,9 @@ const DEFAULT_CACHE_SIZE = 1024;
  * @param {boolean} opts.dontJoin True to not attempt to join a room before
  * sending messages into it. The surrounding code will have to ensure the correct
  * membership state itself in this case. Default: false.
- * 
+ *
  * @param {boolean} [opts.enablePresence=true] True to send presence, false to no-op.
- * 
+ *
  * @param {Number} opts.caching.ttl How long requests can stay in the cache, in milliseconds.
  * @param {Number} opts.caching.size How many entries should be kept in the cache, before the oldest is dropped.
  */
@@ -466,7 +466,7 @@ Intent.prototype.leave = function(roomId) {
  * @param {string} userId The ID of the user whose profile to return
  * @param {string} info The profile field name to retrieve (e.g. 'displayname'
  * or 'avatar_url'), or null to fetch the entire profile information.
- * @param {boolean} [useCache=true] Should the request attempt to lookup
+ * @param {boolean} [uuserIdseCache=true] Should the request attempt to lookup
  * state from the cache.
  * @return {Promise} A Promise that resolves with the requested user's profile
  * information
@@ -521,7 +521,7 @@ Intent.prototype.createAlias = function(alias, roomId) {
  * Set the presence of this user.
  * @param {string} presence One of "online", "offline" or "unavailable".
  * @param {string} status_msg The status message to attach.
- * @return {Promise} Resolves if the presence was set or no-oped, rejects otherwise. 
+ * @return {Promise} Resolves if the presence was set or no-oped, rejects otherwise.
  */
 Intent.prototype.setPresence = function(presence, status_msg=undefined) {
     if (!this.opts.enablePresence) {
@@ -535,10 +535,12 @@ Intent.prototype.setPresence = function(presence, status_msg=undefined) {
 
 /**
  * Get an event in a room.
+ * This will automatically make the client join the room so they can get the
+ * event if they are not already joined.
  * @param {string} roomId The room to fetch the event from.
  * @param {string} eventId The eventId of the event to fetch.
  * @param {boolean} [useCache=true] Should the request attempt to lookup from the cache.
- * @return {Promise} Resolves with the content of the event, or rejects if not found. 
+ * @return {Promise} Resolves with the content of the event, or rejects if not found.
  */
 Intent.prototype.getEvent = function(roomId, eventId, useCache=true) {
     return this._ensureRegistered().then(() => {
@@ -546,6 +548,21 @@ Intent.prototype.getEvent = function(roomId, eventId, useCache=true) {
             return this._requestCaches.event.get(`${roomId}:${eventId}`, roomId, eventId);
         }
         return this.client.fetchRoomEvent(roomId, eventId);
+    });
+};
+
+/**
+ * Get a state event in a room.
+ * This will automatically make the client join the room so they can get the
+ * state if they are not already joined.
+ * @param {string} roomId The room to get the state from.
+ * @param {string} eventType The event type to fetch.
+ * @param {string} [stateKey=""] The state key of the event to fetch.
+ * @return {Promise}
+ */
+Intent.prototype.getStateEvent = function(roomId, eventType, stateKey = "") {
+    return this._ensureJoined(roomId).then(() => {
+        return this.client.getStateEvent(roomId, eventType, stateKey);
     });
 };
 
@@ -586,7 +603,7 @@ Intent.prototype._joinGuard = function(roomId, promiseFn) {
     };
 };
 
-Intent.prototype._ensureJoined = function(roomId, ignoreCache) {
+Intent.prototype._ensureJoined = function(roomId, ignoreCache, passthroughError = false) {
     var self = this;
     var userId = self.client.credentials.userId;
     if (this.opts.backingStore.getMembership(roomId, userId) === "join" && !ignoreCache) {
@@ -630,10 +647,11 @@ Intent.prototype._ensureJoined = function(roomId, ignoreCache) {
         self.client.joinRoom(roomId, { syncRoom: false }).then(function() {
             mark(roomId, "join");
         }, function(e) {
-            if (e.errcode !== "M_FORBIDDEN") {
-                d.reject(new Error("Failed to join room"));
+            if (e.errcode !== "M_FORBIDDEN" || self.botClient === self) {
+                d.reject(passthroughError ? e : new Error("Failed to join room"));
                 return;
             }
+
             // Try bot inviting client
             self.botClient.invite(roomId, userId).then(function() {
                 return self.client.joinRoom(roomId, { syncRoom: false });
@@ -648,7 +666,7 @@ Intent.prototype._ensureJoined = function(roomId, ignoreCache) {
                 }).done(function() {
                     mark(roomId, "join");
                 }, function(finalErr) {
-                    d.reject(new Error("Failed to join room"));
+                    d.reject(passthroughError ? e : new Error("Failed to join room"));
                     return;
                 });
             });

--- a/lib/components/room-upgrade-handler.js
+++ b/lib/components/room-upgrade-handler.js
@@ -1,5 +1,6 @@
 const log = require("./logging").get("RoomUpgradeHandler");
 const MatrixRoom = require("../models/rooms/matrix");
+const MatrixUser = require("../models/users/matrix");
 
 /**
  * Handles migration of rooms when a room upgrade is performed.
@@ -18,42 +19,30 @@ class RoomUpgradeHandler {
     onTombstone(ev) {
         const movingTo = ev.content.replacement_room;
         log.info(`Got tombstone event for ${ev.room_id} -> ${movingTo}`);
+        const joinVia = new MatrixUser(ev.sender).domain;
         // Try to join the new room.
-        return this._joinNewRoom(movingTo, movingTo).then(() => {
-            return this._onJoinedNewRoom(ev.room_id, movingTo);
+        return this._joinNewRoom(movingTo, [joinVia]).then((couldJoin) => {
+            if (couldJoin) {
+                return this._onJoinedNewRoom(ev.room_id, movingTo);
+            }
+            this._waitingForInvite.set(movingTo, ev.room_id);
+            return true;
         }).catch((err) => {
             log.error("Couldn't handle room upgrade: ", err);
-            // We can wait for an invite and try again.
-            this._waitingForInvite.set(movingTo, ev.room_id);
+            return false;
         });
-
     }
 
-    _joinNewRoom(newRoomId, roomIdOrAlias) {
+    _joinNewRoom(newRoomId, joinVia=[]) {
         const intent = this._bridge.getIntent();
-        return intent.join(roomIdOrAlias, true, true).catch((ex) => {
-            if (newRoomId !== roomIdOrAlias ||
-                !(ex.errcode == "M_UNKNONW" && ex.error === "No known servers")) {
-                // We need to wait to be invited
-                throw Error("Need to wait for invite");
+        return intent.join(newRoomId, [joinVia]).then(() => {
+            return true;
+        }).catch((ex) => {
+            if (ex.errcode === "M_FORBIDDEN") {
+                return false;
             }
-            // RoomId is not routable, so try to get the alias and join that.
-            return intent.roomState(newRoomId).then((state) => {
-                const canonicalAlias = state.find(
-                    (e) => e.type === "m.room.canonical_alias");
-                if (canonicalAlias) {
-                    log.debug(`Joining canonical alias ${canonicalAlias.content.alias}`);
-                    return this._joinNewRoom(newRoomId, canonicalAlias.content.alias);
-                }
-                const aliases = state.filter((e) => e.type === "m.room.alias");
-                if (aliases.length > 0) {
-                    // Take the first one.
-                    const alias = aliases[0].content.alias;
-                    log.debug(`Joining first alias ${alias}`);
-                    return this._joinNewRoom(newRoomId, alias);
-                }
-            });
-        });
+            throw Error("Failed to handle upgrade");
+        })
     }
 
     onInvite(ev) {
@@ -63,7 +52,7 @@ class RoomUpgradeHandler {
         const oldRoomId = this._waitingForInvite.get(ev.room_id);
         this._waitingForInvite.delete(ev.room_id);
         log.debug(`Got invite to upgraded room ${ev.room_id}`);
-        this._joinNewRoom(ev.room_id, ev.room_id).then(() => {
+        this._joinNewRoom(ev.room_id).then(() => {
             return this._onJoinedNewRoom(oldRoomId, ev.room_id);
         }).catch((err) => {
             log.error("Couldn't handle room upgrade: ", err);
@@ -123,13 +112,15 @@ module.exports = RoomUpgradeHandler;
   */
 
  /**
-  * Returned by getUser and parseUser third-party user lookups
+  * Options to supply to the {@link RoomUpgradeHandler}.
   * @typedef RoomUpgradeHandler~Options
   * @type {Object}
   * @property {RoomUpgradeHandler~Options~MigrateEntry} migrateEntry Called when
   * the handler wishes to migrate a MatrixRoom entry to a new room_id. If omitted,
   * {@link RoomUpgradeHandler~_migrateEntry} will be used instead.
-  * @property {RoomUpgradeHandler~Options~onRoomMigrated} onRoomMigrated
+  * @property {RoomUpgradeHandler~Options~onRoomMigrated} onRoomMigrated This is called
+  * when the entries of the room have been migrated, the bridge should do any cleanup it
+  * needs of the old room and setup the new room (ex: Joining ghosts to the new room).
   * @property {bool} [consumeEvent=true] Consume tombstone or invite events that
   * are acted on by this handler.
   */

--- a/lib/components/room-upgrade-handler.js
+++ b/lib/components/room-upgrade-handler.js
@@ -1,0 +1,155 @@
+const log = require("./logging").get("RoomUpgradeHandler");
+const MatrixRoom = require("../models/rooms/matrix");
+
+/**
+ * Get a m.room.tombstone.
+ Join that room?
+   Failed to join room -> retry in 30s
+   Failed to join?
+    - Retry again?
+    - Drop room?
+   Invite only?
+    - Leave room in a tempoary state until invited.
+ */
+
+/**
+ * Handles migration of rooms when a room upgrade is performed.
+ */
+class RoomUpgradeHandler {
+    /**
+     * @param {RoomUpgradeHandler~Options} opts
+     * @param {Bridge} bridge The parent bridge.
+     */
+    constructor(opts, bridge) {
+        this.roomsPendingUpgrade();
+        this.opts = opts;
+        this.bridge = bridge;
+        this.waitingForInvite = new Map(); //newRoomId: oldRoomId
+    }
+
+    onTombstone(ev) {
+        const movingTo = ev.content.replacement_room;
+        log.info(`Got tombstone event for ${ev.room_id} -> ${movingTo}`);
+        // Try to join the new room.
+        this._joinNewRoom(movingTo, movingTo).then((res) => {
+            return this._onJoinedNewRoom(event.room_id, movingTo);
+        }).catch((err) => {
+            log.error("Couldn't handle room upgrade: ", err);
+            // We can wait for an invite and try again.
+            this.waitingForInvite.set(movingTo, event.room_id);
+        });
+
+    }
+
+    _joinNewRoom(newRoomId, roomIdOrAlias) {
+        const intent = this.bridge.getIntent();
+        intent.join(roomIdOrAlias, true, true).then((res) => {
+            return;
+        }).catch((ex) => {
+            if (newRoomId !== roomIdOrAlias ||
+                !(ex.errcode == "M_UNKNONW" && ex.error === "No known servers")) {
+                // We need to wait to be invited
+                throw Error("Need to wait for invite");
+            }
+            // RoomId is not routable, so try to get the alias and join that.
+            return intent.roomState(newRoomId).then((state) => {
+                const canonicalAlias = state.find(
+                    (e) => e.type === "m.room.canonical_alias");
+                if (canonicalAlias) {
+                    log.debug(`Joining canonical alias ${canonicalAlias.content.alias}`);
+                    return this._joinNewRoom(newRoomId, canonicalAlias.content.alias);
+                }
+                const aliases = state.filter((e) => e.type === "m.room.alias");
+                if (aliases.length > 0) {
+                    // Take the first one.
+                    const alias = aliases[0].content.alias;
+                    log.debug(`Joining first alias ${alias}`);
+                    return this._joinNewRoom(newRoomId, alias);
+                }
+            });
+        });
+    }
+
+    onInvite(ev) {
+        if (!this.waitingForInvite.has(ev.room_id)) {
+            return false;
+        }
+        const oldRoomId = this.waitingForInvite.get(ev.room_id);
+        this.waitingForInvite.delete(ev.room_id);
+        log.debug(`Got invite to upgraded room ${ev.room_id}`);
+        this._joinNewRoom(ev.room_id, ev.room_id).then(() => {
+            return this._onJoinedNewRoom(oldRoomId, ev.room_id);
+        }).catch((err) => {
+            log.error("Couldn't handle room upgrade: ", err);
+        });
+        return true;
+    }
+
+    _onJoinedNewRoom(oldRoomId, newRoomId) {
+        log.debug(`Joined ${newRoomId}`);
+        const intent = this.bridge.getIntent();
+        return this.getRoomStore().getEntriesByMatrixId((entries) => {
+            return entries.map((entry) => {
+                const newEntry = (
+                    this.opts.migrateEntry || this._migrateEntry)(entry, newRoomId);
+                if (!newEntry) {
+                    return Promise.resolve();
+                }
+                return this.getRoomStore().upsertEntry(newEntry);
+            });
+        }).then(() => {
+            log.debug(`Migrated entries from ${oldRoomId} to ${newRoomId} successfully.`);
+            if (this.opts.onRoomMigrated) {
+                this.opts.onRoomMigrated(oldRoomId, newRoomId);
+            }
+            return intent.leave(oldRoomId);
+        });
+    }
+
+    /**
+     * [migrateEntry description]
+     * @param  {[type]} entry     [description]
+     * @param  {[type]} newRoomId [description]
+     * @return {[type]}           [description]
+     */
+    _migrateEntry(entry, newRoomId) {
+        entry.matrix = new MatrixRoom(newRoomId, {
+            name: entry.name,
+            topic: entry.topic,
+            extras: entry._extras,
+        });
+        return entry;
+    }
+}
+
+module.exports = RoomUpgradeHandler;
+
+
+/**
+ * Invoked when iterating around a rooms entries. Should be used to update entries
+ * with a new room id.
+ * @callback RoomUpgradeHandler~Options~MigrateEntry
+ * @param {RoomBridgeStore~Entry} entry The existing entry.
+ * @param {string} newRoomId The new roomId.
+ * @return {RoomBridgeStore~Entry|null} Return the entry to upsert it,
+ * or null to ignore it.
+ */
+
+ /**
+  * Invoked after a room has been upgraded and it's entries updated.
+  * @callback RoomUpgradeHandler~Options~onRoomMigrated
+  * @param {string} oldRoomId The old roomId.
+  * @param {string} newRoomId The new roomId.
+  */
+
+ /**
+  * Returned by getUser and parseUser third-party user lookups
+  * @typedef RoomUpgradeHandler~Options
+  * @type {Object}
+  * @property {RoomUpgradeHandler~Options~MigrateEntry} migrateEntry Called when
+  * the handler wishes to migrate a MatrixRoom entry to a new room_id. If omitted,
+  * {@link RoomUpgradeHandler~_migrateEntry} will be used instead.
+  * @property {RoomUpgradeHandler~Options~onRoomMigrated} onRoomMigrated
+  * @property {bool} [consumeEvent=true] Consume tombstone or invite events that
+  * are acted on by this handler.
+  */

--- a/lib/components/room-upgrade-handler.js
+++ b/lib/components/room-upgrade-handler.js
@@ -66,6 +66,7 @@ class RoomUpgradeHandler {
     _onJoinedNewRoom(oldRoomId, newRoomId) {
         log.debug(`Joined ${newRoomId}`);
         const intent = this._bridge.getIntent();
+        const asBot = this.bridge.getBot();
         return this.getRoomStore().getEntriesByMatrixId((entries) => {
             return entries.map((entry) => {
                 const newEntry = (
@@ -83,20 +84,21 @@ class RoomUpgradeHandler {
                 this._opts.onRoomMigrated(oldRoomId, newRoomId);
             }
 
-            if (this.opts.migrateGhosts === false) {
+            if (!this.opts.migrateGhosts) {
                 return;
             }
-            const asBot = this.bridge.getBot();
             return asBot.getJoinedMembers(oldRoomId);
         }).then((members) => {
-            const userIds = Object.keys(members);
+            const userIds = Object.keys(members).filter((u) => asBot.isRemoteUser(u));
             log.debug(`Migrating ${userIds.length} ghosts`);
             return Promise.all(userIds.map((uId) => {
                 Promise.all([
                     this.bridge.getIntent(userId).leave(oldRoomId),
                     this.bridge.getIntent(userId).join(newRoomId)
                 ])
-            }));
+            }).concat([
+                intent.leave(oldRoomId)
+            ]));
         }).catch((ex) => {
             log.warn("Failed to migrate room ghosts:", ex);
         }).then(() => {

--- a/lib/components/room-upgrade-handler.js
+++ b/lib/components/room-upgrade-handler.js
@@ -11,6 +11,9 @@ class RoomUpgradeHandler {
      * @param {Bridge} bridge The parent bridge.
      */
     constructor(opts, bridge) {
+        if (opts.migrateGhosts !== false) {
+            opts.migrateGhosts = opts.migrateGhosts !== false;
+        }
         this._opts = opts;
         this._bridge = bridge;
         this._waitingForInvite = new Map(); //newRoomId: oldRoomId
@@ -72,13 +75,33 @@ class RoomUpgradeHandler {
                 }
                 return this.getRoomStore().upsertEntry(newEntry);
             });
+        }).catch((ex) => {
+            log.warn("Failed to migrate room entries:", ex);
         }).then(() => {
             log.debug(`Migrated entries from ${oldRoomId} to ${newRoomId} successfully.`);
             if (this._opts.onRoomMigrated) {
                 this._opts.onRoomMigrated(oldRoomId, newRoomId);
             }
-            return intent.leave(oldRoomId);
-        });
+
+            if (this.opts.migrateGhosts === false) {
+                return;
+            }
+            const asBot = this.bridge.getBot();
+            return asBot.getJoinedMembers(oldRoomId);
+        }).then((members) => {
+            const userIds = Object.keys(members);
+            log.debug(`Migrating ${userIds.length} ghosts`);
+            return Promise.all(userIds.map((uId) => {
+                Promise.all([
+                    this.bridge.getIntent(userId).leave(oldRoomId),
+                    this.bridge.getIntent(userId).join(newRoomId)
+                ])
+            }));
+        }).catch((ex) => {
+            log.warn("Failed to migrate room ghosts:", ex);
+        }).then(() => {
+            log.debug("Migrated all ghosts across");
+        })
     }
 
     _migrateEntry(entry, newRoomId) {
@@ -123,4 +146,6 @@ module.exports = RoomUpgradeHandler;
   * needs of the old room and setup the new room (ex: Joining ghosts to the new room).
   * @property {bool} [consumeEvent=true] Consume tombstone or invite events that
   * are acted on by this handler.
+  * @property {bool} [migrateGhosts=true] If given, migrate all ghost users across to
+  * the new room.
   */

--- a/lib/components/room-upgrade-handler.js
+++ b/lib/components/room-upgrade-handler.js
@@ -85,7 +85,7 @@ class RoomUpgradeHandler {
             }
 
             if (!this.opts.migrateGhosts) {
-                return;
+                return Promise.resolve();
             }
             return asBot.getJoinedMembers(oldRoomId);
         }).then((members) => {

--- a/lib/components/room-upgrade-handler.js
+++ b/lib/components/room-upgrade-handler.js
@@ -2,17 +2,6 @@ const log = require("./logging").get("RoomUpgradeHandler");
 const MatrixRoom = require("../models/rooms/matrix");
 
 /**
- * Get a m.room.tombstone.
- Join that room?
-   Failed to join room -> retry in 30s
-   Failed to join?
-    - Retry again?
-    - Drop room?
-   Invite only?
-    - Leave room in a tempoary state until invited.
- */
-
-/**
  * Handles migration of rooms when a room upgrade is performed.
  */
 class RoomUpgradeHandler {
@@ -21,31 +10,28 @@ class RoomUpgradeHandler {
      * @param {Bridge} bridge The parent bridge.
      */
     constructor(opts, bridge) {
-        this.roomsPendingUpgrade();
-        this.opts = opts;
-        this.bridge = bridge;
-        this.waitingForInvite = new Map(); //newRoomId: oldRoomId
+        this._opts = opts;
+        this._bridge = bridge;
+        this._waitingForInvite = new Map(); //newRoomId: oldRoomId
     }
 
     onTombstone(ev) {
         const movingTo = ev.content.replacement_room;
         log.info(`Got tombstone event for ${ev.room_id} -> ${movingTo}`);
         // Try to join the new room.
-        this._joinNewRoom(movingTo, movingTo).then((res) => {
-            return this._onJoinedNewRoom(event.room_id, movingTo);
+        return this._joinNewRoom(movingTo, movingTo).then(() => {
+            return this._onJoinedNewRoom(ev.room_id, movingTo);
         }).catch((err) => {
             log.error("Couldn't handle room upgrade: ", err);
             // We can wait for an invite and try again.
-            this.waitingForInvite.set(movingTo, event.room_id);
+            this._waitingForInvite.set(movingTo, ev.room_id);
         });
 
     }
 
     _joinNewRoom(newRoomId, roomIdOrAlias) {
-        const intent = this.bridge.getIntent();
-        intent.join(roomIdOrAlias, true, true).then((res) => {
-            return;
-        }).catch((ex) => {
+        const intent = this._bridge.getIntent();
+        return intent.join(roomIdOrAlias, true, true).catch((ex) => {
             if (newRoomId !== roomIdOrAlias ||
                 !(ex.errcode == "M_UNKNONW" && ex.error === "No known servers")) {
                 // We need to wait to be invited
@@ -71,11 +57,11 @@ class RoomUpgradeHandler {
     }
 
     onInvite(ev) {
-        if (!this.waitingForInvite.has(ev.room_id)) {
+        if (!this._waitingForInvite.has(ev.room_id)) {
             return false;
         }
-        const oldRoomId = this.waitingForInvite.get(ev.room_id);
-        this.waitingForInvite.delete(ev.room_id);
+        const oldRoomId = this._waitingForInvite.get(ev.room_id);
+        this._waitingForInvite.delete(ev.room_id);
         log.debug(`Got invite to upgraded room ${ev.room_id}`);
         this._joinNewRoom(ev.room_id, ev.room_id).then(() => {
             return this._onJoinedNewRoom(oldRoomId, ev.room_id);
@@ -87,11 +73,11 @@ class RoomUpgradeHandler {
 
     _onJoinedNewRoom(oldRoomId, newRoomId) {
         log.debug(`Joined ${newRoomId}`);
-        const intent = this.bridge.getIntent();
+        const intent = this._bridge.getIntent();
         return this.getRoomStore().getEntriesByMatrixId((entries) => {
             return entries.map((entry) => {
                 const newEntry = (
-                    this.opts.migrateEntry || this._migrateEntry)(entry, newRoomId);
+                    this._opts.migrateEntry || this._migrateEntry)(entry, newRoomId);
                 if (!newEntry) {
                     return Promise.resolve();
                 }
@@ -99,19 +85,13 @@ class RoomUpgradeHandler {
             });
         }).then(() => {
             log.debug(`Migrated entries from ${oldRoomId} to ${newRoomId} successfully.`);
-            if (this.opts.onRoomMigrated) {
-                this.opts.onRoomMigrated(oldRoomId, newRoomId);
+            if (this._opts.onRoomMigrated) {
+                this._opts.onRoomMigrated(oldRoomId, newRoomId);
             }
             return intent.leave(oldRoomId);
         });
     }
 
-    /**
-     * [migrateEntry description]
-     * @param  {[type]} entry     [description]
-     * @param  {[type]} newRoomId [description]
-     * @return {[type]}           [description]
-     */
     _migrateEntry(entry, newRoomId) {
         entry.matrix = new MatrixRoom(newRoomId, {
             name: entry.name,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "is-my-json-valid": "^2.19.0",
     "js-yaml": "^3.12.0",
     "matrix-appservice": "0.3.5",
-    "matrix-js-sdk": "^0.10.9",
+    "matrix-js-sdk": "^1.0.1",
     "nedb": "^1.1.3",
     "nopt": "^3.0.3",
     "prom-client": "^11.1.1",
@@ -39,8 +39,7 @@
     "eslint": "^1.2.0",
     "istanbul": "^0.4.5",
     "jasmine": "^2.5.2",
-    "jsdoc": "^3.3.2",
-    "eslint": "^1.2.0"
+    "jsdoc": "^3.3.2"
   },
   "optionalDependencies": {
     "winston": "^3.1.0",

--- a/spec/unit/room-upgrade-handler.spec.js
+++ b/spec/unit/room-upgrade-handler.spec.js
@@ -4,7 +4,7 @@ describe("RoomLinkValidator", () => {
     describe("constructor", () => {
         it("should construct", () => {
             const ruh = new RoomUpgradeHandler({isOpts: true}, {isBridge: true});
-            expect(ruh._opts).toEqual({isOpts: true});
+            expect(ruh._opts).toEqual({isOpts: true, migrateGhosts: true});
             expect(ruh._bridge).toEqual({isBridge: true});
             expect(ruh._waitingForInvite.size).toEqual(0);
         });

--- a/spec/unit/room-upgrade-handler.spec.js
+++ b/spec/unit/room-upgrade-handler.spec.js
@@ -1,0 +1,139 @@
+const RoomUpgradeHandler = require("../../lib/components/room-upgrade-handler")
+
+describe("RoomLinkValidator", () => {
+    describe("constructor", () => {
+        it("should construct", () => {
+            const ruh = new RoomUpgradeHandler({isOpts: true}, {isBridge: true});
+            expect(ruh._opts).toEqual({isOpts: true});
+            expect(ruh._bridge).toEqual({isBridge: true});
+            expect(ruh._waitingForInvite.size).toEqual(0);
+        });
+    });
+    describe("onTombstone", () => {
+        it("should join the new room", () => {
+            let joined;
+            const bridge = {
+                getIntent: () => ({
+                    join: (room_id) => { joined = room_id; return Promise.resolve(); },
+                }),
+            };
+            const ruh = new RoomUpgradeHandler({}, bridge);
+            ruh._onJoinedNewRoom = () => true;
+            return ruh.onTombstone({
+                room_id: "!abc:def",
+                sender: "@foo:bar",
+                content: {
+                    replacement_room: "!new:def",
+                }
+            }).then((res) => {
+                expect(joined).toEqual("!new:def");
+                expect(ruh._waitingForInvite.size).toEqual(0);
+                expect(res).toEqual(true);
+            });
+        });
+        it("should wait for an invite on M_FORBIDDEN", () => {
+            let joined;
+            const bridge = {
+                getIntent: () => ({
+                    join: (room_id) => { joined = room_id; return Promise.reject({errcode: "M_FORBIDDEN"}); },
+                }),
+            };
+            const ruh = new RoomUpgradeHandler({}, bridge);
+            return ruh.onTombstone({
+                room_id: "!abc:def",
+                sender: "@foo:bar",
+                content: {
+                    replacement_room: "!new:def",
+                }
+            }).then((res) => {
+                expect(joined).toEqual("!new:def");
+                expect(ruh._waitingForInvite.size).toEqual(1);
+                expect(res).toEqual(true);
+            });
+        });
+        it("should do nothing on failure", () => {
+            let joined;
+            const bridge = {
+                getIntent: () => ({
+                    join: (room_id) => { joined = room_id; return Promise.reject({}); },
+                }),
+            };
+            const ruh = new RoomUpgradeHandler({}, bridge);
+            ruh._onJoinedNewRoom = () => true;
+            return ruh.onTombstone({
+                room_id: "!abc:def",
+                sender: "@foo:bar",
+                content: {
+                    replacement_room: "!new:def",
+                }
+            }).then((res) => {
+                expect(joined).toEqual("!new:def");
+                expect(ruh._waitingForInvite.size).toEqual(0);
+                expect(res).toEqual(false);
+            });
+        });
+    });
+    describe("_joinNewRoom", () => {
+        it("should join a room successfully", () => {
+            let joined;
+            const bridge = {
+                getIntent: () => ({
+                    join: (room_id) => { joined = room_id; return Promise.resolve({}); },
+                }),
+            };
+            const ruh = new RoomUpgradeHandler({}, bridge);
+            return ruh._joinNewRoom("!new:def", "!new:def").then((res) => {
+                expect(res).toEqual(true);
+                expect(joined).toEqual("!new:def");
+            });
+        });
+        it("should return false on M_FORBIDDEN", () => {
+            let joined;
+            const bridge = {
+                getIntent: () => ({
+                    join: (room_id) => { joined = room_id; return Promise.reject({errcode: "M_FORBIDDEN"}); },
+                }),
+            };
+            const ruh = new RoomUpgradeHandler({}, bridge);
+            return ruh._joinNewRoom("!new:def").then((res) => {
+                expect(joined).toEqual("!new:def");
+                expect(res).toEqual(false);
+            });
+        });
+        it("should fail for any other reason", () => {
+            const bridge = {
+                getIntent: () => ({
+                    join: (room_id) => { return Promise.reject({}); },
+                }),
+            };
+            const ruh = new RoomUpgradeHandler({}, bridge);
+            return ruh._joinNewRoom("!new:def", "!new:def").catch((err) => {
+                expect(err.message).toEqual("Failed to handle upgrade");
+            });
+        });
+    });
+    describe("onInvite", () => {
+        it("should not handle a unexpected invite", () => {
+            const ruh = new RoomUpgradeHandler({}, {});
+            expect(ruh.onInvite({
+                room_id: "!abc:def",
+            })).toEqual(false);
+        });
+        it("should handle a expected invite", (done) => {
+            const ruh = new RoomUpgradeHandler({}, {});
+            let newRoomId = false;
+            ruh._waitingForInvite.set("!new:def", "!abc:def");
+            ruh._joinNewRoom = (_newRoomId) => {
+                newRoomId = _newRoomId;
+                return Promise.resolve();
+            }
+            ruh._onJoinedNewRoom = () => {
+                expect(newRoomId).toEqual("!new:def");
+                done();
+            }
+            expect(ruh.onInvite({
+                room_id: "!new:def",
+            })).toEqual(true);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #95 

This works by listening for a `m.room.tombstone` event and attempts to join the referenced room (first by room_id, then by alias). If that succeeds it finds all entries by the old room id and replace with the new room id. If the join fails, it waits for a subsequent invite before trying to update the entries.

The entry update logic can be overriden by providing a callback, and bridges can hook into another callback once an upgrade has been completed.

This functionality is disabled by default and must be enabled by providing a config.