### PR TITLE
Escape user IDs correctly

### DIFF
--- a/lib/models/users/matrix.js
+++ b/lib/models/users/matrix.js
@@ -59,7 +59,7 @@ MatrixUser.prototype.set = function(key, val) {
     this._data[key] = val;
 };
 
-/**u
+/**
  * Get the data value for the given key.
  * @param {string} key An arbitrary bridge-specific key.
  * @return {*} Stored data for this key. May be undefined.

--- a/lib/models/users/matrix.js
+++ b/lib/models/users/matrix.js
@@ -80,8 +80,9 @@ MatrixUser.prototype.serialize = function() {
  * Grammar taken from: https://matrix.org/docs/spec/appendices.html#identifier-grammar
  */
 MatrixUser.prototype.escapeUserId = function() {
-    // Currently Matrix accepts / in the userId, although going forward it will be removed.
-    const badChars = new Set(this.localpart.replace(/([A-z0-9]|-|\.|=|_)+/g, ""));
+    // NOTE: Currently Matrix accepts / in the userId, although going forward it will be removed.
+    // NOTE: We also allow uppercase for the time being.
+    const badChars = new Set(this.localpart.replace(/([A-Z]|[a-z]|[0-9]|-|\.|=|_)+/g, ""));
     let res = this.localpart;
     badChars.forEach((c) => {
         const hex = c.charCodeAt(0).toString(16).toLowerCase();

--- a/lib/models/users/matrix.js
+++ b/lib/models/users/matrix.js
@@ -5,9 +5,10 @@
  * @constructor
  * @param {string} userId The user_id of the user.
  * @param {Object=} data Serialized data values
- * @param {boolean} escape [true] Escape the user's localpart.
+ * @param {boolean} escape [true] Escape the user's localpart. Modify {@link MatrixUser~ESCAPE_DEFAULT}
+ *                  to change the default value.
  */
-function MatrixUser(userId, data, escape=true) {
+function MatrixUser(userId, data, escape=MatrixUser.ESCAPE_DEFAULT) {
     if (!userId) {
         throw new Error("Missing user_id");
     }
@@ -58,7 +59,7 @@ MatrixUser.prototype.set = function(key, val) {
     this._data[key] = val;
 };
 
-/**
+/**u
  * Get the data value for the given key.
  * @param {string} key An arbitrary bridge-specific key.
  * @return {*} Stored data for this key. May be undefined.
@@ -75,6 +76,7 @@ MatrixUser.prototype.serialize = function() {
     this._data.localpart = this.localpart;
     return this._data;
 };
+
 /**
  * Make a userId conform to the matrix spec using QP escaping.
  * Grammar taken from: https://matrix.org/docs/spec/appendices.html#identifier-grammar
@@ -94,5 +96,9 @@ MatrixUser.prototype.escapeUserId = function() {
     this.localpart = res;
     this.userId = `@${this.localpart}:${this.host}`;
 };
+
+MatrixUser.ESCAPE_DEFAULT = true;
+
+
 /** The MatrixUser class */
 module.exports = MatrixUser;

--- a/lib/models/users/matrix.js
+++ b/lib/models/users/matrix.js
@@ -97,6 +97,10 @@ MatrixUser.prototype.escapeUserId = function() {
     this.userId = `@${this.localpart}:${this.host}`;
 };
 
+/**
+ * @static
+ * This is a global variable to modify the default escaping behaviour of MatrixUser.
+ */
 MatrixUser.ESCAPE_DEFAULT = true;
 
 

--- a/spec/unit/matrix-user.spec.js
+++ b/spec/unit/matrix-user.spec.js
@@ -35,5 +35,13 @@ describe("MatrixUser", function() {
                 expect(user.getId()).toBe(expected[i]);
             })
         });
+        it("should not escape if ESCAPE_DEFAULT is false", function() {
+            MatrixUser.ESCAPE_DEFAULT = false;
+            expect(new MatrixUser("@$:localhost", null).getId()).toBe("@$:localhost");
+        });
+        it("should escape if ESCAPE_DEFAULT is true", function() {
+            MatrixUser.ESCAPE_DEFAULT = true;
+            expect(new MatrixUser("@$:localhost", null).getId()).toBe("@=24:localhost");
+        });
     });
 });

--- a/spec/unit/matrix-user.spec.js
+++ b/spec/unit/matrix-user.spec.js
@@ -21,13 +21,15 @@ describe("MatrixUser", function() {
                 "@woah=2a=2a=2a:localhost",
                 "@=d83d:localhost",
                 "@matrix.org=2fspec:localhost",
+                "@=5bdoggo=5d:localhost"
             ];
             [
                 new MatrixUser("@$:localhost", null, false),
                 new MatrixUser("@500$ dog:localhost", null, false),
                 new MatrixUser("@woah***:localhost", null, false),
                 new MatrixUser("@🐶:localhost", null, false),
-                new MatrixUser("@matrix.org/spec:localhost", null, false)
+                new MatrixUser("@matrix.org/spec:localhost", null, false),
+                new MatrixUser("@[doggo]:localhost", null, false)
             ].forEach((user, i) => {
                 user.escapeUserId();
                 expect(user.getId()).toBe(expected[i]);


### PR DESCRIPTION
This fixes #109. In addition, this PR adds a global variable to disable userid escaping for bridges that don't support it yet.