### PR TITLE
Repair linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "env": {
     "node": true,
     "jasmine": true,
-    "es6": true,
+    "es6": true
   },
   "rules": {
     "consistent-return": 2,
@@ -67,7 +67,7 @@
     "no-nested-ternary": 1,
     "no-spaced-func": 1,
     "no-trailing-spaces": 1,
-    "space-after-keywords": [1, "always"],
+    "keyword-spacing": [1, {"after": true}],
     "space-before-blocks": [1, "always"]
   }
 }

--- a/lib/components/room-link-validator.js
+++ b/lib/components/room-link-validator.js
@@ -145,6 +145,7 @@ class RoomLinkValidator {
             }
             this.conflictCache.delete(roomId);
         }
+        return undefined;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "request": "^2.61.0"
   },
   "devDependencies": {
-    "eslint": "^1.2.0",
+    "eslint": "^5.16.0",
     "istanbul": "^0.4.5",
     "jasmine": "^2.5.2",
     "jsdoc": "^3.3.2"

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -705,6 +705,7 @@ function mkMockMatrixClient(uid) {
         if (method === "POST" && path === "/register") {
             return client.register(data.user);
         }
+        return undefined;
     });
     client.credentials.userId = uid;
     return client;


### PR DESCRIPTION
Some small changes to make linting work again properly. Fixes vulnerabilites, deprecation warnings, linter errors and a superfluous comma.

- upgrade eslint `^1.2.0`→`^5.16.0`
- rename `.eslintrc`→`.eslintrc.json`
- replace eslint attribute `space-after-keywords` with `keyword-spacing`
- add explicit returns to functions where they are missing to avoid lint erros

Note: I did not fix the linter *warnings* to avoid tainting the blame.