### PR TITLE
Enable signaling of bridge errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,22 @@ will not be emitted by `onEvent`. For more information, see the docs.
  * `RemoteRoom` - A representation of a third-party room.
  * `MatrixUser` - A representation of a matrix user.
  * `RemoteUser` - A representation of a third-party user.
+
+
+## Signaling Bridge Errors
+This section applies when you are using `Bridge` and want to notify your users
+about problems while processing their events.
+
+One thing the bridge requires you to do is fulfilling or rejecting the
+`request` promise which is handed to you as argument of the
+`controller.onEvent` callback. When rejecting the promise the `Error` you
+reject with does matter:
+
+- On most `Error`s the bridge will simply notify the homeserver that the event
+  could not be handled right now. The homeserver will then try to resend the
+  message again with exponential backoff.
+- On an `EventNotHandledError` (and all its subtypes) the bridge will declare
+  the event as permanently failed. It will mark it as such by sending a
+  `de.nasnotfound.bridge_error` room event, which will make clients show an
+  error message to their users. The homeserver is signaled that the message was
+  handled and it will not try to resend it.

--- a/README.md
+++ b/README.md
@@ -190,14 +190,12 @@ about problems while processing their events.
 
 One thing the bridge requires you to do is fulfilling or rejecting the
 `request` promise which is handed to you as argument of the
-`controller.onEvent` callback. When rejecting the promise the `Error` you
-reject with does matter:
+`controller.onEvent` callback. When rejecting the promise, the `Error` you
+reject with will indicate to the bridge library how to behave:
 
-- On most `Error`s the bridge will simply notify the homeserver that the event
-  could not be handled right now. The homeserver will then try to resend the
-  message again with exponential backoff.
 - On an `EventNotHandledError` (and all its subtypes) the bridge will declare
   the event as permanently failed. It will mark it as such by sending a
   `de.nasnotfound.bridge_error` room event, which will make clients show an
-  error message to their users. The homeserver is signaled that the message was
-  handled and it will not try to resend it.
+  error message to their users.
+- On all other `Error` types no message is sent to the clients. The bridge
+  still uses the information that the event was handled for queuing purposes.

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -768,11 +768,11 @@ Bridge.prototype._onAliasQuery = function(alias) {
 };
 
 // returns a Promise for the request linked to this event for testing.
-Bridge.prototype._onEvent = function(event) {
+Bridge.prototype._onEvent = async function(event) {
     this._updateIntents(event);
     if (this.opts.suppressEcho &&
             this.opts.registration.isUserMatch(event.user_id, true)) {
-        return Promise.resolve();
+        return null;
     }
 
     if (this._roomUpgradeHandler) {
@@ -780,7 +780,7 @@ Bridge.prototype._onEvent = function(event) {
         if (event.type === "m.room.tombstone" && this._roomUpgradeHandler) {
             this._roomUpgradeHandler.onTombstone(event);
             if (this.opts.roomUpgradeOpts.consumeEvent) {
-                return Promise.resolve();
+                return null;
             }
         }
         else if (event.type === "m.room.member" &&
@@ -791,7 +791,7 @@ Bridge.prototype._onEvent = function(event) {
             const isUpgradeInvite = this._roomUpgradeHandler.onInvite(event);
             if (isUpgradeInvite &&
                 this.opts.roomUpgradeOpts.consumeEvent) {
-                return Promise.resolve();
+                return null;
             }
         }
     }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -873,7 +873,7 @@ Bridge.prototype._handleEventError = function(event, error) {
         event.event_id,
         "Discord",
         error.reason,
-        this._getUserRegex()
+        this._getUserRegex(),
     );
 };
 
@@ -884,8 +884,7 @@ Bridge.prototype._handleEventError = function(event, error) {
  */
 Bridge.prototype._getUserRegex = function() {
     const reg = this.opts.registration;
-    const userRegexes = reg.namespaces["users"].map(o => o.regex);
-    return userRegexes.join("|");
+    return reg.namespaces["users"].map(o => o.regex);
 };
 
 Bridge.prototype._updateIntents = function(event) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -813,9 +813,15 @@ Bridge.prototype._onEvent = async function(event) {
 };
 
 /**
- * Returns a promise that is like `promise` but adheres to all necessary limits.
+ * Restricts the promise according to the bridges `perRequest` setting.
+ *
+ * `perRequest` enabled:
+ *     Returns a promise similar to `promise`, with the addition of it only
+ *     resolving after `request`.
+ * `perRequest` disabled:
+ *     Returns the promise unchanged.
  */
-Bridge.prototype._limited = function(promise, request) {
+Bridge.prototype._limited = async function(promise, request) {
     // queue.perRequest controls whether multiple request can be processed by
     // the bridge at once.
     if (this.opts.queue.perRequest) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -30,6 +30,16 @@ const INTENT_CULL_CHECK_PERIOD_MS = 1000 * 60; // once per minute
 // How long a given Intent object can hang around unused for.
 const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
 
+/* Returns a new promise which behaves like `main`, but holds settling back
+ * until `prolonger` was settled.
+ * @param {Promise} main The promise to mimick.
+ * @param {Promise} prolonger The promise to wait for.
+ * @return {Promise} A new promise behaving like main, but waiting for prolonger.
+ */
+function prolong(main, prolonger) {
+    return Promise.all([main, prolonger.reflect()]).then(([m, _]) => m);
+}
+
 /**
  * @constructor
  * @param {Object} opts Options to pass to the bridge
@@ -793,51 +803,46 @@ Bridge.prototype._onEvent = function(event) {
         }
     }
 
-    var request = this._requestFactory.newRequest({ data: event });
-    var context = new BridgeContext({
-        sender: event.user_id,
-        target: event.state_key,
-        room: event.room_id
-    });
-    var data = {
+    const request = this._requestFactory.newRequest({ data: event });
+    const contextReady = this._getBridgeContext(event);
+    const dataReady = contextReady.then(c => ({
         request: request,
-        context: context
-    };
-
-    var promise;
-    if (this.opts.disableContext) {
-        promise = Promise.resolve();
-        data.context = null;
-    }
-    else {
-        promise = context.get(this._roomStore, this._userStore);
-    }
+        context: c
+    }));
 
     if (this.opts.queue.perRequest) {
-        promise = Promise.settle([
-            promise,
-            this._prevRequestPromise
-        ]);
+        dataReady = prolong(dataReady, this._prevRequestPromise)
         this._prevRequestPromise = request.getPromise();
     }
 
-    this._queue.push(event, data, promise);
+    this._queue.push(event, dataReady);
     this._queue.consume();
     return request.getPromise();
 };
 
 Bridge.prototype._onConsume = function(err, data) {
-    if (!err) {
-        this.opts.controller.onEvent(data.request, data.context);
+    if (err) {
+        this.opts.controller.onLog("onEvent failure: " + err);
         return;
     }
-    if (!this.opts.controller.onLog) {
-        return;
-    }
-    this.opts.controller.onLog(
-        "onEvent failure: " + err
-    );
+
+    this.opts.controller.onEvent(data.request, data.context);
 };
+
+Bridge.prototype._getBridgeContext = function(event) {
+    if (this.opts.disableContext) {
+        return Promise.resolve(null);
+    }
+
+    const context = new BridgeContext({
+        sender: event.user_id,
+        target: event.state_key,
+        room: event.room_id
+    });
+    const contextReady = context.get(this._roomStore, this._userStore)
+
+    return contextReady.return(context);
+}
 
 Bridge.prototype._updateIntents = function(event) {
     if (event.type === "m.room.member") {
@@ -984,57 +989,55 @@ function queueAlgorithm(event) {
 }
 
 class EventQueue {
-    constructor(opt, consumeFn) {
-        this.type = opt.type;
+    constructor(type, consumeFn) {
+        this.type = type;
         this._queues = {
             // $identifier: {
-            //  events: [ {data: promise: } ],
+            //  events: [ {dataReady: } ],
             //  consuming: true|false
             // }
         };
         this.consumeFn = consumeFn;
     }
 
-    push(event, data, promise) {
-        var identifier = this.type === "per_room" ? event.room_id : "none";
+    push(event, dataReady) {
+        const queue = this._getQueue(event);
+        queue.events.push({
+            dataReady: dataReady
+        });
+    }
+
+    _getQueue(event) {
+        const identifier = this.type === "per_room" ? event.room_id : "none";
         if (!this._queues[identifier]) {
             this._queues[identifier] = {
                 events: [],
                 consuming: false
             };
         }
-        this._queues[identifier].events.push({
-            data: data,
-            promise: promise
-        });
+        return this._queues[identifier];
     }
 
     consume() {
-        var self = this;
-        Object.keys(this._queues).forEach(function(identifier) {
-            if (!self._queues[identifier].consuming) {
-                self._queues[identifier].consuming = true;
-                self._takeNext(identifier);
+        Object.keys(this._queues).forEach((identifier) => {
+            if (!this._queues[identifier].consuming) {
+                this._queues[identifier].consuming = true;
+                this._takeNext(identifier);
             }
         });
-    };
+    }
 
     _takeNext(identifier) {
-        var self = this;
-        var events = this._queues[identifier].events;
+        const events = this._queues[identifier].events;
         if (events.length === 0) {
             this._queues[identifier].consuming = false;
             return;
         }
-        var entry = events.shift();
-        entry.promise.done(function() {
-            self.consumeFn(null, entry.data);
-            self._takeNext(identifier);
-        }, function(e) {
-            self.consumeFn(e, null);
-            self._takeNext(identifier);
-        });
-    };
+        const entry = events.shift();
+
+        entry.dataReady.asCallback(this.consumeFn);
+        entry.dataReady.finally(() => this._takeNext(identifier));
+    }
 
     static create(opts, consumeFn) {
         const type = opts.type;
@@ -1053,19 +1056,19 @@ class EventQueue {
 
 class EventQueueSingle extends EventQueue {
     constructor(consumeFn) {
-        super({type: "single"}, consumeFn);
+        super("single", consumeFn);
     }
 }
 
 class EventQueuePerRoom extends EventQueue {
     constructor(consumeFn) {
-        super({type: "per_room"}, consumeFn);
+        super("per_room", consumeFn);
     }
 }
 
 class EventQueueNone extends EventQueue {
     constructor(consumeFn) {
-        super({type: "none"}, consumeFn);
+        super("none", consumeFn);
     }
 
     push(event, data, promise) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -22,6 +22,7 @@ const MembershipCache = require("./components/membership-cache");
 const RoomLinkValidator = require("./components/room-link-validator").RoomLinkValidator;
 const RLVStatus = require("./components/room-link-validator").validationStatuses;
 const RoomUpgradeHandler = require("./components/room-upgrade-handler");
+const EventQueue = require("./components/event-queue").EventQueue;
 
 const log = require("./components/logging").get("bridge");
 
@@ -977,100 +978,6 @@ function queueAlgorithm(event) {
     // allow all other events continue concurrently.
     return null;
 }
-
-class EventQueue {
-    constructor(type, consumeFn) {
-        this.type = type;
-        this._queues = {
-            // $identifier: {
-            //  events: [ {dataReady: } ],
-            //  consuming: true|false
-            // }
-        };
-        this.consumeFn = consumeFn;
-    }
-
-    push(event, dataReady) {
-        const queue = this._getQueue(event);
-        queue.events.push({
-            dataReady: dataReady
-        });
-    }
-
-    _getQueue(event) {
-        const identifier = this.type === "per_room" ? event.room_id : "none";
-        if (!this._queues[identifier]) {
-            this._queues[identifier] = {
-                events: [],
-                consuming: false
-            };
-        }
-        return this._queues[identifier];
-    }
-
-    consume() {
-        Object.keys(this._queues).forEach((identifier) => {
-            if (!this._queues[identifier].consuming) {
-                this._queues[identifier].consuming = true;
-                this._takeNext(identifier);
-            }
-        });
-    }
-
-    _takeNext(identifier) {
-        const events = this._queues[identifier].events;
-        if (events.length === 0) {
-            this._queues[identifier].consuming = false;
-            return;
-        }
-        const entry = events.shift();
-
-        entry.dataReady.asCallback(this.consumeFn);
-        entry.dataReady.finally(() => this._takeNext(identifier));
-    }
-
-    static create(opts, consumeFn) {
-        const type = opts.type;
-        if (type == "single") {
-            return new EventQueueSingle(consumeFn);
-        }
-        if (type == "per_room") {
-            return new EventQueuePerRoom(consumeFn);
-        }
-        if (type == "none") {
-            return new EventQueueNone(consumeFn);
-        }
-        throw Error(`Invalid EventQueue type '${type}'.`);
-    }
-}
-
-class EventQueueSingle extends EventQueue {
-    constructor(consumeFn) {
-        super("single", consumeFn);
-    }
-}
-
-class EventQueuePerRoom extends EventQueue {
-    constructor(consumeFn) {
-        super("per_room", consumeFn);
-    }
-}
-
-class EventQueueNone extends EventQueue {
-    constructor(consumeFn) {
-        super("none", consumeFn);
-    }
-
-    push(event, data, promise) {
-        // consume the event instantly
-        promise.asCallback(this.consumeFn);
-    }
-
-    consume() {
-        // no-op for EventQueueNone
-    }
-}
-
 
 function BridgeContext(ctx) {
     this._ctx = ctx;

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -22,6 +22,8 @@ const MembershipCache = require("./components/membership-cache");
 const RoomLinkValidator = require("./components/room-link-validator").RoomLinkValidator;
 const RLVStatus = require("./components/room-link-validator").validationStatuses;
 const RoomUpgradeHandler = require("./components/room-upgrade-handler");
+const EventNotHandledError = require("./errors").EventNotHandledError;
+const InternalError = require("./errors").InternalError;
 const EventQueue = require("./components/event-queue").EventQueue;
 
 const log = require("./components/logging").get("bridge");
@@ -805,7 +807,12 @@ Bridge.prototype._onEvent = function(event) {
 
     this._queue.push(event, dataReadyLimited);
     this._queue.consume();
-    return request.getPromise();
+
+    return (
+        request
+        .getPromise()
+        .catch(EventNotHandledError, e => this._handleEventError(event, e))
+    );
 };
 
 /**
@@ -825,6 +832,10 @@ Bridge.prototype._limited = function(promise, request) {
 
 Bridge.prototype._onConsume = function(err, data) {
     if (err) {
+        // The data for the event could not be retrieved.
+        // In this case we reject the request and the event will be delivered
+        // by the HS to the bridge again.
+        data.request.reject();
         this.opts.controller.onLog("onEvent failure: " + err);
         return;
     }
@@ -846,6 +857,18 @@ Bridge.prototype._getBridgeContext = function(event) {
 
     return contextReady.return(context);
 }
+
+Bridge.prototype._handleEventError = function(event, error) {
+    if (!error instanceof EventNotHandledError) {
+        error = wrap(error, InternalError);
+    }
+    this._botIntent.signalBridgeError(
+        event.room_id,
+        event.event_id,
+        "Discord",
+        error.reason
+    );
+};
 
 Bridge.prototype._updateIntents = function(event) {
     if (event.type === "m.room.member") {
@@ -1041,7 +1064,7 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
         if (mxSender) {
             self.senders.matrix = mxSender;
         }
-    });
+    }).catch(e => {throw wrap(e, Error, "Could not retrieve bridge context");});
 };
 
 /**

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -189,7 +189,7 @@ function Bridge(opts) {
         getMembership: this._membershipCache.getMemberEntry.bind(this._membershipCache),
         getPowerLevelContent: this._getPowerLevelEntry.bind(this)
     };
-    this._queue = new EventQueue(this.opts.queue, this._onConsume.bind(this));
+    this._queue = EventQueue.create(this.opts.queue, this._onConsume.bind(this));
     this._prevRequestPromise = Promise.resolve();
     this._metrics = null; // an optional PrometheusMetrics instance
     this._roomLinkValidator = null;
@@ -813,15 +813,6 @@ Bridge.prototype._onEvent = function(event) {
         promise = context.get(this._roomStore, this._userStore);
     }
 
-    if (this.opts.queue.type === "none") { // consume as soon as we have context
-        promise.done(() => {
-            this._onConsume(null, data);
-        }, (err) => {
-            this._onConsume(err);
-        });
-        return request.getPromise();
-    }
-
     if (this.opts.queue.perRequest) {
         promise = Promise.settle([
             promise,
@@ -992,57 +983,101 @@ function queueAlgorithm(event) {
     return null;
 }
 
-function EventQueue(opts, consumeFn) {
-    this.type = opts.type;
-    this._queues = {
-        // $identifier: {
-        //  events: [ {data: promise: } ],
-        //  consuming: true|false
-        // }
+class EventQueue {
+    constructor(opt, consumeFn) {
+        this.type = opt.type;
+        this._queues = {
+            // $identifier: {
+            //  events: [ {data: promise: } ],
+            //  consuming: true|false
+            // }
+        };
+        this.consumeFn = consumeFn;
+    }
+
+    push(event, data, promise) {
+        var identifier = this.type === "per_room" ? event.room_id : "none";
+        if (!this._queues[identifier]) {
+            this._queues[identifier] = {
+                events: [],
+                consuming: false
+            };
+        }
+        this._queues[identifier].events.push({
+            data: data,
+            promise: promise
+        });
+    }
+
+    consume() {
+        var self = this;
+        Object.keys(this._queues).forEach(function(identifier) {
+            if (!self._queues[identifier].consuming) {
+                self._queues[identifier].consuming = true;
+                self._takeNext(identifier);
+            }
+        });
     };
-    this.consumeFn = consumeFn;
+
+    _takeNext(identifier) {
+        var self = this;
+        var events = this._queues[identifier].events;
+        if (events.length === 0) {
+            this._queues[identifier].consuming = false;
+            return;
+        }
+        var entry = events.shift();
+        entry.promise.done(function() {
+            self.consumeFn(null, entry.data);
+            self._takeNext(identifier);
+        }, function(e) {
+            self.consumeFn(e, null);
+            self._takeNext(identifier);
+        });
+    };
+
+    static create(opts, consumeFn) {
+        const type = opts.type;
+        if (type == "single") {
+            return new EventQueueSingle(consumeFn);
+        }
+        if (type == "per_room") {
+            return new EventQueuePerRoom(consumeFn);
+        }
+        if (type == "none") {
+            return new EventQueueNone(consumeFn);
+        }
+        throw Error(`Invalid EventQueue type '${type}'.`);
+    }
 }
 
-EventQueue.prototype.push = function(event, data, promise) {
-    var identifier = this.type === "per_room" ? event.room_id : "none";
-    if (!this._queues[identifier]) {
-        this._queues[identifier] = {
-            events: [],
-            consuming: false
-        };
+class EventQueueSingle extends EventQueue {
+    constructor(consumeFn) {
+        super({type: "single"}, consumeFn);
     }
-    this._queues[identifier].events.push({
-        data: data,
-        promise: promise
-    });
-};
+}
 
-EventQueue.prototype.consume = function() {
-    var self = this;
-    Object.keys(this._queues).forEach(function(identifier) {
-        if (!self._queues[identifier].consuming) {
-            self._queues[identifier].consuming = true;
-            self._takeNext(identifier);
-        }
-    });
-};
-
-EventQueue.prototype._takeNext = function(identifier) {
-    var self = this;
-    var events = this._queues[identifier].events;
-    if (events.length === 0) {
-        this._queues[identifier].consuming = false;
-        return;
+class EventQueuePerRoom extends EventQueue {
+    constructor(consumeFn) {
+        super({type: "per_room"}, consumeFn);
     }
-    var entry = events.shift();
-    entry.promise.done(function() {
-        self.consumeFn(null, entry.data);
-        self._takeNext(identifier);
-    }, function(e) {
-        self.consumeFn(e, null);
-        self._takeNext(identifier);
-    });
-};
+}
+
+class EventQueueNone extends EventQueue {
+    constructor(consumeFn) {
+        super({type: "none"}, consumeFn);
+    }
+
+    push(event, data, promise) {
+        // consume the event instantly
+        promise.asCallback(this.consumeFn);
+    }
+
+    consume() {
+        // no-op for EventQueueNone
+    }
+}
+
 
 function BridgeContext(ctx) {
     this._ctx = ctx;

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -798,10 +798,7 @@ Bridge.prototype._onEvent = function(event) {
 
     const request = this._requestFactory.newRequest({ data: event });
     const contextReady = this._getBridgeContext(event);
-    const dataReady = contextReady.then(c => ({
-        request: request,
-        context: c
-    }));
+    const dataReady = contextReady.then(context => ({ request, context }));
 
     const dataReadyLimited = this._limited(dataReady, request);
 
@@ -843,9 +840,9 @@ Bridge.prototype._onConsume = function(err, data) {
     this.opts.controller.onEvent(data.request, data.context);
 };
 
-Bridge.prototype._getBridgeContext = function(event) {
+Bridge.prototype._getBridgeContext = async function(event) {
     if (this.opts.disableContext) {
-        return Promise.resolve(null);
+        return null;
     }
 
     const context = new BridgeContext({
@@ -878,8 +875,8 @@ Bridge.prototype._handleEventError = function(event, error) {
  */
 Bridge.prototype._getUserRegex = function() {
     const reg = this.opts.registration;
-    const user_regexes = reg.namespaces["users"].map(o => o.regex);
-    return user_regexes.join("|");
+    const userRegexes = reg.namespaces["users"].map(o => o.regex);
+    return userRegexes.join("|");
 };
 
 Bridge.prototype._updateIntents = function(event) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -866,8 +866,20 @@ Bridge.prototype._handleEventError = function(event, error) {
         event.room_id,
         event.event_id,
         "Discord",
-        error.reason
+        error.reason,
+        this._getUserRegex()
     );
+};
+
+/**
+ * Returns a regex matching all users of the bridge.
+ *
+ * @return {string} Super regex composed of all user regexes.
+ */
+Bridge.prototype._getUserRegex = function() {
+    const reg = this.opts.registration;
+    const user_regexes = reg.namespaces["users"].map(o => o.regex);
+    return user_regexes.join("|");
 };
 
 Bridge.prototype._updateIntents = function(event) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -30,16 +30,6 @@ const INTENT_CULL_CHECK_PERIOD_MS = 1000 * 60; // once per minute
 // How long a given Intent object can hang around unused for.
 const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
 
-/* Returns a new promise which behaves like `main`, but holds settling back
- * until `prolonger` was settled.
- * @param {Promise} main The promise to mimick.
- * @param {Promise} prolonger The promise to wait for.
- * @return {Promise} A new promise behaving like main, but waiting for prolonger.
- */
-function prolong(main, prolonger) {
-    return Promise.all([main, prolonger.reflect()]).then(([m, _]) => m);
-}
-
 /**
  * @constructor
  * @param {Object} opts Options to pass to the bridge
@@ -811,7 +801,7 @@ Bridge.prototype._onEvent = function(event) {
     }));
 
     if (this.opts.queue.perRequest) {
-        dataReady = prolong(dataReady, this._prevRequestPromise)
+        dataReady = this._prevRequestPromise.finally(() => dataReady);
         this._prevRequestPromise = request.getPromise();
     }
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -859,6 +859,9 @@ Bridge.prototype._handleEventError = function(event, error) {
     if (!error instanceof EventNotHandledError) {
         error = wrap(error, InternalError);
     }
+    // TODO[V02460@gmail.com]: Send via different means when the bridge bot is
+    // unavailable. _MSC2162: Signaling Errors at Bridges_ will have details on
+    // how this should be done.
     this._botIntent.signalBridgeError(
         event.room_id,
         event.event_id,

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -801,15 +801,27 @@ Bridge.prototype._onEvent = function(event) {
         context: c
     }));
 
-    if (this.opts.queue.perRequest) {
-        dataReady = this._prevRequestPromise.finally(() => dataReady);
-        this._prevRequestPromise = request.getPromise();
-    }
+    const dataReadyLimited = this._limited(dataReady, request);
 
-    this._queue.push(event, dataReady);
+    this._queue.push(event, dataReadyLimited);
     this._queue.consume();
     return request.getPromise();
 };
+
+/**
+ * Returns a promise that is like `promise` but adheres to all necessary limits.
+ */
+Bridge.prototype._limited = function(promise, request) {
+    // queue.perRequest controls whether multiple request can be processed by
+    // the bridge at once.
+    if (this.opts.queue.perRequest) {
+        const promiseLimited = this._prevRequestPromise.reflect().return(promise);
+        this._prevRequestPromise = request.getPromise();
+        return promiseLimited;
+    }
+
+    return promise;
+}
 
 Bridge.prototype._onConsume = function(err, data) {
     if (err) {

--- a/lib/components/event-queue.js
+++ b/lib/components/event-queue.js
@@ -1,3 +1,5 @@
+const Bluebird = require("bluebird");
+
 /**
  * Handles the processing order of incoming Matrix events.
  *
@@ -73,7 +75,7 @@ class EventQueue {
         }
         const entry = events.shift();
 
-        entry.dataReady.asCallback(this.consumeFn);
+        Bluebird.resolve(entry.dataReady).asCallback(this.consumeFn);
         entry.dataReady.finally(() => this._takeNext(identifier));
     }
 

--- a/lib/components/event-queue.js
+++ b/lib/components/event-queue.js
@@ -136,9 +136,9 @@ class EventQueueNone extends EventQueue {
         super("none", consumeFn);
     }
 
-    push(event, data, promise) {
+    push(event, dataReady) {
         // consume the event instantly
-        promise.asCallback(this.consumeFn);
+        Bluebird.resolve(dataReady).asCallback(this.consumeFn);
     }
 
     consume() {

--- a/lib/components/event-queue.js
+++ b/lib/components/event-queue.js
@@ -1,4 +1,21 @@
+/**
+ * Handles the processing order of incoming Matrix events.
+ *
+ * Events can be pushed to the queue and will be processed when their
+ * corresponding data is ready and they are at the head of line.
+ * Different types of queues can be chosen for the processing order of events.
+ *
+ * Abstract Base Class. Use the factory method `create` to create new instances.
+ */
 class EventQueue {
+    /**
+     * Private constructor.
+     *
+     * @constructor
+     * @param {"none"\|"single"\|"per_room"} type The type of event queue to create.
+     * @param {consumeCallback} consumeFn Function which is called when an event
+     *     is consumed.
+     */
     constructor(type, consumeFn) {
         this.type = type;
         this._queues = {
@@ -10,6 +27,12 @@ class EventQueue {
         this.consumeFn = consumeFn;
     }
 
+    /**
+     * Push the event and its related data to the queue.
+     *
+     * @param {IMatrixEvent} event The event to enqueue.
+     * @param {Promise<object>} dataReady Promise containing data related to the event.
+     */
     push(event, dataReady) {
         const queue = this._getQueue(event);
         queue.events.push({
@@ -28,6 +51,11 @@ class EventQueue {
         return this._queues[identifier];
     }
 
+    /**
+     * Starts consuming the queue.
+     *
+     * As long as events are enqueued they will continue to be consumed.
+     */
     consume() {
         Object.keys(this._queues).forEach((identifier) => {
             if (!this._queues[identifier].consuming) {
@@ -49,6 +77,14 @@ class EventQueue {
         entry.dataReady.finally(() => this._takeNext(identifier));
     }
 
+    /**
+     * Factory for EventQueues.
+     *
+     * @param {"none"\|"single"\|"per_room"} opts.type Type of the queue to create.
+     * @param {consumeCallback} consumeFn Function which is called when an event
+     *     is consumed.
+     * @return {EventQueue} The newly created EventQueue.
+     */
     static create(opts, consumeFn) {
         const type = opts.type;
         if (type == "single") {
@@ -64,18 +100,33 @@ class EventQueue {
     }
 }
 
+/**
+ * EventQueue for which all events are enqueued in their order of arrival.
+ *
+ * The foremost event is processed as soon as its data is available.
+ */
 class EventQueueSingle extends EventQueue {
     constructor(consumeFn) {
         super("single", consumeFn);
     }
 }
 
+/**
+ * EventQueue for which one queue per room is utilized.
+ *
+ * Events at the head of line are processed as soon as their data is available.
+ */
 class EventQueuePerRoom extends EventQueue {
     constructor(consumeFn) {
         super("per_room", consumeFn);
     }
 }
 
+/**
+ * Dummy EventQueue for which no queue is utilized.
+ *
+ * Every event is handled as soon as its data is available.
+ */
 class EventQueueNone extends EventQueue {
     constructor(consumeFn) {
         super("none", consumeFn);
@@ -90,6 +141,12 @@ class EventQueueNone extends EventQueue {
         // no-op for EventQueueNone
     }
 }
+
+/**
+ * @callback consumeCallback
+ * @param {Error} [err] The error in case the data could not be retrieved.
+ * @param {object} data The data associated with the consumed event.
+ */
 
 module.exports = {
     EventQueue,

--- a/lib/components/event-queue.js
+++ b/lib/components/event-queue.js
@@ -1,0 +1,99 @@
+class EventQueue {
+    constructor(type, consumeFn) {
+        this.type = type;
+        this._queues = {
+            // $identifier: {
+            //  events: [ {dataReady: } ],
+            //  consuming: true|false
+            // }
+        };
+        this.consumeFn = consumeFn;
+    }
+
+    push(event, dataReady) {
+        const queue = this._getQueue(event);
+        queue.events.push({
+            dataReady: dataReady
+        });
+    }
+
+    _getQueue(event) {
+        const identifier = this.type === "per_room" ? event.room_id : "none";
+        if (!this._queues[identifier]) {
+            this._queues[identifier] = {
+                events: [],
+                consuming: false
+            };
+        }
+        return this._queues[identifier];
+    }
+
+    consume() {
+        Object.keys(this._queues).forEach((identifier) => {
+            if (!this._queues[identifier].consuming) {
+                this._queues[identifier].consuming = true;
+                this._takeNext(identifier);
+            }
+        });
+    }
+
+    _takeNext(identifier) {
+        const events = this._queues[identifier].events;
+        if (events.length === 0) {
+            this._queues[identifier].consuming = false;
+            return;
+        }
+        const entry = events.shift();
+
+        entry.dataReady.asCallback(this.consumeFn);
+        entry.dataReady.finally(() => this._takeNext(identifier));
+    }
+
+    static create(opts, consumeFn) {
+        const type = opts.type;
+        if (type == "single") {
+            return new EventQueueSingle(consumeFn);
+        }
+        if (type == "per_room") {
+            return new EventQueuePerRoom(consumeFn);
+        }
+        if (type == "none") {
+            return new EventQueueNone(consumeFn);
+        }
+        throw Error(`Invalid EventQueue type '${type}'.`);
+    }
+}
+
+class EventQueueSingle extends EventQueue {
+    constructor(consumeFn) {
+        super("single", consumeFn);
+    }
+}
+
+class EventQueuePerRoom extends EventQueue {
+    constructor(consumeFn) {
+        super("per_room", consumeFn);
+    }
+}
+
+class EventQueueNone extends EventQueue {
+    constructor(consumeFn) {
+        super("none", consumeFn);
+    }
+
+    push(event, data, promise) {
+        // consume the event instantly
+        promise.asCallback(this.consumeFn);
+    }
+
+    consume() {
+        // no-op for EventQueueNone
+    }
+}
+
+module.exports = {
+    EventQueue,
+    EventQueueSingle,
+    EventQueuePerRoom,
+    EventQueueNone,
+};

--- a/lib/components/event-queue.js
+++ b/lib/components/event-queue.js
@@ -87,6 +87,7 @@ class EventQueue {
      */
     static create(opts, consumeFn) {
         const type = opts.type;
+        /* eslint-disable no-use-before-define */
         if (type == "single") {
             return new EventQueueSingle(consumeFn);
         }
@@ -96,6 +97,7 @@ class EventQueue {
         if (type == "none") {
             return new EventQueueNone(consumeFn);
         }
+        /* eslint-enable no-use-before-define */
         throw Error(`Invalid EventQueue type '${type}'.`);
     }
 }

--- a/lib/components/event-queue.js
+++ b/lib/components/event-queue.js
@@ -12,7 +12,7 @@ class EventQueue {
      * Private constructor.
      *
      * @constructor
-     * @param {"none"\|"single"\|"per_room"} type The type of event queue to create.
+     * @param {"none"|"single"|"per_room"} type The type of event queue to create.
      * @param {consumeCallback} consumeFn Function which is called when an event
      *     is consumed.
      */
@@ -80,7 +80,7 @@ class EventQueue {
     /**
      * Factory for EventQueues.
      *
-     * @param {"none"\|"single"\|"per_room"} opts.type Type of the queue to create.
+     * @param {"none"|"single"|"per_room"} opts.type Type of the queue to create.
      * @param {consumeCallback} consumeFn Function which is called when an event
      *     is consumed.
      * @return {EventQueue} The newly created EventQueue.

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -548,7 +548,7 @@ Intent.prototype.setPresence = function(presence, status_msg=undefined) {
  * @param {string} eventId ID of the event for which the error occured.
  * @param {string} network_name Name of the bridged network.
  * @param {BridgeErrorReason} reason The reason why the bridge error occured.
- * @param {string[]} affected_users Optional. Matrix IDs of all affected users.
+ * @param {string} affected_users Regex matching all affected users.
  * @return {Promise}
  */
 Intent.prototype.signalBridgeError = function(
@@ -558,11 +558,6 @@ Intent.prototype.signalBridgeError = function(
     reason,
     affected_users
 ) {
-    if (!affected_users) {
-        const room = this.client.getRoom(roomId)
-        affected_users = room.getJoinedMembers().map(m => m.userId)
-    }
-
     return this.sendEvent(
         roomId,
         "m.room.bridge_error",

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -551,7 +551,7 @@ Intent.prototype.setPresence = function(presence, status_msg=undefined) {
  * @param {string} eventID ID of the event for which the error occured.
  * @param {string} networkName Name of the bridged network.
  * @param {BridgeErrorReason} reason The reason why the bridge error occured.
- * @param {string} affectedUsers Regex matching all affected users.
+ * @param {string[]} affectedUsers Array of regex matching all affected users.
  * @return {Promise}
  */
 Intent.prototype.signalBridgeError = function(

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -547,30 +547,30 @@ Intent.prototype.setPresence = function(presence, status_msg=undefined) {
 
 /**
  * Signals that an error occured while handling an event by the bridge.
- * @param {string} roomId ID of the room in which the error occured.
- * @param {string} eventId ID of the event for which the error occured.
- * @param {string} network_name Name of the bridged network.
+ * @param {string} roomID ID of the room in which the error occured.
+ * @param {string} eventID ID of the event for which the error occured.
+ * @param {string} networkName Name of the bridged network.
  * @param {BridgeErrorReason} reason The reason why the bridge error occured.
- * @param {string} affected_users Regex matching all affected users.
+ * @param {string} affectedUsers Regex matching all affected users.
  * @return {Promise}
  */
 Intent.prototype.signalBridgeError = function(
-    roomId,
-    eventId,
-    network_name,
+    roomID,
+    eventID,
+    networkName,
     reason,
-    affected_users
+    affectedUsers
 ) {
     return this.sendEvent(
-        roomId,
+        roomID,
         "de.nasnotfound.bridge_error",
         {
-            "network_name": network_name,
-            "reason": reason,
-            "affected_users": affected_users,
+            network_name: networkName,
+            reason: reason,
+            affected_users: affectedUsers,
             "m.relates_to": {
-                "rel_type": "m.reference",
-                "event_id": eventId,
+                rel_type: "m.reference",
+                event_id: eventID,
             },
         }
     );

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -535,12 +535,15 @@ Intent.prototype.setPresence = function(presence, status_msg=undefined) {
     });
 };
 
-// type BridgeErrorReason =
-//    |"m.event_not_handled"
-//    |"m.event_too_old"
-//    |"m.internal_error"
-//    |"m.foreign_network_error"
-//    |"m.event_unknown"
+/**
+ * @typedef {
+ *       "m.event_not_handled"
+ *     | "m.event_too_old"
+ *     | "m.internal_error"
+ *     | "m.foreign_network_error"
+ *     | "m.event_unknown"
+ * } BridgeErrorReason
+ */
 
 /**
  * Signals that an error occured while handling an event by the bridge.

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -535,6 +535,49 @@ Intent.prototype.setPresence = function(presence, status_msg=undefined) {
     });
 };
 
+// type BridgeErrorReason =
+//    |"m.event_not_handled"
+//    |"m.event_too_old"
+//    |"m.internal_error"
+//    |"m.foreign_network_error"
+//    |"m.event_unknown"
+
+/**
+ * Signals that an error occured while handling an event by the bridge.
+ * @param {string} roomId ID of the room in which the error occured.
+ * @param {string} eventId ID of the event for which the error occured.
+ * @param {string} network_name Name of the bridged network.
+ * @param {BridgeErrorReason} reason The reason why the bridge error occured.
+ * @param {string[]} affected_users Optional. Matrix IDs of all affected users.
+ * @return {Promise}
+ */
+Intent.prototype.signalBridgeError = function(
+    roomId,
+    eventId,
+    network_name,
+    reason,
+    affected_users
+) {
+    if (!affected_users) {
+        const room = this.client.getRoom(roomId)
+        affected_users = room.getJoinedMembers().map(m => m.userId)
+    }
+
+    return this.sendEvent(
+        roomId,
+        "m.room.bridge_error",
+        {
+            "network_name": network_name,
+            "reason": reason,
+            "affected_users": affected_users,
+            "m.relates_to": {
+                "rel_type": "m.reference",
+                "event_id": eventId,
+            },
+        }
+    );
+}
+
 /**
  * Get an event in a room.
  * This will automatically make the client join the room so they can get the

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -563,7 +563,7 @@ Intent.prototype.signalBridgeError = function(
 ) {
     return this.sendEvent(
         roomId,
-        "m.room.bridge_error",
+        "de.nasnotfound.bridge_error",
         {
             "network_name": network_name,
             "reason": reason,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,100 @@
+/**
+ * Append the old error message to the new one and keep its stack trace.
+ * Example:
+ *     throw wrap(e, HighLevelError, "This error is more specific");
+ */
+function wrap(
+    old_error,
+    new_error_type,
+    ...args
+) {
+    const new_error = new new_error_type(...args);
+    let append_msg;
+    if (old_error instanceof Error) {
+        append_msg = old_error.message;
+        new_error.stack = old_error.stack;
+    }
+    else {
+        append_msg = old_error.toString();
+    }
+    new_error.message += ":\n" + append_msg;
+    return new_error;
+}
+
+/**
+ * Sets the default message for the given error arguments.
+ */
+function default_message(args, msg) {
+    if (!(0 in args)) {
+        args[0] = msg;
+   }
+}
+
+/**
+ * Base Error for when the bride can not handle the event.
+ */
+class EventNotHandledError extends Error {
+    constructor(...args) {
+        default_message(args, "The event could not be handled by the bridge");
+        super(...args);
+        this.name = "EventNotHandledError";
+        this.reason = "m.event_not_handled";
+    }
+}
+
+/**
+ * The bridge decides that the event is too old to be sent.
+ */
+class EventTooOldError extends EventNotHandledError {
+    constructor(...args) {
+        default_message(args, "The event was too old to be handled by the bridge");
+        super(...args);
+        this.name = "EventTooOldError";
+        this.reason = "m.event_too_old";
+    }
+}
+
+/**
+ * An unexpected internal error occured while the bridge handled the event.
+ */
+class BridgeInternalError extends EventNotHandledError {
+    constructor(...args) {
+        default_message(args, "The bridge experienced an internal error");
+        super(...args);
+        this.name = "EventTooOldError";
+        this.reason = "m.internal_error";
+    }
+}
+
+/**
+ * The foreign network errored and the event couldn't be delivered.
+ */
+class ForeignNetworkError extends EventNotHandledError {
+    constructor(...args) {
+        default_message(args, "The foreign network experienced an error");
+        super(...args);
+        this.name = "ForeignNetworkError";
+        this.reason = "m.foreign_network_error";
+    }
+}
+
+/**
+ * The event is not understood by the bridge.
+ */
+class EventUnknownError extends EventNotHandledError {
+    constructor(...args) {
+        default_message(args, "The event is not known to the bridge");
+        super(...args);
+        this.name = "EventUnknownError";
+        this.reason = "m.event_unknown";
+    }
+}
+
+module.exports = {
+    wrap,
+    EventNotHandledError,
+    EventTooOldError,
+    BridgeInternalError,
+    ForeignNetworkError,
+    EventUnknownError,
+}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -4,30 +4,32 @@
  *     throw wrap(e, HighLevelError, "This error is more specific");
  */
 function wrap(
-    old_error,
-    new_error_type,
+    oldError,
+    newErrorType,
     ...args
 ) {
-    const new_error = new new_error_type(...args);
-    let append_msg;
-    if (old_error instanceof Error) {
-        append_msg = old_error.message;
-        new_error.stack = old_error.stack;
+    const newError = new newErrorType(...args);
+    let appendMsg;
+    if (oldError instanceof Error) {
+        appendMsg = oldError.message;
+        newError.stack = oldError.stack;
     }
     else {
-        append_msg = old_error.toString();
+        appendMsg = oldError.toString();
     }
-    new_error.message += ":\n" + append_msg;
-    return new_error;
+    newError.message += ":\n" + appendMsg;
+    return newError;
 }
 
 /**
- * Sets the default message for the given error arguments.
+ * Ensures `args` contain an error message defaulting to `defaultMsg`.
+ *
+ * Modifies `args`.
+ * @param {Array<str>} args The arguments to an Error object constructor.
+ * @param {str} defaultMsg The error message to default to if there is none given.
  */
-function default_message(args, msg) {
-    if (!(0 in args)) {
-        args[0] = msg;
-   }
+function defaultMessage(args, defaultMsg) {
+    args[0] = args[0] || defaultMsg;
 }
 
 /**
@@ -35,7 +37,7 @@ function default_message(args, msg) {
  */
 class EventNotHandledError extends Error {
     constructor(...args) {
-        default_message(args, "The event could not be handled by the bridge");
+        defaultMessage(args, "The event could not be handled by the bridge");
         super(...args);
         this.name = "EventNotHandledError";
         this.reason = "m.event_not_handled";
@@ -47,7 +49,7 @@ class EventNotHandledError extends Error {
  */
 class EventTooOldError extends EventNotHandledError {
     constructor(...args) {
-        default_message(args, "The event was too old to be handled by the bridge");
+        defaultMessage(args, "The event was too old to be handled by the bridge");
         super(...args);
         this.name = "EventTooOldError";
         this.reason = "m.event_too_old";
@@ -59,7 +61,7 @@ class EventTooOldError extends EventNotHandledError {
  */
 class BridgeInternalError extends EventNotHandledError {
     constructor(...args) {
-        default_message(args, "The bridge experienced an internal error");
+        defaultMessage(args, "The bridge experienced an internal error");
         super(...args);
         this.name = "EventTooOldError";
         this.reason = "m.internal_error";
@@ -71,7 +73,7 @@ class BridgeInternalError extends EventNotHandledError {
  */
 class ForeignNetworkError extends EventNotHandledError {
     constructor(...args) {
-        default_message(args, "The foreign network experienced an error");
+        defaultMessage(args, "The foreign network experienced an error");
         super(...args);
         this.name = "ForeignNetworkError";
         this.reason = "m.foreign_network_error";
@@ -83,7 +85,7 @@ class ForeignNetworkError extends EventNotHandledError {
  */
 class EventUnknownError extends EventNotHandledError {
     constructor(...args) {
-        default_message(args, "The event is not known to the bridge");
+        defaultMessage(args, "The event is not known to the bridge");
         super(...args);
         this.name = "EventUnknownError";
         this.reason = "m.event_unknown";

--- a/lib/exports.js
+++ b/lib/exports.js
@@ -40,10 +40,18 @@ module.exports.PrometheusMetrics.AgeCounters = require("./components/agecounters
 // Caches
 module.exports.MembershipCache = require("./components/membership-cache");
 
-//Logging
+// Logging
 module.exports.Logging = require("./components/logging");
 
 // Consts for RoomLinkValidator
 module.exports.RoomLinkValidatorStatus = require(
 	"./components/room-link-validator"
 ).validationStatuses;
+
+// Errors
+module.exports.EventNotHandledError = require("./errors").EventNotHandledError;
+module.exports.EventTooOldError = require("./errors").EventTooOldError;
+module.exports.BridgeInternalError = require("./errors").BridgeInternalError;
+module.exports.ForeignNetworkError = require("./errors").ForeignNetworkError;
+module.exports.EventUnknownError = require("./errors").EventUnknownError;
+module.exports.default_message = require("./errors").default_message;

--- a/spec/unit/event-queue.spec.js
+++ b/spec/unit/event-queue.spec.js
@@ -1,0 +1,201 @@
+"use strict";
+const log = require("../log");
+
+const EventQueue = require("../../lib/components/event-queue").EventQueue;
+
+
+// HELPER FUNCTIONS
+
+
+const SLEEP_TIME = 200; // ms
+const TOLERANCE = 20; // ms
+
+
+var customMatchers = {
+    toLast: function() {
+        return {
+            compare: function(duration, timesteps) {
+                const expectedDuration = SLEEP_TIME * timesteps;
+                const tolerance = TOLERANCE * timesteps;
+                const timeDifference = Math.abs(duration - expectedDuration);
+                return {
+                    pass:  timeDifference < tolerance,
+                    message: (
+                        `Expected duration to be ` +
+                        `${expectedDuration}±${tolerance}, but was ${duration}.`
+                    ),
+                };
+            }
+        }
+    },
+};
+
+
+async function getValueDelayed(value, timesteps) {
+    return new Promise(resolve =>
+        setTimeout(() => resolve(value), timesteps * SLEEP_TIME)
+    );
+}
+
+
+function timeRangeData(i, j, data) {
+    const time1 = data[i][0];
+    const time2 = data[j][0];
+
+    if (time1 > time2) {
+        // The happy path doesn't need an abs now :)
+        throw Error("time1 before time2");
+    }
+    return time2 - time1
+}
+
+
+// UNIT TESTS
+
+
+const eventRoomA = {room_id: "!A:room.org"}
+const eventRoomB = {room_id: "!B:room.org"}
+
+
+describe("EventQueue", function() {
+    let queue;
+    let callbackData; // array of (time, data) tuples, [0] is (start time, null)
+    let timeRange;
+    let addedDataCallback;
+    let errorCallback;
+
+    function eventQueueCallback(err, data) {
+        if (err) {
+            errorCallback(err);
+            return;
+        }
+        callbackData.push([new Date().getTime(), data]);
+        addedDataCallback(data);
+    }
+
+    beforeEach(
+    /** @this */
+    function() {
+        log.beforeEach(this);
+        jasmine.addMatchers(customMatchers);
+
+        callbackData = [[new Date().getTime(), null]];
+        timeRange = (i, j) => timeRangeData(i, j, callbackData);
+    });
+
+    // Those two tests are not required if the type signature of `create` is respected.
+    it("should not create queue if no type was given", function() {
+        const creation = () => EventQueue.create({}, (err, data) => {});
+        expect(creation).toThrowError();
+    });
+
+    it("should not create queue for an invalid type string", function() {
+        const creation = (() =>
+            EventQueue.create({type: "novalidtype"}, (err, data) => {})
+        );
+        expect(creation).toThrowError();
+    });
+
+
+    describe("EventQueueNone", function() {
+        beforeEach(function() {
+            queue = EventQueue.create({type: "none"}, eventQueueCallback);
+        });
+
+        it("should have the proper type", function() {
+            expect(queue.type).toEqual("none");
+        });
+
+        it("should allow consume on an empty queue", function() {
+            queue.consume();
+        });
+
+        it("should not show any head of line blocking", function() {
+            addedDataCallback = () => {
+                // EXPLAINATION
+                // Here we check if all 4 (5-1) callbacks finished
+                if (callbackData.length != 5) {
+                    return;
+                }
+                // Here we check if the time between the start of the test and
+                // the nth finished callback is t timesteps:
+                // expect(timeRange(0, n)).toLast(t);
+                expect(timeRange(0, 1)).toLast(0);
+                expect(timeRange(0, 2)).toLast(0);
+                expect(timeRange(0, 3)).toLast(1);
+                expect(timeRange(0, 4)).toLast(1);
+                done();
+            }
+
+            queue.push(eventRoomA, getValueDelayed("A1", 1));
+            queue.push(eventRoomA, Promise.resolve("A2"));
+            queue.push(eventRoomB, getValueDelayed("B1", 1));
+            queue.push(eventRoomB, Promise.resolve("B2"));
+            queue.consume();
+        });
+    });
+
+
+    describe("EventQueuePerRoom", function() {
+        beforeEach(function() {
+            queue = EventQueue.create({type: "per_room"}, eventQueueCallback);
+        });
+
+        it("should have the proper type", function() {
+            expect(queue.type).toEqual("per_room");
+        });
+
+        it("should allow consume on an empty queue", function() {
+            queue.consume();
+        });
+
+        it("should show head of line blocking per room", function(done) {
+            addedDataCallback = () => {
+                if (callbackData.length != 5) {
+                    return;
+                }
+                expect(timeRange(0, 1)).toLast(1);
+                expect(timeRange(0, 2)).toLast(1);
+                expect(timeRange(0, 3)).toLast(1);
+                expect(timeRange(0, 4)).toLast(1);
+                done();
+            }
+
+            queue.push(eventRoomA, getValueDelayed("A1", 1));
+            queue.push(eventRoomA, Promise.resolve("A2"));
+            queue.push(eventRoomB, getValueDelayed("B1", 1));
+            queue.push(eventRoomB, Promise.resolve("B2"));
+            queue.consume();
+        });
+    });
+
+
+    describe("EventQueueSingle", function() {
+        beforeEach(function() {
+            queue = EventQueue.create({type: "single"}, eventQueueCallback);
+        });
+
+        it("should have the proper type", function() {
+            expect(queue.type).toEqual("single");
+        });
+
+        it("should allow consume on an empty queue", function() {
+            queue.consume();
+        });
+
+        it("should show head of line blocking", function(done) {
+            addedDataCallback = () => {
+                if (callbackData.length != 3) {
+                    return;
+                }
+                expect(timeRange(0, 1)).toLast(1);
+                expect(timeRange(0, 2)).toLast(1);
+                done();
+            }
+
+            queue.push(eventRoomA, getValueDelayed("A", 1));
+            queue.push(eventRoomB, Promise.resolve("B"));
+            queue.consume();
+        });
+    });
+});

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -2,7 +2,6 @@
 var Intent = require("../..").Intent;
 var Promise = require("bluebird");
 var log = require("../log");
-const RoomMember = require("matrix-js-sdk").RoomMember;
 
 describe("Intent", function() {
     var intent, client, botClient;
@@ -397,7 +396,7 @@ describe("Intent", function() {
 
     describe("signaling bridge error", function() {
         const reason = "m.event_not_handled"
-        var affectedUsers, eventId, bridge, room, roomMembers;
+        var affectedUsers, eventId, bridge;
 
         beforeEach(function() {
             intent.opts.dontCheckPowerLevel = true;
@@ -413,12 +412,7 @@ describe("Intent", function() {
             });
             eventId = "$random:event.id";
             bridge = "International Pidgeon Post";
-            affectedUsers = [
-                "@pidgeonpost_1134:home.server",
-                "pidgeonpost_0001:home.server"
-            ];
-            roomMembers = affectedUsers.map(s => new RoomMember(roomId, s))
-            room = jasmine.createSpyObj("room", ["getJoinedMembers"]);
+            affectedUsers = "@_pidgeonpost_*:home.server";
         });
 
         it("should send an event", function(done) {
@@ -438,34 +432,6 @@ describe("Intent", function() {
                         "m.relates_to": {
                             "rel_type": "m.reference",
                             "event_id": eventId
-                        }
-                    }
-                );
-                expect(client.joinRoom).not.toHaveBeenCalled();
-                done();
-            });
-        });
-
-        it("should get room members and send an event", function(done) {
-            client.sendEvent.and.returnValue(Promise.resolve({
-                event_id: "$abra:kadabra"
-            }));
-
-            client.getRoom.and.returnValue(room);
-            room.getJoinedMembers.and.returnValue(roomMembers)
-            intent
-            .signalBridgeError(roomId, eventId, bridge, reason)
-            .then(() => {
-                expect(client.sendEvent).toHaveBeenCalledWith(
-                    roomId,
-                    "m.room.bridge_error",
-                    {
-                        "network_name": bridge,
-                        "reason": reason,
-                        "affected_users": affectedUsers,
-                        "m.relates_to": {
-                            "rel_type": "m.reference",
-                            "event_id": eventId,
                         }
                     }
                 );

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -424,7 +424,7 @@ describe("Intent", function() {
             .then(() => {
                 expect(client.sendEvent).toHaveBeenCalledWith(
                     roomId,
-                    "m.room.bridge_error",
+                    "de.nasnotfound.bridge_error",
                     {
                         "network_name": bridge,
                         "reason": reason,

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -412,7 +412,7 @@ describe("Intent", function() {
             });
             eventId = "$random:event.id";
             bridge = "International Pidgeon Post";
-            affectedUsers = "@_pidgeonpost_*:home.server";
+            affectedUsers = ["@_pidgeonpost_.*:home.server"];
         });
 
         it("should send an event", function(done) {

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -19,7 +19,7 @@ describe("Intent", function() {
         var clientFields = [
             "credentials", "joinRoom", "invite", "leave", "ban", "unban",
             "kick", "getStateEvent", "setPowerLevel", "sendTyping", "sendEvent",
-            "sendStateEvent", "setDisplayName", "setAvatarUrl", "getRoom"
+            "sendStateEvent", "setDisplayName", "setAvatarUrl",
         ];
         client = jasmine.createSpyObj("client", clientFields);
         client.credentials.userId = userId;


### PR DESCRIPTION
Adds the ability of signaling permanent errors occuring at the bridge to the SDK as well as automatic sending of these events. If the bridge rejects a room event that was handed to it, the room will automatically be notified of this error.

Mainly two things are added by this PR:
- A new method `signalBridgeError` is added to the `Intent` class.
- Rejection of requests provided to the `onEvent` callback will trigger the new intent.

Bridges should not have to do much work or work at all to profit from the new feature. Every bridge rejecting the request object delivered to it (as should be the case already) will profit. If a bridge swallows errors and simply logs them, code has to be changed to reject the request object properly.

In addition to these changes there is some refactoring and documentation going on, mainly related to the `EventQueue` class.
