### PR TITLE
Export and cleanup BridgeContext

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -1062,17 +1062,17 @@ class BridgeContext {
         this.senders = {
             matrix: new MatrixUser(ctx.sender),
             remote: null,
-            remotes: []
+            remotes: [],
         };
         this.targets = {
-            matrix: typeof(ctx.target) === "string" && ctx.target ? new MatrixUser(ctx.target) : null,
+            matrix: ctx.target ? new MatrixUser(ctx.target) : null,
             remote: null,
-            remotes: []
+            remotes: [],
         };
         this.rooms = {
             matrix: new MatrixRoom(ctx.room),
             remote: null,
-            remotes: []
+            remotes: [],
         };
     }
 
@@ -1083,36 +1083,36 @@ class BridgeContext {
      * @param {UserBridgeStore} userStore
      * @returns {Promise<void>}
      */
-    get(roomStore, userStore) {
-        var self = this;
-        return Promise.try(function() {
+    async get(roomStore, userStore) {
+        return Promise.try(() => {
             return [
-                roomStore.getLinkedRemoteRooms(self._ctx.room),
-                userStore.getRemoteUsersFromMatrixId(self._ctx.sender),
-                (self._ctx.target ?
-                    userStore.getRemoteUsersFromMatrixId(self._ctx.target) :
-                    Promise.resolve([])),
-                roomStore.getMatrixRoom(self._ctx.room),
-                userStore.getMatrixUser(self._ctx.sender)
+                roomStore.getLinkedRemoteRooms(this._ctx.room),
+                userStore.getRemoteUsersFromMatrixId(this._ctx.sender),
+                (this._ctx.target ?
+                    userStore.getRemoteUsersFromMatrixId(this._ctx.target) :
+                    Promise.resolve([])
+                ),
+                roomStore.getMatrixRoom(this._ctx.room),
+                userStore.getMatrixUser(this._ctx.sender)
             ];
-        }).spread(function(remoteRooms, remoteSenders, remoteTargets, mxRoom, mxSender) {
-            if (remoteRooms && remoteRooms.length > 0) {
-                self.rooms.remotes = remoteRooms;
-                self.rooms.remote = remoteRooms[0];
+        }).spread((remoteRooms, remoteSenders, remoteTargets, mxRoom, mxSender) => {
+            if (remoteRooms.length) {
+                this.rooms.remotes = remoteRooms;
+                this.rooms.remote = remoteRooms[0];
             }
-            if (remoteSenders && remoteSenders.length > 0) {
-                self.senders.remotes = remoteSenders;
-                self.senders.remote = remoteSenders[0];
+            if (remoteSenders.length) {
+                this.senders.remotes = remoteSenders;
+                this.senders.remote = remoteSenders[0];
             }
-            if (remoteTargets && remoteTargets.length > 0) {
-                self.targets.remotes = remoteTargets;
-                self.targets.remote = remoteTargets[0];
+            if (remoteTargets.length) {
+                this.targets.remotes = remoteTargets;
+                this.targets.remote = remoteTargets[0];
             }
             if (mxRoom) {
-                self.rooms.matrix = mxRoom;
+                this.rooms.matrix = mxRoom;
             }
             if (mxSender) {
-                self.senders.matrix = mxSender;
+                this.senders.matrix = mxSender;
             }
         }).catch(e => {throw wrap(e, Error, "Could not retrieve bridge context");});
     }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -981,8 +981,6 @@ Bridge.prototype._requestCheckToken = function(req, res) {
     return true;
 }
 
-module.exports = Bridge;
-
 function loadDatabase(path, Cls) {
     var defer = Promise.defer();
     var db = new Datastore({
@@ -1117,6 +1115,9 @@ class BridgeContext {
         .return(this);
     }
 }
+
+
+module.exports = { Bridge, BridgeContext };
 
 
 /**

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -1033,62 +1033,9 @@ function queueAlgorithm(event) {
     return null;
 }
 
-function BridgeContext(ctx) {
-    this._ctx = ctx;
-    this.senders = {
-        matrix: new MatrixUser(ctx.sender),
-        remote: null,
-        remotes: []
-    };
-    this.targets = {
-        matrix: typeof(ctx.target) === "string" && ctx.target ? new MatrixUser(ctx.target) : null,
-        remote: null,
-        remotes: []
-    };
-    this.rooms = {
-        matrix: new MatrixRoom(ctx.room),
-        remote: null,
-        remotes: []
-    };
-}
-
-BridgeContext.prototype.get = function(roomStore, userStore) {
-    var self = this;
-    return Promise.try(function() {
-        return [
-            roomStore.getLinkedRemoteRooms(self._ctx.room),
-            userStore.getRemoteUsersFromMatrixId(self._ctx.sender),
-            (self._ctx.target ?
-                userStore.getRemoteUsersFromMatrixId(self._ctx.target) :
-                Promise.resolve([])),
-            roomStore.getMatrixRoom(self._ctx.room),
-            userStore.getMatrixUser(self._ctx.sender)
-        ];
-    }).spread(function(remoteRooms, remoteSenders, remoteTargets, mxRoom, mxSender) {
-        if (remoteRooms && remoteRooms.length > 0) {
-            self.rooms.remotes = remoteRooms;
-            self.rooms.remote = remoteRooms[0];
-        }
-        if (remoteSenders && remoteSenders.length > 0) {
-            self.senders.remotes = remoteSenders;
-            self.senders.remote = remoteSenders[0];
-        }
-        if (remoteTargets && remoteTargets.length > 0) {
-            self.targets.remotes = remoteTargets;
-            self.targets.remote = remoteTargets[0];
-        }
-        if (mxRoom) {
-            self.rooms.matrix = mxRoom;
-        }
-        if (mxSender) {
-            self.senders.matrix = mxSender;
-        }
-    }).catch(e => {throw wrap(e, Error, "Could not retrieve bridge context");});
-};
-
 /**
- * @typedef Bridge~BridgeContext
- * @type {Object}
+ * Bridge context.
+ *
  * @property {Object} senders Data models on senders of this event
  * @property {MatrixUser} senders.matrix The sender of this event
  * @property {?RemoteUser} senders.remote The first linked remote sender: remotes[0]
@@ -1103,6 +1050,74 @@ BridgeContext.prototype.get = function(roomStore, userStore) {
  * @property {?RemoteRoom} rooms.remote The first linked remote room: remotes[0]
  * @property {RemoteRoom[]} rooms.remotes The linked remote rooms for this event
  */
+class BridgeContext {
+    /**
+     * @param {Object} ctx Event related data
+     * @param {string} ctx.sender Matrix user ID of the sender.
+     * @param {string=} ctx.target Matrix user ID of the target.
+     * @param {string} ctx.room Matrix room ID.
+     */
+    constructor(ctx) {
+        this._ctx = ctx;
+        this.senders = {
+            matrix: new MatrixUser(ctx.sender),
+            remote: null,
+            remotes: []
+        };
+        this.targets = {
+            matrix: typeof(ctx.target) === "string" && ctx.target ? new MatrixUser(ctx.target) : null,
+            remote: null,
+            remotes: []
+        };
+        this.rooms = {
+            matrix: new MatrixRoom(ctx.room),
+            remote: null,
+            remotes: []
+        };
+    }
+
+    /**
+     * Returns this instance after its initialization.
+     *
+     * @param {RoomBridgeStore} roomStore
+     * @param {UserBridgeStore} userStore
+     * @returns {Promise<void>}
+     */
+    get(roomStore, userStore) {
+        var self = this;
+        return Promise.try(function() {
+            return [
+                roomStore.getLinkedRemoteRooms(self._ctx.room),
+                userStore.getRemoteUsersFromMatrixId(self._ctx.sender),
+                (self._ctx.target ?
+                    userStore.getRemoteUsersFromMatrixId(self._ctx.target) :
+                    Promise.resolve([])),
+                roomStore.getMatrixRoom(self._ctx.room),
+                userStore.getMatrixUser(self._ctx.sender)
+            ];
+        }).spread(function(remoteRooms, remoteSenders, remoteTargets, mxRoom, mxSender) {
+            if (remoteRooms && remoteRooms.length > 0) {
+                self.rooms.remotes = remoteRooms;
+                self.rooms.remote = remoteRooms[0];
+            }
+            if (remoteSenders && remoteSenders.length > 0) {
+                self.senders.remotes = remoteSenders;
+                self.senders.remote = remoteSenders[0];
+            }
+            if (remoteTargets && remoteTargets.length > 0) {
+                self.targets.remotes = remoteTargets;
+                self.targets.remote = remoteTargets[0];
+            }
+            if (mxRoom) {
+                self.rooms.matrix = mxRoom;
+            }
+            if (mxSender) {
+                self.senders.matrix = mxSender;
+            }
+        }).catch(e => {throw wrap(e, Error, "Could not retrieve bridge context");});
+    }
+}
+
 
 /**
  * @typedef Bridge~ProvisionedUser

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -859,9 +859,8 @@ Bridge.prototype._getBridgeContext = async function(event) {
         target: event.type === "m.room.member" ? event.state_key : null,
         room: event.room_id
     });
-    const contextReady = context.get(this._roomStore, this._userStore)
 
-    return contextReady.return(context);
+    return context.get(this._roomStore, this._userStore);
 }
 
 Bridge.prototype._handleEventError = function(event, error) {
@@ -1081,7 +1080,7 @@ class BridgeContext {
      *
      * @param {RoomBridgeStore} roomStore
      * @param {UserBridgeStore} userStore
-     * @returns {Promise<void>}
+     * @returns {Promise<BridgeContext>}
      */
     async get(roomStore, userStore) {
         return Promise.try(() => {
@@ -1114,7 +1113,8 @@ class BridgeContext {
             if (mxSender) {
                 this.senders.matrix = mxSender;
             }
-        }).catch(e => {throw wrap(e, Error, "Could not retrieve bridge context");});
+        }).catch(e => {throw wrap(e, Error, "Could not retrieve bridge context");})
+        .return(this);
     }
 }
 

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -1,9 +1,17 @@
 "use strict";
 
+const Datastore = require("nedb");
+const Promise = require("bluebird");
+const fs = require("fs");
+const util = require("util");
+const yaml = require("js-yaml");
+
 const AppServiceRegistration = require("matrix-appservice").AppServiceRegistration;
 const AppService = require("matrix-appservice").AppService;
-const ClientFactory = require("./components/client-factory");
 const MatrixScheduler = require("matrix-js-sdk").MatrixScheduler;
+
+const BridgeContext = require("./components/bridge-context");
+const ClientFactory = require("./components/client-factory");
 const AppServiceBot = require("./components/app-service-bot");
 const RequestFactory = require("./components/request-factory");
 const Intent = require("./components/intent");
@@ -13,11 +21,6 @@ const EventBridgeStore = require("./components/event-bridge-store");
 const MatrixUser = require("./models/users/matrix");
 const MatrixRoom = require("./models/rooms/matrix");
 const PrometheusMetrics = require("./components/prometheusmetrics");
-const fs = require("fs");
-const yaml = require("js-yaml");
-const Promise = require("bluebird");
-const Datastore = require("nedb");
-const util = require("util");
 const MembershipCache = require("./components/membership-cache");
 const RoomLinkValidator = require("./components/room-link-validator").RoomLinkValidator;
 const RLVStatus = require("./components/room-link-validator").validationStatuses;
@@ -1030,94 +1033,8 @@ function queueAlgorithm(event) {
     return null;
 }
 
-/**
- * Bridge context.
- *
- * @property {Object} senders Data models on senders of this event
- * @property {MatrixUser} senders.matrix The sender of this event
- * @property {?RemoteUser} senders.remote The first linked remote sender: remotes[0]
- * @property {RemoteUser[]} senders.remotes The linked remote senders
- * @property {Object} targets Data models on targets (e.g. state_key in
- * m.room.member) of this event.
- * @property {?MatrixUser} targets.matrix The target of this event if applicable.
- * @property {?RemoteUser} targets.remote The first linked remote target: remotes[0]
- * @property {RemoteUser[]} targets.remotes The linked remote targets
- * @property {Object} rooms Data models on rooms concerning this event.
- * @property {MatrixRoom} rooms.matrix The room for this event.
- * @property {?RemoteRoom} rooms.remote The first linked remote room: remotes[0]
- * @property {RemoteRoom[]} rooms.remotes The linked remote rooms for this event
- */
-class BridgeContext {
-    /**
-     * @param {Object} ctx Event related data
-     * @param {string} ctx.sender Matrix user ID of the sender.
-     * @param {string=} ctx.target Matrix user ID of the target.
-     * @param {string} ctx.room Matrix room ID.
-     */
-    constructor(ctx) {
-        this._ctx = ctx;
-        this.senders = {
-            matrix: new MatrixUser(ctx.sender),
-            remote: null,
-            remotes: [],
-        };
-        this.targets = {
-            matrix: ctx.target ? new MatrixUser(ctx.target) : null,
-            remote: null,
-            remotes: [],
-        };
-        this.rooms = {
-            matrix: new MatrixRoom(ctx.room),
-            remote: null,
-            remotes: [],
-        };
-    }
 
-    /**
-     * Returns this instance after its initialization.
-     *
-     * @param {RoomBridgeStore} roomStore
-     * @param {UserBridgeStore} userStore
-     * @returns {Promise<BridgeContext>}
-     */
-    async get(roomStore, userStore) {
-        return Promise.try(() => {
-            return [
-                roomStore.getLinkedRemoteRooms(this._ctx.room),
-                userStore.getRemoteUsersFromMatrixId(this._ctx.sender),
-                (this._ctx.target ?
-                    userStore.getRemoteUsersFromMatrixId(this._ctx.target) :
-                    Promise.resolve([])
-                ),
-                roomStore.getMatrixRoom(this._ctx.room),
-                userStore.getMatrixUser(this._ctx.sender)
-            ];
-        }).spread((remoteRooms, remoteSenders, remoteTargets, mxRoom, mxSender) => {
-            if (remoteRooms.length) {
-                this.rooms.remotes = remoteRooms;
-                this.rooms.remote = remoteRooms[0];
-            }
-            if (remoteSenders.length) {
-                this.senders.remotes = remoteSenders;
-                this.senders.remote = remoteSenders[0];
-            }
-            if (remoteTargets.length) {
-                this.targets.remotes = remoteTargets;
-                this.targets.remote = remoteTargets[0];
-            }
-            if (mxRoom) {
-                this.rooms.matrix = mxRoom;
-            }
-            if (mxSender) {
-                this.senders.matrix = mxSender;
-            }
-        }).catch(e => {throw wrap(e, Error, "Could not retrieve bridge context");})
-        .return(this);
-    }
-}
-
-
-module.exports = { Bridge, BridgeContext };
+module.exports = Bridge;
 
 
 /**

--- a/lib/components/bridge-context.js
+++ b/lib/components/bridge-context.js
@@ -1,0 +1,92 @@
+const Promise = require("bluebird");
+
+const MatrixUser = require("../models/users/matrix");
+const MatrixRoom = require("../models/rooms/matrix");
+
+/**
+ * Bridge context.
+ *
+ * @property {Object} senders Data models on senders of this event
+ * @property {MatrixUser} senders.matrix The sender of this event
+ * @property {?RemoteUser} senders.remote The first linked remote sender: remotes[0]
+ * @property {RemoteUser[]} senders.remotes The linked remote senders
+ * @property {Object} targets Data models on targets (e.g. state_key in
+ * m.room.member) of this event.
+ * @property {?MatrixUser} targets.matrix The target of this event if applicable.
+ * @property {?RemoteUser} targets.remote The first linked remote target: remotes[0]
+ * @property {RemoteUser[]} targets.remotes The linked remote targets
+ * @property {Object} rooms Data models on rooms concerning this event.
+ * @property {MatrixRoom} rooms.matrix The room for this event.
+ * @property {?RemoteRoom} rooms.remote The first linked remote room: remotes[0]
+ * @property {RemoteRoom[]} rooms.remotes The linked remote rooms for this event
+ */
+class BridgeContext {
+    /**
+     * @param {Object} ctx Event related data
+     * @param {string} ctx.sender Matrix user ID of the sender.
+     * @param {string=} ctx.target Matrix user ID of the target.
+     * @param {string} ctx.room Matrix room ID.
+     */
+    constructor(ctx) {
+        this._ctx = ctx;
+        this.senders = {
+            matrix: new MatrixUser(ctx.sender),
+            remote: null,
+            remotes: [],
+        };
+        this.targets = {
+            matrix: ctx.target ? new MatrixUser(ctx.target) : null,
+            remote: null,
+            remotes: [],
+        };
+        this.rooms = {
+            matrix: new MatrixRoom(ctx.room),
+            remote: null,
+            remotes: [],
+        };
+    }
+
+    /**
+     * Returns this instance after its initialization.
+     *
+     * @param {RoomBridgeStore} roomStore
+     * @param {UserBridgeStore} userStore
+     * @returns {Promise<BridgeContext>}
+     */
+    async get(roomStore, userStore) {
+        return Promise.try(() => {
+            return [
+                roomStore.getLinkedRemoteRooms(this._ctx.room),
+                userStore.getRemoteUsersFromMatrixId(this._ctx.sender),
+                (this._ctx.target ?
+                    userStore.getRemoteUsersFromMatrixId(this._ctx.target) :
+                    Promise.resolve([])
+                ),
+                roomStore.getMatrixRoom(this._ctx.room),
+                userStore.getMatrixUser(this._ctx.sender)
+            ];
+        }).spread((remoteRooms, remoteSenders, remoteTargets, mxRoom, mxSender) => {
+            if (remoteRooms.length) {
+                this.rooms.remotes = remoteRooms;
+                this.rooms.remote = remoteRooms[0];
+            }
+            if (remoteSenders.length) {
+                this.senders.remotes = remoteSenders;
+                this.senders.remote = remoteSenders[0];
+            }
+            if (remoteTargets.length) {
+                this.targets.remotes = remoteTargets;
+                this.targets.remote = remoteTargets[0];
+            }
+            if (mxRoom) {
+                this.rooms.matrix = mxRoom;
+            }
+            if (mxSender) {
+                this.senders.matrix = mxSender;
+            }
+        }).catch(e => {throw wrap(e, Error, "Could not retrieve bridge context");})
+        .return(this);
+    }
+}
+
+module.exports = BridgeContext;

--- a/lib/exports.js
+++ b/lib/exports.js
@@ -26,8 +26,8 @@ module.exports.MatrixRoom = require("./models/rooms/matrix");
 module.exports.RemoteRoom = require("./models/rooms/remote");
 module.exports.StoredEvent = require("./models/events/event");
 
-module.exports.Bridge = require("./bridge").Bridge;
-module.exports.BridgeContext = require("./bridge").BridgeContext;
+module.exports.Bridge = require("./bridge");
+module.exports.BridgeContext = require("./components/bridge-context");
 module.exports.AppServiceRegistration = (
     require("matrix-appservice").AppServiceRegistration
 );

--- a/lib/exports.js
+++ b/lib/exports.js
@@ -26,7 +26,8 @@ module.exports.MatrixRoom = require("./models/rooms/matrix");
 module.exports.RemoteRoom = require("./models/rooms/remote");
 module.exports.StoredEvent = require("./models/events/event");
 
-module.exports.Bridge = require("./bridge");
+module.exports.Bridge = require("./bridge").Bridge;
+module.exports.BridgeContext = require("./bridge").BridgeContext;
 module.exports.AppServiceRegistration = (
     require("matrix-appservice").AppServiceRegistration
 );


### PR DESCRIPTION
The `BridgeContext` class is part of the public interface of the bridge (`controller.onEvent`), so it should be properly exported.

The PR also refactors the class to something appearing to be from this century.