### PR TITLE
Remove old entries during upgrade

### DIFF
--- a/lib/components/room-bridge-store.js
+++ b/lib/components/room-bridge-store.js
@@ -420,6 +420,17 @@ RoomBridgeStore.prototype.removeEntriesByLinkData = function(data) {
     return this.delete(data);
 };
 
+/**
+ * Remove an existing entry based on the provided entry ID.
+ * @param {String} id The ID of the entry to remove.
+ * @return {Promise}
+ * @example
+ * store.removeEntryById("anid");
+ */
+RoomBridgeStore.prototype.removeEntryById = function(id) {
+    return this.delete({ id });
+}
+
 
 function createUniqueId(matrixRoomId, remoteRoomId, delimiter) {
     return (matrixRoomId || "") + delimiter + (remoteRoomId || "");

--- a/lib/components/room-upgrade-handler.js
+++ b/lib/components/room-upgrade-handler.js
@@ -63,52 +63,62 @@ class RoomUpgradeHandler {
         return true;
     }
 
-    _onJoinedNewRoom(oldRoomId, newRoomId) {
+    async _onJoinedNewRoom(oldRoomId, newRoomId) {
         log.debug(`Joined ${newRoomId}`);
         const intent = this._bridge.getIntent();
         const asBot = this._bridge.getBot();
         const roomStore = this._bridge.getRoomStore();
-        return roomStore.getEntriesByMatrixId(oldRoomId).then((entries) => {
-            console.log("Entries:", entries);
-            return entries.map((entry) => {
+        const entries = roomStore.getEntriesByMatrixId(oldRoomId);
+        let success = false;
+        for (const entry of entries) {
+            log.debug(`Migrating room entry ${entry.id}`);
+            const existingId = entry;
+            try {
                 const newEntry = (
                     this._opts.migrateEntry || this._migrateEntry)(entry, newRoomId);
                 if (!newEntry) {
-                    return Promise.resolve();
+                    continue;
                 }
-                return roomStore.upsertEntry(newEntry);
-            });
-        }).catch((ex) => {
-            log.warn("Failed to migrate room entries:", ex);
-        }).then(() => {
-            log.debug(`Migrated entries from ${oldRoomId} to ${newRoomId} successfully.`);
-            if (this._opts.onRoomMigrated) {
-                this._opts.onRoomMigrated(oldRoomId, newRoomId);
+                await roomStore.upsertEntry(newEntry);
+                success = true;
             }
+            catch (ex) {
+                log.error(`Failed to migrate room entry ${entry.id}.`);
+            }
+        }
+        // Upgrades are critical to get right, or a room will be stuck
+        // until someone manaually intervenes. It's important to continue
+        // migrating if at least one entry is successfully migrated.
+        if (!success) {
+            log.error("Failed to migrate room entries. Not continuing with migration.");
+            return false;
+        }
 
-            if (!this._opts.migrateGhosts) {
-                return Promise.resolve(false);
-            }
-            return asBot.getJoinedMembers(oldRoomId);
-        }).then((members) => {
-            if (members === false) {
-                return false;
-            }
+        log.debug(`Migrated entries from ${oldRoomId} to ${newRoomId} successfully.`);
+        if (this._opts.onRoomMigrated) {
+            // This may or may not be a promise, so await it.
+            await this._opts.onRoomMigrated(oldRoomId, newRoomId);
+        }
+
+        if (!this._opts.migrateGhosts) {
+            return false;
+        }
+        try {
+            const members = await asBot.getJoinedMembers(oldRoomId);
             const userIds = Object.keys(members).filter((u) => asBot.isRemoteUser(u));
             log.debug(`Migrating ${userIds.length} ghosts`);
-            return Promise.all(userIds.map((uId) => {
+            for (const userId of userIds) {
                 const i = this._bridge.getIntent(userId);
-                return Promise.all([i.leave(oldRoomId), i.join(newRoomId)]);
-            }).concat([
-                intent.leave(oldRoomId)
-            ]));
-        }).catch((ex) => {
-            log.warn("Failed to migrate room ghosts:", ex);
-        }).then((res) => {
-            if (res !== false) {
-                log.debug("Migrated all ghosts across");
+                await i.leave(oldRoomId);
+                await i.join(newRoomId);
             }
-        })
+            intent.leave(oldRoomId);
+        }
+        catch (ex) {
+            log.warn("Failed to migrate ghosts", ex);
+            return false;
+        }
+        return true;
     }
 
     _migrateEntry(entry, newRoomId) {

--- a/lib/components/room-upgrade-handler.js
+++ b/lib/components/room-upgrade-handler.js
@@ -79,6 +79,11 @@ class RoomUpgradeHandler {
                 if (!newEntry) {
                     continue;
                 }
+                // If migrateEntry changed the id of the room, then ensure
+                // that we remove the old one.
+                if (existingId !== newEntry.id) {
+                    await roomStore.removeEntryById(existingId);
+                }
                 await roomStore.upsertEntry(newEntry);
                 success = true;
             }


### PR DESCRIPTION
Bridges such as the IRC bridge store lots of information in the `entry.id` and subsequently everything gets borked on upgrade, as we don't modify the `id` of the entry. Typically how this works is that the IRC bridge will store the channel + network + **`matrix_room_id`** in the entry, and then will also try to fetch the entry based upon that string. 

Upgrades will update the entries contents, but not the id and thus everything expodes!

This PR changes things so that a changed `id` will be detected, and the old entry will be removed.