### PR TITLE
Add note: replace localhost with server_name

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -163,6 +163,9 @@ slack from an inbound webhook). `qs.parse` is used to convert the POST string in
 The `Intent` object obtained from the bridge is scoped to a slack user ID specified in `getIntent`.
 This means that `sendText` will be sent as the `@slack_<user_name>:localhost` entity.
 
+Note that if your `server_name` is not `localhost` you must change the server part of the user ID
+in the `bridge.getIntent()` call.
+
 Then run the application service with `node index.js -p 9000` and send a message from Slack. It
 should then be passed through to the specified matrix room!
 


### PR DESCRIPTION
IMHO it was not clear that localhost is the servername.
(Because in the note which says that the AS user must be invited if the room ist non-public the example userid is `@slackbot:domain` not `:localhost`)