### PR TITLE
Always return promises when handing events

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -772,8 +772,12 @@ Bridge.prototype._onAliasQuery = function(alias) {
     return Promise.resolve();
 };
 
+Bridge.prototype._onEvent = function (event) {
+    return Promise.cast(this.__onEvent(event));
+};
+
 // returns a Promise for the request linked to this event for testing.
-Bridge.prototype._onEvent = async function(event) {
+Bridge.prototype.__onEvent = async function(event) {
     const isCanonicalState = event.state_key === "";
     this._updateIntents(event);
     if (this.opts.suppressEcho &&

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -814,17 +814,15 @@ Bridge.prototype.__onEvent = async function(event) {
 
     this._queue.push(event, dataReadyLimited);
     this._queue.consume();
-
     const reqPromise = request.getPromise();
 
-    // Filter for bridge errors and emit them.
-    reqPromise.catch(
-        EventNotHandledError,
-        e => this._handleEventError(event, e)
-    );
-
     // We *must* return the result of the request.
-    return reqPromise;
+    return reqPromise.catch(
+        EventNotHandledError,
+        e => {
+            this._handleEventError(event, e)
+        }
+    );
 };
 
 /**


### PR DESCRIPTION
This fixes a bug where some bridges would rely on errors falling through for testing, which we would filter out accidentally. 