### PR TITLE
Allow bridges to bind to a hostname

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -269,8 +269,9 @@ Bridge.prototype.loadDatabases = function() {
  * @param {Object} config Configuration options
  * @param {AppService=} appServiceInstance The AppService instance to attach to.
  * If not provided, one will be created.
+ * @param {String} hostname Optional hostname to bind to. (e.g. 0.0.0.0)
  */
-Bridge.prototype.run = function(port, config, appServiceInstance) {
+Bridge.prototype.run = function(port, config, appServiceInstance, hostname) {
     var self = this;
 
     // Load the registration file into an AppServiceRegistration object.
@@ -357,7 +358,7 @@ Bridge.prototype.run = function(port, config, appServiceInstance) {
         this._metrics.addAppServicePath(this);
     }
 
-    this.appService.listen(port);
+    this.appService.listen(port, hostname);
     return this.loadDatabases();
 };
 

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -430,7 +430,11 @@ describe("Bridge", function() {
     describe("run", function() {
         it("should invoke listen(port) on the AppService instance", function() {
             bridge.run(101, {}, appService);
-            expect(appService.listen).toHaveBeenCalledWith(101);
+            expect(appService.listen).toHaveBeenCalledWith(101, undefined);
+        });
+        it("should invoke listen(port, hostname) on the AppService instance", function() {
+            bridge.run(101, {}, appService, "foobar");
+            expect(appService.listen).toHaveBeenCalledWith(101, "foobar");
         });
     });
 


### PR DESCRIPTION
This has been a long requested feature, because presently bridges will bind to `0.0.0.0` which tends to leave everything quite exposed.

Fixes https://github.com/matrix-org/matrix-appservice-bridge/issues/113