### PR TITLE
Always return request result when handing errors

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -811,19 +811,16 @@ Bridge.prototype._onEvent = async function(event) {
     this._queue.push(event, dataReadyLimited);
     this._queue.consume();
 
-    dataReady.catch(e => this._handleEventError(event, e));
+    const reqPromise = request.getPromise();
 
-    return (
-        request
-        .getPromise()
-        .catch(EventNotHandledError, e => this._handleEventError(event, e))
-        .catch(e =>
-            this.opts.controller.onLog(
-                `Dropping event ${event.event_id} (${e.name})`,
-                false
-            )
-        )
+    // Filter for bridge errors and emit them.
+    reqPromise.catch(
+        EventNotHandledError,
+        e => this._handleEventError(event, e)
     );
+
+    // We *must* return the result of the request.
+    return reqPromise;
 };
 
 /**


### PR DESCRIPTION
This change makes it so that we:
- Do not log when we drop events, the bridge itself can handle that.
- Always return the result of the request, as it's expected behavior
- Continue to report errors asynchronously 
- Do not send bridge errors when we fail to get context, because that's unhelpful.