### PR TITLE
Create an EventStore for Cadair

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ mapping between different types of users.
 Provides storage for matrix and remote rooms. Provides CRUD operations and
 mapping between different types of rooms.
 
+### `EventBridgeStore`
+Provides storage for matrix and remote event ids.
+
 ### `ClientFactory`
 Provides a method to obtain a JS SDK `MatrixClient` in the context of a
 particular `user_id` and/or `Request`. This is used to send messages as other

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -564,7 +564,7 @@ Bridge.prototype.addAppServicePath = function(opts) {
 };
 
 /**
- * Retrieve a connected room store instance.
+ * Retrieve the connected room store instance.
  * @return {?RoomBridgeStore} The connected instance ready for querying.
  */
 Bridge.prototype.getRoomStore = function() {
@@ -572,7 +572,7 @@ Bridge.prototype.getRoomStore = function() {
 };
 
 /**
- * Retrieve a connected user store instance.
+ * Retrieve the connected user store instance.
  * @return {?UserBridgeStore} The connected instance ready for querying.
  */
 Bridge.prototype.getUserStore = function() {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -580,7 +580,7 @@ Bridge.prototype.getUserStore = function() {
 };
 
 /**
- * Retrieve a connected event store instance.
+ * Retrieve the connected event store instance, if one was configured.
  * @return {?EventBridgeStore} The connected instance ready for querying.
  */
 Bridge.prototype.getEventStore = function() {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -66,6 +66,9 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * @param {(UserBridgeStore|string)=} opts.userStore The user store instance to
  * use, or the path to the user .db file to load. A database will be created if
  * this is not specified.
+ * @param {(EventBridgeStore|string)=} opts.eventStore The event store instance to
+ * use, or the path to the event .db file to load. This will NOT be created if it
+ * isn't specified.
  * @param {MembershipCache=} opts.membershipCache The membership cache instance
  * to use, which can be manually created by a bridge for greater control over
  * caching. By default a membership cache will be created internally.
@@ -134,7 +137,7 @@ function Bridge(opts) {
 
     opts.userStore = opts.userStore || "user-store.db";
     opts.roomStore = opts.roomStore || "room-store.db";
-    opts.eventStore = opts.eventStore || "event-store.db";
+    opts.eventStore = null; // Must be enabled
     opts.queue = opts.queue || {};
     opts.intentOptions = opts.intentOptions || {};
     opts.queue.type = opts.queue.type || "single";

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -137,7 +137,8 @@ function Bridge(opts) {
 
     opts.userStore = opts.userStore || "user-store.db";
     opts.roomStore = opts.roomStore || "room-store.db";
-    opts.eventStore = null; // Must be enabled
+    
+    opts.eventStore = opts.eventStore || null; // Must be enabled
     opts.queue = opts.queue || {};
     opts.intentOptions = opts.intentOptions || {};
     opts.queue.type = opts.queue.type || "single";

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -9,6 +9,7 @@ const RequestFactory = require("./components/request-factory");
 const Intent = require("./components/intent");
 const RoomBridgeStore = require("./components/room-bridge-store");
 const UserBridgeStore = require("./components/user-bridge-store");
+const EventBridgeStore = require("./components/event-bridge-store");
 const MatrixUser = require("./models/users/matrix");
 const MatrixRoom = require("./models/rooms/matrix");
 const PrometheusMetrics = require("./components/prometheusmetrics");
@@ -133,6 +134,7 @@ function Bridge(opts) {
 
     opts.userStore = opts.userStore || "user-store.db";
     opts.roomStore = opts.roomStore || "room-store.db";
+    opts.eventStore = opts.eventStore || "event-store.db";
     opts.queue = opts.queue || {};
     opts.intentOptions = opts.intentOptions || {};
     opts.queue.type = opts.queue.type || "single";
@@ -209,6 +211,9 @@ Bridge.prototype.loadDatabases = function() {
     if (typeof self.opts.roomStore === "string") {
         self.opts.roomStore = loadDatabase(self.opts.roomStore, RoomBridgeStore);
     }
+    if (typeof self.opts.eventStore === "string") {
+        self.opts.eventStore = loadDatabase(self.opts.eventStore, EventBridgeStore);
+    }
 
     // This works because if they provided a string we converted it to a Promise
     // which will be resolved when we have the db instance. If they provided a
@@ -219,6 +224,9 @@ Bridge.prototype.loadDatabases = function() {
         }),
         Promise.resolve(self.opts.roomStore).then(function(db) {
             self._roomStore = db;
+        }),
+        Promise.resolve(self.opts.eventStore).then(function(db) {
+            self._eventStore = db;
         })
     ]);
 };
@@ -565,6 +573,14 @@ Bridge.prototype.getRoomStore = function() {
  */
 Bridge.prototype.getUserStore = function() {
     return this._userStore;
+};
+
+/**
+ * Retrieve a connected event store instance.
+ * @return {?EventBridgeStore} The connected instance ready for querying.
+ */
+Bridge.prototype.getEventStore = function() {
+    return this._eventStore;
 };
 
 /**

--- a/lib/components/event-bridge-store.js
+++ b/lib/components/event-bridge-store.js
@@ -1,9 +1,11 @@
 /*
 Copyright 2019 The Matrix.org Foundation C.I.C.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/components/event-bridge-store.js
+++ b/lib/components/event-bridge-store.js
@@ -1,0 +1,104 @@
+"use strict";
+const BridgeStore = require("./bridge-store");
+const StoreEvent = require("../models/events/event");
+const util = require("util");
+
+/**
+ * Construct a store suitable for event mapping information. Data is stored
+ * as {@link StoreEvent}s.
+ * @constructor
+ * @param {Datastore} db The connected NEDB database instance
+ */
+function EventBridgeStore(db) {
+    this.db = db;
+}
+
+util.inherits(EventBridgeStore, BridgeStore);
+
+/**
+ * Insert an event, clobbering based on the ID of the StoreEvent.
+ * @param {StoreEvent} event
+ * @return {Promise}
+ */
+EventBridgeStore.prototype.upsertEvent = function(event) {
+    return this.upsert({
+        id: event.getId()
+    }, event.serialize());
+}
+
+/**
+ * Get an existing event based on the provided matrix IDs.
+ * @param {string} roomId The ID of the room.
+ * @param {string} eventId The ID of the event.
+ * @return {?StoreEvent} A promise which resolves to the StoreEvent or null.
+ */
+EventBridgeStore.prototype.getEntryByMatrixId = function(roomId, eventId) {
+    return this.selectOne({
+        matrix: {
+            roomId,
+            eventId,
+        }
+    }, this.convertTo(function(doc) {
+        return StoreEvent.deserialize(doc);
+    }));
+}
+
+/**
+ * Get an existing event based on the provided remote IDs.
+ * @param {string} roomId The ID of the room.
+ * @param {string} eventId The ID of the event.
+ * @return {?StoreEvent} A promise which resolves to the StoreEvent or null.
+ */
+EventBridgeStore.prototype.getEntryByRemoteId = function(roomId, eventId) {
+    return this.selectOne({
+        remote: {
+            roomId,
+            eventId,
+        }
+    }, this.convertTo(function(doc) {
+        return StoreEvent.deserialize(doc);
+    }));
+}
+
+/**
+ * Remove entries based on the event data.
+ * @param {StoreEvent} event The event to remove.
+ * @return {Promise}
+ */
+EventBridgeStore.prototype.removeEvent = function(event) {
+    return this.delete({
+        id: event.getId(),
+    });
+};
+
+/**
+ * Remove entries based on the matrix IDs.
+ * @param {string} roomId The ID of the room.
+ * @param {string} eventId The ID of the event.
+ * @return {Promise}
+ */
+EventBridgeStore.prototype.removeEventByMatrixId = function(roomId, eventId) {
+    return this.delete({
+        matrix: {
+            roomId,
+            eventId,
+        }
+    });
+};
+
+/**
+ * Remove entries based on the matrix IDs.
+ * @param {string} roomId The ID of the room.
+ * @param {string} eventId The ID of the event.
+ * @return {Promise}
+ */
+EventBridgeStore.prototype.removeEventByRemoteId = function(roomId, eventId) {
+    return this.delete({
+        remote: {
+            roomId,
+            eventId,
+        }
+    });
+};
+
+module.exports = EventBridgeStore;

--- a/lib/components/event-bridge-store.js
+++ b/lib/components/event-bridge-store.js
@@ -34,10 +34,8 @@ EventBridgeStore.prototype.upsertEvent = function(event) {
  */
 EventBridgeStore.prototype.getEntryByMatrixId = function(roomId, eventId) {
     return this.selectOne({
-        matrix: {
-            roomId,
-            eventId,
-        }
+        "matrix.roomId": roomId,
+        "matrix.eventId": eventId,
     }, this.convertTo(function(doc) {
         return StoreEvent.deserialize(doc);
     }));
@@ -51,10 +49,8 @@ EventBridgeStore.prototype.getEntryByMatrixId = function(roomId, eventId) {
  */
 EventBridgeStore.prototype.getEntryByRemoteId = function(roomId, eventId) {
     return this.selectOne({
-        remote: {
-            roomId,
-            eventId,
-        }
+        "remote.roomId": roomId,
+        "remote.eventId": eventId,
     }, this.convertTo(function(doc) {
         return StoreEvent.deserialize(doc);
     }));
@@ -79,10 +75,8 @@ EventBridgeStore.prototype.removeEvent = function(event) {
  */
 EventBridgeStore.prototype.removeEventByMatrixId = function(roomId, eventId) {
     return this.delete({
-        matrix: {
-            roomId,
-            eventId,
-        }
+        "matrix.roomId": roomId,
+        "matrix.eventId": eventId,
     });
 };
 
@@ -94,10 +88,8 @@ EventBridgeStore.prototype.removeEventByMatrixId = function(roomId, eventId) {
  */
 EventBridgeStore.prototype.removeEventByRemoteId = function(roomId, eventId) {
     return this.delete({
-        remote: {
-            roomId,
-            eventId,
-        }
+        "remote.roomId": roomId,
+        "remote.eventId": eventId,
     });
 };
 

--- a/lib/components/event-bridge-store.js
+++ b/lib/components/event-bridge-store.js
@@ -1,11 +1,22 @@
-"use strict";
+/*
+Copyright 2019 New Vector Ltd
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 const BridgeStore = require("./bridge-store");
-const StoreEvent = require("../models/events/event");
+const StoredEvent = require("../models/events/event");
 const util = require("util");
 
 /**
  * Construct a store suitable for event mapping information. Data is stored
- * as {@link StoreEvent}s.
+ * as {@link StoredEvent}s.
  * @constructor
  * @param {Datastore} db The connected NEDB database instance
  */
@@ -16,8 +27,8 @@ function EventBridgeStore(db) {
 util.inherits(EventBridgeStore, BridgeStore);
 
 /**
- * Insert an event, clobbering based on the ID of the StoreEvent.
- * @param {StoreEvent} event
+ * Insert an event, clobbering based on the ID of the StoredEvent.
+ * @param {StoredEvent} event
  * @return {Promise}
  */
 EventBridgeStore.prototype.upsertEvent = function(event) {
@@ -30,14 +41,14 @@ EventBridgeStore.prototype.upsertEvent = function(event) {
  * Get an existing event based on the provided matrix IDs.
  * @param {string} roomId The ID of the room.
  * @param {string} eventId The ID of the event.
- * @return {?StoreEvent} A promise which resolves to the StoreEvent or null.
+ * @return {?StoredEvent} A promise which resolves to the StoredEvent or null.
  */
 EventBridgeStore.prototype.getEntryByMatrixId = function(roomId, eventId) {
     return this.selectOne({
         "matrix.roomId": roomId,
         "matrix.eventId": eventId,
     }, this.convertTo(function(doc) {
-        return StoreEvent.deserialize(doc);
+        return StoredEvent.deserialize(doc);
     }));
 }
 
@@ -45,20 +56,20 @@ EventBridgeStore.prototype.getEntryByMatrixId = function(roomId, eventId) {
  * Get an existing event based on the provided remote IDs.
  * @param {string} roomId The ID of the room.
  * @param {string} eventId The ID of the event.
- * @return {?StoreEvent} A promise which resolves to the StoreEvent or null.
+ * @return {?StoredEvent} A promise which resolves to the StoredEvent or null.
  */
 EventBridgeStore.prototype.getEntryByRemoteId = function(roomId, eventId) {
     return this.selectOne({
         "remote.roomId": roomId,
         "remote.eventId": eventId,
     }, this.convertTo(function(doc) {
-        return StoreEvent.deserialize(doc);
+        return StoredEvent.deserialize(doc);
     }));
 }
 
 /**
  * Remove entries based on the event data.
- * @param {StoreEvent} event The event to remove.
+ * @param {StoredEvent} event The event to remove.
  * @return {Promise}
  */
 EventBridgeStore.prototype.removeEvent = function(event) {

--- a/lib/components/event-bridge-store.js
+++ b/lib/components/event-bridge-store.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/lib/exports.js
+++ b/lib/exports.js
@@ -24,7 +24,7 @@ module.exports.MatrixUser = require("./models/users/matrix");
 module.exports.RemoteUser = require("./models/users/remote");
 module.exports.MatrixRoom = require("./models/rooms/matrix");
 module.exports.RemoteRoom = require("./models/rooms/remote");
-module.exports.StoreEvent = require("./models/events/event");
+module.exports.StoredEvent = require("./models/events/event");
 
 module.exports.Bridge = require("./bridge");
 module.exports.AppServiceRegistration = (

--- a/lib/exports.js
+++ b/lib/exports.js
@@ -17,12 +17,14 @@ module.exports.RequestFactory = require("./components/request-factory");
 module.exports.BridgeStore = require("./components/bridge-store");
 module.exports.UserBridgeStore = require("./components/user-bridge-store");
 module.exports.RoomBridgeStore = require("./components/room-bridge-store");
+module.exports.EventBridgeStore = require("./components/event-bridge-store");
 
 // Models
 module.exports.MatrixUser = require("./models/users/matrix");
 module.exports.RemoteUser = require("./models/users/remote");
 module.exports.MatrixRoom = require("./models/rooms/matrix");
 module.exports.RemoteRoom = require("./models/rooms/remote");
+module.exports.StoreEvent = require("./models/events/event");
 
 module.exports.Bridge = require("./bridge");
 module.exports.AppServiceRegistration = (

--- a/lib/models/events/event.js
+++ b/lib/models/events/event.js
@@ -1,9 +1,11 @@
 /*
 Copyright 2019 The Matrix.org Foundation C.I.C.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/models/events/event.js
+++ b/lib/models/events/event.js
@@ -19,7 +19,7 @@ function StoreEvent(roomId, eventId, remoteRoomId, remoteEventId, extras) {
 
 /**
  * Get the unique ID.
- * @return {string} The room ID
+ * @return {string} A unique ID
  */
 StoreEvent.prototype.getId = function() {
     return this.eventId + this.remoteEventId;
@@ -67,7 +67,7 @@ StoreEvent.prototype.get = function(key) {
 };
 
 /**
- * Set an arbitrary bridge-specific data value for this room. This will be serailized
+ * Set an arbitrary bridge-specific data value for this event. This will be serailized
  * under an 'extras' key.
  * @param {string} key The key to store the data value under.
  * @param {*} val The data value. This value should be serializable via
@@ -78,12 +78,12 @@ StoreEvent.prototype.set = function(key, val) {
 };
 
 /**
- * Serialize data about this room into a JSON object.
+ * Serialize data about this event into a JSON object.
  * @return {Object} The serialised data
  */
 StoreEvent.prototype.serialize = function() {
     return {
-        id: event.getId(),
+        id: this.getId(),
         matrix: {
             roomId: this.roomId,
             eventId: this.eventId,
@@ -97,15 +97,17 @@ StoreEvent.prototype.serialize = function() {
 };
 
 /**
- * Set data about this room from a serialized data object.
+ * Set data about this event from a serialized data object.
  * @param {Object} data The serialized data
  */
 StoreEvent.deserialize = function(data) {
-    this.roomId = data.matrix.roomId;
-    this.eventId = data.matrix.eventId;
-    this.remoteRoomId = data.remote.roomId;
-    this.remoteEventId = data.remote.eventId;
-    this._extras = data.extras;
+    return new StoreEvent(
+        data.matrix.roomId,
+        data.matrix.eventId,
+        data.remote.roomId,
+        data.remote.eventId,
+        data.extras
+    );
 };
 
 module.exports = StoreEvent;

--- a/lib/models/events/event.js
+++ b/lib/models/events/event.js
@@ -1,0 +1,111 @@
+"use strict";
+
+/**
+ * Create a store event.
+ * @constructor
+ * @param {string} roomId The matrix room ID
+ * @param {string} eventId The matrix event ID
+ * @param {string} remoteRoomId The remote room ID
+ * @param {string} remoteEventId The remote event ID
+ * @param {any} extras Any extra data that may be included with the event.
+ */
+function StoreEvent(roomId, eventId, remoteRoomId, remoteEventId, extras) {
+    this.roomId = roomId;
+    this.eventId = eventId;
+    this.remoteRoomId = remoteRoomId;
+    this.remoteEventId = remoteEventId;
+    this._extras = extras || {};
+}
+
+/**
+ * Get the unique ID.
+ * @return {string} The room ID
+ */
+StoreEvent.prototype.getId = function() {
+    return this.eventId + this.remoteEventId;
+};
+
+/**
+ * Get the matrix room ID.
+ * @return {string} The room ID
+ */
+StoreEvent.prototype.getMatrixRoomId = function() {
+    return this.roomId;
+};
+
+/**
+ * Get the matrix event ID.
+ * @return {string} The event ID
+ */
+StoreEvent.prototype.getMatrixEventId = function() {
+    return this.eventId;
+};
+
+/**
+ * Get the remote room ID.
+ * @return {string} The remote room ID
+ */
+StoreEvent.prototype.getRemoteRoomId = function() {
+    return this.remoteRoomId;
+};
+
+/**
+ * Get the remote event ID.
+ * @return {string} The remote event ID
+ */
+StoreEvent.prototype.getRemoteEventId = function() {
+    return this.remoteEventId;
+};
+
+/**
+ * Get the data value for the given key.
+ * @param {string} key An arbitrary bridge-specific key.
+ * @return {*} Stored data for this key. May be undefined.
+ */
+StoreEvent.prototype.get = function(key) {
+    return this._extras[key];
+};
+
+/**
+ * Set an arbitrary bridge-specific data value for this room. This will be serailized
+ * under an 'extras' key.
+ * @param {string} key The key to store the data value under.
+ * @param {*} val The data value. This value should be serializable via
+ * <code>JSON.stringify(data)</code>.
+ */
+StoreEvent.prototype.set = function(key, val) {
+    this._extras[key] = val;
+};
+
+/**
+ * Serialize data about this room into a JSON object.
+ * @return {Object} The serialised data
+ */
+StoreEvent.prototype.serialize = function() {
+    return {
+        id: event.getId(),
+        matrix: {
+            roomId: this.roomId,
+            eventId: this.eventId,
+        },
+        remote: {
+            roomId: this.remoteRoomId,
+            eventId: this.remoteEventId,
+        },
+        extras: this._extras,
+    };
+};
+
+/**
+ * Set data about this room from a serialized data object.
+ * @param {Object} data The serialized data
+ */
+StoreEvent.deserialize = function(data) {
+    this.roomId = data.matrix.roomId;
+    this.eventId = data.matrix.eventId;
+    this.remoteRoomId = data.remote.roomId;
+    this.remoteEventId = data.remote.eventId;
+    this._extras = data.extras;
+};
+
+module.exports = StoreEvent;

--- a/lib/models/events/event.js
+++ b/lib/models/events/event.js
@@ -1,4 +1,15 @@
-"use strict";
+/*
+Copyright 2019 New Vector Ltd
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 /**
  * Create a store event.
@@ -9,7 +20,7 @@
  * @param {string} remoteEventId The remote event ID
  * @param {any} extras Any extra data that may be included with the event.
  */
-function StoreEvent(roomId, eventId, remoteRoomId, remoteEventId, extras) {
+function StoredEvent(roomId, eventId, remoteRoomId, remoteEventId, extras) {
     this.roomId = roomId;
     this.eventId = eventId;
     this.remoteRoomId = remoteRoomId;
@@ -21,7 +32,7 @@ function StoreEvent(roomId, eventId, remoteRoomId, remoteEventId, extras) {
  * Get the unique ID.
  * @return {string} A unique ID
  */
-StoreEvent.prototype.getId = function() {
+StoredEvent.prototype.getId = function() {
     return this.eventId + this.remoteEventId;
 };
 
@@ -29,7 +40,7 @@ StoreEvent.prototype.getId = function() {
  * Get the matrix room ID.
  * @return {string} The room ID
  */
-StoreEvent.prototype.getMatrixRoomId = function() {
+StoredEvent.prototype.getMatrixRoomId = function() {
     return this.roomId;
 };
 
@@ -37,7 +48,7 @@ StoreEvent.prototype.getMatrixRoomId = function() {
  * Get the matrix event ID.
  * @return {string} The event ID
  */
-StoreEvent.prototype.getMatrixEventId = function() {
+StoredEvent.prototype.getMatrixEventId = function() {
     return this.eventId;
 };
 
@@ -45,7 +56,7 @@ StoreEvent.prototype.getMatrixEventId = function() {
  * Get the remote room ID.
  * @return {string} The remote room ID
  */
-StoreEvent.prototype.getRemoteRoomId = function() {
+StoredEvent.prototype.getRemoteRoomId = function() {
     return this.remoteRoomId;
 };
 
@@ -53,7 +64,7 @@ StoreEvent.prototype.getRemoteRoomId = function() {
  * Get the remote event ID.
  * @return {string} The remote event ID
  */
-StoreEvent.prototype.getRemoteEventId = function() {
+StoredEvent.prototype.getRemoteEventId = function() {
     return this.remoteEventId;
 };
 
@@ -62,7 +73,7 @@ StoreEvent.prototype.getRemoteEventId = function() {
  * @param {string} key An arbitrary bridge-specific key.
  * @return {*} Stored data for this key. May be undefined.
  */
-StoreEvent.prototype.get = function(key) {
+StoredEvent.prototype.get = function(key) {
     return this._extras[key];
 };
 
@@ -73,7 +84,7 @@ StoreEvent.prototype.get = function(key) {
  * @param {*} val The data value. This value should be serializable via
  * <code>JSON.stringify(data)</code>.
  */
-StoreEvent.prototype.set = function(key, val) {
+StoredEvent.prototype.set = function(key, val) {
     this._extras[key] = val;
 };
 
@@ -81,7 +92,7 @@ StoreEvent.prototype.set = function(key, val) {
  * Serialize data about this event into a JSON object.
  * @return {Object} The serialised data
  */
-StoreEvent.prototype.serialize = function() {
+StoredEvent.prototype.serialize = function() {
     return {
         id: this.getId(),
         matrix: {
@@ -100,8 +111,8 @@ StoreEvent.prototype.serialize = function() {
  * Set data about this event from a serialized data object.
  * @param {Object} data The serialized data
  */
-StoreEvent.deserialize = function(data) {
-    return new StoreEvent(
+StoredEvent.deserialize = function(data) {
+    return new StoredEvent(
         data.matrix.roomId,
         data.matrix.eventId,
         data.remote.roomId,
@@ -110,4 +121,4 @@ StoreEvent.deserialize = function(data) {
     );
 };
 
-module.exports = StoreEvent;
+module.exports = StoredEvent;

--- a/lib/models/events/event.js
+++ b/lib/models/events/event.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/spec/integ/event-bridge-store.spec.js
+++ b/spec/integ/event-bridge-store.spec.js
@@ -1,10 +1,21 @@
-"use strict";
+/*
+Copyright 2019 New Vector Ltd
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 const Datastore = require("nedb");
 const fs = require("fs");
 const log = require("../log");
 
 const EventBridgeStore = require("../..").EventBridgeStore;
-const StoreEvent = require("../..").StoreEvent;
+const StoredEvent = require("../..").StoredEvent;
 var TEST_DB_PATH = __dirname + "/test.db";
 
 describe("EventBridgeStore", function() {
@@ -40,7 +51,7 @@ describe("EventBridgeStore", function() {
     describe("upsertEvent", function() {
         it("should be able to store a SourceEvent, retrievable again via getEntryBy(Matrix|Remote)Id",
         function(done) {
-            const ev = new StoreEvent(
+            const ev = new StoredEvent(
                 "!room:bar",
                 "$event:bar",
                 "remoteroom:bar",
@@ -62,7 +73,7 @@ describe("EventBridgeStore", function() {
     describe("removeEvent", function() {
         it("should be able to remove a SourceEvent",
         function(done) {
-            const ev = new StoreEvent(
+            const ev = new StoredEvent(
                 "!room:bar",
                 "$event:bar",
                 "remoteroom:bar",
@@ -82,7 +93,7 @@ describe("EventBridgeStore", function() {
     describe("removeEventByMatrixId", function() {
         it("should be able to remove a SourceEvent",
         function(done) {
-            const ev = new StoreEvent(
+            const ev = new StoredEvent(
                 "!room:bar",
                 "$event:bar",
                 "remoteroom:bar",
@@ -102,7 +113,7 @@ describe("EventBridgeStore", function() {
     describe("removeEventByRemoteId", function() {
         it("should be able to remove a SourceEvent",
         function(done) {
-            const ev = new StoreEvent(
+            const ev = new StoredEvent(
                 "!room:bar",
                 "$event:bar",
                 "remoteroom:bar",

--- a/spec/integ/event-bridge-store.spec.js
+++ b/spec/integ/event-bridge-store.spec.js
@@ -1,8 +1,10 @@
 /*
 Copyright 2019 The Matrix.org Foundation C.I.C.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/spec/integ/event-bridge-store.spec.js
+++ b/spec/integ/event-bridge-store.spec.js
@@ -1,0 +1,121 @@
+"use strict";
+const Datastore = require("nedb");
+const fs = require("fs");
+const log = require("../log");
+
+const EventBridgeStore = require("../..").EventBridgeStore;
+const StoreEvent = require("../..").StoreEvent;
+var TEST_DB_PATH = __dirname + "/test.db";
+
+describe("EventBridgeStore", function() {
+    var store, db;
+
+    beforeEach(
+    /** @this TestCase */
+    function(done) {
+        log.beforeEach(this);
+        db = new Datastore({
+            filename: TEST_DB_PATH,
+            autoload: true,
+            onload: function(err) {
+                if (err) {
+                    console.error(err);
+                    return;
+                }
+                store = new EventBridgeStore(db);
+                done();
+            }
+        });
+    });
+
+    afterEach(function() {
+        try {
+            fs.unlinkSync(TEST_DB_PATH);
+        }
+        catch (e) {
+            // do nothing
+        }
+    });
+
+    describe("upsertEvent", function() {
+        it("should be able to store a SourceEvent, retrievable again via getEntryBy(Matrix|Remote)Id",
+        function(done) {
+            const ev = new StoreEvent(
+                "!room:bar",
+                "$event:bar",
+                "remoteroom:bar",
+                "remoteevent:bar"
+            );
+            store.upsertEvent(ev).then(() => {
+                return store.getEntryByMatrixId("!room:bar", "$event:bar");
+            }).then((res) => {
+                expect(res).toBeDefined();
+                expect(res.getId()).toEqual(ev.getId());
+                return store.getEntryByRemoteId("remoteroom:bar", "remoteevent:bar");
+            }).then((res) => {
+                expect(res.getId()).toEqual(ev.getId());
+                done();
+            });
+        });
+    });
+
+    describe("removeEvent", function() {
+        it("should be able to remove a SourceEvent",
+        function(done) {
+            const ev = new StoreEvent(
+                "!room:bar",
+                "$event:bar",
+                "remoteroom:bar",
+                "remoteevent:bar"
+            );
+            store.upsertEvent(ev).then(() => {
+                return store.removeEvent(ev);
+            }).then(() => {
+                return store.getEntryByMatrixId("remoteroom:bar", "remoteevent:bar");
+            }).then((res) => {
+                expect(res).toBeNull();
+                done();
+            });
+        });
+    });
+
+    describe("removeEventByMatrixId", function() {
+        it("should be able to remove a SourceEvent",
+        function(done) {
+            const ev = new StoreEvent(
+                "!room:bar",
+                "$event:bar",
+                "remoteroom:bar",
+                "remoteevent:bar"
+            );
+            store.upsertEvent(ev).then(() => {
+                return store.removeEventByMatrixId("!room:bar", "$event:bar");
+            }).then(() => {
+                return store.getEntryByMatrixId("remoteroom:bar", "remoteevent:bar");
+            }).then((res) => {
+                expect(res).toBeNull();
+                done();
+            });
+        });
+    });
+
+    describe("removeEventByRemoteId", function() {
+        it("should be able to remove a SourceEvent",
+        function(done) {
+            const ev = new StoreEvent(
+                "!room:bar",
+                "$event:bar",
+                "remoteroom:bar",
+                "remoteevent:bar"
+            );
+            store.upsertEvent(ev).then(() => {
+                return store.removeEventByRemoteId("remoteroom:bar", "remoteevent:bar");
+            }).then(() => {
+                return store.getEntryByMatrixId("remoteroom:bar", "remoteevent:bar");
+            }).then((res) => {
+                expect(res).toBeNull();
+                done();
+            });
+        });
+    });
+});

--- a/spec/integ/event-bridge-store.spec.js
+++ b/spec/integ/event-bridge-store.spec.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 New Vector Ltd
+Copyright 2019 The Matrix.org Foundation C.I.C.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
Fixes #92 

Some bridges want to be able to store events ids long term, mapped against their bridged counterparts for things like replies and redactions. This should be a suitable starting point.