### PR TITLE
Catch all request errors before returning from _onEvent

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -814,6 +814,12 @@ Bridge.prototype._onEvent = async function(event) {
         request
         .getPromise()
         .catch(EventNotHandledError, e => this._handleEventError(event, e))
+        .catch(e =>
+            this.opts.controller.onLog(
+                `Dropping event ${event.event_id} (${e.name})`,
+                false
+            )
+        )
     );
 };
 


### PR DESCRIPTION
Catches the error of the rejected request promise and logs it as responsible for dropping the event. By this `_onEvent` will never return a rejected promise.

Signed-off-by: Kai A. Hiller <V02460@gmail.com>