### PR TITLE
Add option to disable stores

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -709,7 +709,12 @@ Bridge.prototype.getIntentFromLocalpart = function(localpart, request) {
  * @param {Bridge~ProvisionedUser} provisionedUser Provisioning information.
  * @return {Promise} Resolved when provisioned.
  */
-Bridge.prototype.provisionUser = async function(matrixUser, provisionedUser) {
+Bridge.prototype.provisionUser = function (matrixUser, provisionedUser) {
+    // For backwards compat
+    return Promise.cast(this._provisionUser(matrixUser, provisionedUser));
+};
+
+Bridge.prototype._provisionUser = async function(matrixUser, provisionedUser) {
     await this._botClient.register(matrixUser.localpart);
 
     if (!this.disableStores) {
@@ -743,7 +748,12 @@ Bridge.prototype._onUserQuery = function(userId) {
     return Promise.resolve();
 };
 
-Bridge.prototype._onAliasQuery = async function(alias) {
+Bridge.prototype._onAliasQuery = function (alias) {
+    // For backwards compat
+    return Promise.cast(this.__onAliasQuery(alias));
+};
+
+Bridge.prototype.__onAliasQuery = async function(alias) {
     if (!this.opts.controller.onAliasQuery) {
         return;
     }

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -238,13 +238,13 @@ Bridge.prototype.loadDatabases = function() {
     }
     // Load up the databases if they provided file paths to them (or defaults)
     if (typeof this.opts.userStore === "string") {
-        this.opts.userStore = loadDatabase(self.opts.userStore, UserBridgeStore);
+        this.opts.userStore = loadDatabase(this.opts.userStore, UserBridgeStore);
     }
     if (typeof this.opts.roomStore === "string") {
-        this.opts.roomStore = loadDatabase(self.opts.roomStore, RoomBridgeStore);
+        this.opts.roomStore = loadDatabase(this.opts.roomStore, RoomBridgeStore);
     }
     if (typeof this.opts.eventStore === "string") {
-        this.opts.eventStore = loadDatabase(self.opts.eventStore, EventBridgeStore);
+        this.opts.eventStore = loadDatabase(this.opts.eventStore, EventBridgeStore);
     }
 
     // This works because if they provided a string we converted it to a Promise
@@ -341,7 +341,7 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
     this.appService = appServiceInstance || new AppService({
         homeserverToken: this.opts.registration.getHomeserverToken()
     });
-    this.appService.onUserQuery = this._onUserQuery.bind(this);
+    this.appService.onUserQuery = (userId) => Promise.cast(this._onUserQuery(userId));
     this.appService.onAliasQuery = this._onAliasQuery.bind(this);
     this.appService.on("event", this._onEvent.bind(this));
     this.appService.on("http-log", function(line) {
@@ -723,32 +723,34 @@ Bridge.prototype._provisionUser = async function(matrixUser, provisionedUser) {
     if (!this.disableStores) {
         await this._userStore.setMatrixUser(matrixUser);
         if (provisionedUser.remote) {
-            await self._userStore.linkUsers(matrixUser, provisionedUser.remote);
+            await this._userStore.linkUsers(matrixUser, provisionedUser.remote);
         }
     }
-    const userClient = self._clientFactory.getClientAs(matrixUser.getId());
+    const userClient = this._clientFactory.getClientAs(matrixUser.getId());
     if (provisionedUser.name) {
         await userClient.setDisplayName(provisionedUser.name);
     }
     if (provisionedUser.url) {
-        await userClient.setAvatarUrl(provisionedUser.name);
+        await userClient.setAvatarUrl(provisionedUser.url);
     }
 };
 
-Bridge.prototype._onUserQuery = function(userId) {
-    var self = this;
-    if (self.opts.controller.onUserQuery) {
-        var matrixUser = new MatrixUser(userId);
-        return Promise.resolve(
-            self.opts.controller.onUserQuery(matrixUser)
-        ).then(function(provisionedUser) {
-            if (!provisionedUser) {
-                throw new Error("Not provisioning user for this ID");
-            }
-            return self.provisionUser(matrixUser, provisionedUser);
-        });
+Bridge.prototype._onUserQuery = async function(userId) {
+    if (!this.opts.controller.onUserQuery) {
+        return;
     }
-    return Promise.resolve();
+    const matrixUser = new MatrixUser(userId);
+    try {
+        const provisionedUser = await this.opts.controller.onUserQuery(matrixUser);
+        if (!provisionedUser) {
+            log.warn(`Not provisioning user for ${userId}`);
+            return;
+        }
+        await this.provisionUser(matrixUser, provisionedUser);
+    }
+    catch (ex) {
+        log.error(`Failed _onUserQuery for ${userId}`, ex);
+    }
 };
 
 Bridge.prototype._onAliasQuery = function (alias) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -115,6 +115,10 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * parameters in {@link Bridge~onEvent}. Disabling the context makes the
  * bridge do fewer database lookups, but prevents there from being a
  * <code>context</code> parameter. Default: false.
+ * @param {boolean=} opts.disableStores True to disable enabling of stores.
+ * This should be used by bridges that use their own database instances and
+ * do not need any of the included store objects. This implies setting
+ * disableContext to True. Default: false.
  * @param {Object=} opts.roomLinkValidation Options to supply to the room link
  * validator. If not defined then all room links are accepted.
  * @param {string} opts.roomLinkValidation.ruleFile A file containing rules
@@ -143,6 +147,20 @@ function Bridge(opts) {
         throw new Error("controller.onEvent is a required function");
     }
 
+
+    if (opts.disableContext === undefined) {
+        opts.disableContext = false;
+    }
+
+    if (opts.disableStores === true) {
+        opts.disableStores = true;
+        opts.disableContext = true;
+    }
+    else {
+        opts.disableStores = false;
+    }
+
+
     opts.userStore = opts.userStore || "user-store.db";
     opts.roomStore = opts.roomStore || "room-store.db";
 
@@ -169,9 +187,6 @@ function Bridge(opts) {
     // Default: suppress echo -> True
     if (opts.suppressEcho === undefined) {
         opts.suppressEcho = true;
-    }
-    if (opts.disableContext === undefined) {
-        opts.disableContext = false;
     }
 
     // we'll init these at runtime
@@ -215,30 +230,32 @@ function Bridge(opts) {
  * @return {Promise} Resolved/rejected when the user/room databases have been loaded.
  */
 Bridge.prototype.loadDatabases = function() {
-    var self = this;
+    if (this.disableStores) {
+        return Promise.resolve();
+    }
     // Load up the databases if they provided file paths to them (or defaults)
-    if (typeof self.opts.userStore === "string") {
-        self.opts.userStore = loadDatabase(self.opts.userStore, UserBridgeStore);
+    if (typeof this.opts.userStore === "string") {
+        this.opts.userStore = loadDatabase(self.opts.userStore, UserBridgeStore);
     }
-    if (typeof self.opts.roomStore === "string") {
-        self.opts.roomStore = loadDatabase(self.opts.roomStore, RoomBridgeStore);
+    if (typeof this.opts.roomStore === "string") {
+        this.opts.roomStore = loadDatabase(self.opts.roomStore, RoomBridgeStore);
     }
-    if (typeof self.opts.eventStore === "string") {
-        self.opts.eventStore = loadDatabase(self.opts.eventStore, EventBridgeStore);
+    if (typeof this.opts.eventStore === "string") {
+        this.opts.eventStore = loadDatabase(self.opts.eventStore, EventBridgeStore);
     }
 
     // This works because if they provided a string we converted it to a Promise
     // which will be resolved when we have the db instance. If they provided a
     // db instance then this will resolve immediately.
     return Promise.all([
-        Promise.resolve(self.opts.userStore).then(function(db) {
-            self._userStore = db;
+        Promise.resolve(this.opts.userStore).then((db) => {
+            this._userStore = db;
         }),
-        Promise.resolve(self.opts.roomStore).then(function(db) {
-            self._roomStore = db;
+        Promise.resolve(this.opts.roomStore).then((db) => {
+            this._roomStore = db;
         }),
-        Promise.resolve(self.opts.eventStore).then(function(db) {
-            self._eventStore = db;
+        Promise.resolve(this.opts.eventStore).then((db) => {
+            this._eventStore = db;
         })
     ]);
 };

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -743,39 +743,34 @@ Bridge.prototype._onUserQuery = function(userId) {
     return Promise.resolve();
 };
 
-Bridge.prototype._onAliasQuery = function(alias) {
-    var self = this;
-    var remoteRoom = null;
-    var roomId;
-    if (self.opts.controller.onAliasQuery) {
-        return Promise.resolve(
-            self.opts.controller.onAliasQuery(alias, alias.split(":")[0].substring(1))
-        ).then(function(provisionedRoom) {
-            if (!provisionedRoom) {
-                throw new Error("Not provisioning room for this alias");
-            }
-            // do the HTTP hit
-            remoteRoom = provisionedRoom.remote;
-            return self._botClient.createRoom(
-                provisionedRoom.creationOpts
-            );
-        }).then(function(createRoomResponse) {
-            // persist the mapping in the store
-            roomId = createRoomResponse.room_id;
-            var matrixRoom = new MatrixRoom(roomId);
-            if (remoteRoom) {
-                return self._roomStore.linkRooms(matrixRoom, remoteRoom);
-            }
-            // store the matrix room only
-            return self._roomStore.setMatrixRoom(matrixRoom);
-        }).then(function() {
-            if (self.opts.controller.onAliasQueried) {
-                self.opts.controller.onAliasQueried(alias, roomId);
-            }
-        });
+Bridge.prototype._onAliasQuery = async function(alias) {
+    if (!this.opts.controller.onAliasQuery) {
+        return;
     }
-    return Promise.resolve();
-};
+    const aliasLocalpart = alias.split(":")[0].substring(1);
+    const provisionedRoom = await this.opts.controller.onAliasQuery(alias, aliasLocalpart);
+    if (!provisionedRoom) {
+        throw new Error("Not provisioning room for this alias");
+    }
+    const createRoomResponse = await this._botClient.createRoom(
+        provisionedRoom.creationOpts
+    );
+    const roomId = createRoomResponse.room_id;
+    if (!this.opts.disableStores) {
+        const matrixRoom = new MatrixRoom(roomId);
+        const remoteRoom = provisionedRoom.remote;
+        if (remoteRoom) {
+            await this._roomStore.linkRooms(matrixRoom, remoteRoom);
+        }
+        else {
+            // store the matrix room only
+            await this._roomStore.setMatrixRoom(matrixRoom);
+        }
+    }
+    if (this.opts.controller.onAliasQueried) {
+        await this.opts.controller.onAliasQueried(alias, roomId);
+    }
+}
 
 Bridge.prototype._onEvent = function (event) {
     return Promise.cast(this.__onEvent(event));

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -709,34 +709,22 @@ Bridge.prototype.getIntentFromLocalpart = function(localpart, request) {
  * @param {Bridge~ProvisionedUser} provisionedUser Provisioning information.
  * @return {Promise} Resolved when provisioned.
  */
-Bridge.prototype.provisionUser = function(matrixUser, provisionedUser) {
-    var self = this;
-    var promise = self._botClient.register(matrixUser.localpart).then(function() {
-        return self._userStore.setMatrixUser(matrixUser);
-    });
+Bridge.prototype.provisionUser = async function(matrixUser, provisionedUser) {
+    await this._botClient.register(matrixUser.localpart);
 
-    // storage promise chain
-    if (provisionedUser.remote) {
-        promise = promise.then(function() {
-            return self._userStore.linkUsers(
-                matrixUser, provisionedUser.remote
-            );
-        });
+    if (!this.disableStores) {
+        await this._userStore.setMatrixUser(matrixUser);
+        if (provisionedUser.remote) {
+            await self._userStore.linkUsers(matrixUser, provisionedUser.remote);
+        }
     }
-
-    // HTTP promise chain
-    var newUser = self._clientFactory.getClientAs(matrixUser.getId());
+    const userClient = self._clientFactory.getClientAs(matrixUser.getId());
     if (provisionedUser.name) {
-        promise = promise.then(function() {
-            return newUser.setDisplayName(provisionedUser.name);
-        });
+        await userClient.setDisplayName(provisionedUser.name);
     }
     if (provisionedUser.url) {
-        promise = promise.then(function() {
-            return newUser.setAvatarUrl(provisionedUser.url);
-        });
+        await userClient.setAvatarUrl(provisionedUser.name);
     }
-    return promise;
 };
 
 Bridge.prototype._onUserQuery = function(userId) {

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -217,7 +217,10 @@ function Bridge(opts) {
     this._metrics = null; // an optional PrometheusMetrics instance
     this._roomLinkValidator = null;
     if (opts.roomUpgradeOpts) {
-        this.opts.roomUpgradeOpts.consumeEvent = opts.roomUpgradeOpts.consumeEvent !== false ? true : false;
+        opts.roomUpgradeOpts.consumeEvent = opts.roomUpgradeOpts.consumeEvent !== false ? true : false;
+        if (this.opts.disableStores) {
+            opts.roomUpgradeOpts.migrateStoreEntries = false;
+        }
         this._roomUpgradeHandler = new RoomUpgradeHandler(opts.roomUpgradeOpts, this);
     }
     else {

--- a/lib/components/room-upgrade-handler.js
+++ b/lib/components/room-upgrade-handler.js
@@ -12,7 +12,10 @@ class RoomUpgradeHandler {
      */
     constructor(opts, bridge) {
         if (opts.migrateGhosts !== false) {
-            opts.migrateGhosts = opts.migrateGhosts !== false;
+            opts.migrateGhosts = true;
+        }
+        if (opts.migrateStoreEntries !== false) {
+            opts.migrateStoreEntries = true;
         }
         this._opts = opts;
         this._bridge = bridge;
@@ -67,38 +70,12 @@ class RoomUpgradeHandler {
         log.debug(`Joined ${newRoomId}`);
         const intent = this._bridge.getIntent();
         const asBot = this._bridge.getBot();
-        const roomStore = this._bridge.getRoomStore();
-        const entries = await roomStore.getEntriesByMatrixId(oldRoomId);
-        let success = false;
-        for (const entry of entries) {
-            log.debug(`Migrating room entry ${entry.id}`);
-            const existingId = entry.id;
-            try {
-                const newEntry = (
-                    this._opts.migrateEntry || this._migrateEntry)(entry, newRoomId);
-
-                if (!newEntry) {
-                    continue;
-                }
-
-                // If migrateEntry changed the id of the room, then ensure
-                // that we remove the old one.
-                if (existingId !== newEntry.id) {
-                    await roomStore.removeEntryById(existingId);
-                }
-                await roomStore.upsertEntry(newEntry);
-                success = true;
+        if (this._opts.migrateStoreEntries) {
+            const success = await this._migrateStoreEntries(oldRoomId, newRoomId);
+            if (!success) {
+                log.error("Failed to migrate room entries. Not continuing with migration.");
+                return false;
             }
-            catch (ex) {
-                log.error(`Failed to migrate room entry ${entry.id}.`);
-            }
-        }
-        // Upgrades are critical to get right, or a room will be stuck
-        // until someone manaually intervenes. It's important to continue
-        // migrating if at least one entry is successfully migrated.
-        if (!success) {
-            log.error("Failed to migrate room entries. Not continuing with migration.");
-            return false;
         }
 
         log.debug(`Migrated entries from ${oldRoomId} to ${newRoomId} successfully.`);
@@ -128,6 +105,39 @@ class RoomUpgradeHandler {
         return true;
     }
 
+    async _migrateStoreEntries(oldRoomId, newRoomId) {
+        const roomStore = this._bridge.getRoomStore();
+        const entries = await roomStore.getEntriesByMatrixId(oldRoomId);
+        let success = false;
+        // Upgrades are critical to get right, or a room will be stuck
+        // until someone manaually intervenes. It's important to continue
+        // migrating if at least one entry is successfully migrated.
+        for (const entry of entries) {
+            log.debug(`Migrating room entry ${entry.id}`);
+            const existingId = entry.id;
+            try {
+                const newEntry = (
+                    this._opts.migrateEntry || this._migrateEntry)(entry, newRoomId);
+
+                if (!newEntry) {
+                    continue;
+                }
+
+                // If migrateEntry changed the id of the room, then ensure
+                // that we remove the old one.
+                if (existingId !== newEntry.id) {
+                    await roomStore.removeEntryById(existingId);
+                }
+                await roomStore.upsertEntry(newEntry);
+                success = true;
+            }
+            catch (ex) {
+                log.error(`Failed to migrate room entry ${entry.id}.`);
+            }
+        }
+        return success;
+    }
+
     _migrateEntry(entry, newRoomId) {
         entry.matrix = new MatrixRoom(newRoomId, {
             name: entry.name,
@@ -152,7 +162,9 @@ module.exports = RoomUpgradeHandler;
   * needs of the old room and setup the new room (ex: Joining ghosts to the new room).
   * @property {bool} [consumeEvent=true] Consume tombstone or invite events that
   * are acted on by this handler.
-  * @property {bool} [migrateGhosts=true] If given, migrate all ghost users across to
+  * @property {bool} [migrateGhosts=true] If true, migrate all ghost users across to
+  * the new room.
+  * @property {bool} [migrateStoreEntries=true] If true, migrate all ghost users across to
   * the new room.
   */
 

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -680,13 +680,16 @@ describe("Bridge", function() {
             var mxUser = new MatrixUser("@foo:bar");
             var provisionedUser = {};
             var botClient = clients["bot"];
-            botClient.register.and.returnValue(Promise.reject({
-                errcode: "M_FORBIDDEN"
-            }));
-            bridge.provisionUser(mxUser, provisionedUser).catch(function() {
+            const err = { errcode: "M_FORBIDDEN" };
+            const errorPromise = Promise.reject(err)
+            botClient.register.and.returnValue(errorPromise);
+            bridge.provisionUser(mxUser, provisionedUser).catch(function(ex) {
+                expect(ex).toBe(err);
                 expect(botClient.register).toHaveBeenCalledWith(mxUser.localpart);
                 done();
             });
+            // This complains otherwise.
+            errorPromise.catch((ex) => {});
         });
     });
 

--- a/spec/unit/room-upgrade-handler.spec.js
+++ b/spec/unit/room-upgrade-handler.spec.js
@@ -4,7 +4,7 @@ describe("RoomLinkValidator", () => {
     describe("constructor", () => {
         it("should construct", () => {
             const ruh = new RoomUpgradeHandler({isOpts: true}, {isBridge: true});
-            expect(ruh._opts).toEqual({isOpts: true, migrateGhosts: true});
+            expect(ruh._opts).toEqual({isOpts: true, migrateGhosts: true, migrateStoreEntries: true});
             expect(ruh._bridge).toEqual({isBridge: true});
             expect(ruh._waitingForInvite.size).toEqual(0);
         });


### PR DESCRIPTION
We've made various hacks in some of the bridges to disable calls to the stores when we switched to other storage mechanisms, but this PR adds a switch to disable store access entirely within the bridge without causing breakages.

Where needed, this PR has refactored some functions into `async function`s for readability