### PR TITLE
Bridge Error: Check if AS user regex has domain part

### DIFF
--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -547,7 +547,7 @@ Intent.prototype.setPresence = function(presence, status_msg=undefined) {
 
 /**
  * Signals that an error occured while handling an event by the bridge.
- *
+ * @throws if any of the `affectedUsers` lack a domain part
  * **Warning**: This function is unstable and is likely to change pending the outcome
  * of https://github.com/matrix-org/matrix-doc/pull/2162.
  * @param {string} roomID ID of the room in which the error occured.

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -547,7 +547,7 @@ Intent.prototype.setPresence = function(presence, status_msg=undefined) {
 
 /**
  * Signals that an error occured while handling an event by the bridge.
- * 
+ *
  * **Warning**: This function is unstable and is likely to change pending the outcome
  * of https://github.com/matrix-org/matrix-doc/pull/2162.
  * @param {string} roomID ID of the room in which the error occured.
@@ -558,13 +558,14 @@ Intent.prototype.setPresence = function(presence, status_msg=undefined) {
  * @param {string[]} affectedUsers Array of regex matching all affected users.
  * @return {Promise}
  */
-Intent.prototype.unstableSignalBridgeError = function(
+Intent.prototype.unstableSignalBridgeError = async function(
     roomID,
     eventID,
     networkName,
     reason,
-    affectedUsers
+    affectedUsers,
 ) {
+    affectedUsers.forEach(this._checkValidUserRegex.bind(this));
     return this.sendEvent(
         roomID,
         "de.nasnotfound.bridge_error",
@@ -578,6 +579,17 @@ Intent.prototype.unstableSignalBridgeError = function(
             },
         }
     );
+}
+
+/**
+ * Checks whether the regex contains a domain part and throws an Error on violation.
+ * @param {string} userRegex The AS user regex
+ */
+Intent.prototype._checkValidUserRegex = function(userRegex) {
+    const containsDomainPart = new RegExp(/@.+:.+/);
+    if (!containsDomainPart.test(userRegex)) {
+        throw new Error("The AS user regex must contain a domain part");
+    }
 }
 
 /**

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -439,5 +439,18 @@ describe("Intent", function() {
                 done();
             });
         });
+
+        it("should complain about the bad AS user regex", function(done) {
+            const badUserRegex = ["@_pidgeon_.*"];
+
+            client.sendEvent.and.returnValue(Promise.resolve({
+                event_id: "$abra:kadabra"
+            }));
+            intent
+            .unstableSignalBridgeError(roomId, eventId, bridge, reason, badUserRegex)
+            .then(() => done.fail("Invalid AS user regex was not detected."))
+            .catch(() => done()
+            );
+        });
     });
 });


### PR DESCRIPTION
This will prevent the bridge from sending a bridge error by rejecting `unstableSignalBridgeError` if the AS user regex does not contain a local part.

Signed-off-by: Kai A. Hiller <V02460@gmail.com>