### PR TITLE
Remove usages of the v1 event format keys

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -797,7 +797,7 @@ Bridge.prototype.__onEvent = async function(event) {
     const isCanonicalState = event.state_key === "";
     this._updateIntents(event);
     if (this.opts.suppressEcho &&
-            this.opts.registration.isUserMatch(event.user_id, true)) {
+            this.opts.registration.isUserMatch(event.sender, true)) {
         return null;
     }
 
@@ -878,7 +878,7 @@ Bridge.prototype._getBridgeContext = async function(event) {
     }
 
     const context = new BridgeContext({
-        sender: event.user_id,
+        sender: event.sender,
         target: event.type === "m.room.member" ? event.state_key : null,
         room: event.room_id
     });

--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -747,10 +747,10 @@ Intent.prototype._ensureHasPowerLevelFor = function(roomId, eventType) {
     }
     return promise.then(function(eventContent) {
         self.opts.backingStore.setPowerLevelContent(roomId, eventContent);
-        var event = {
+        const event = {
             content: eventContent,
             room_id: roomId,
-            user_id: "",
+            sender: "",
             event_id: "_",
             state_key: "",
             type: "m.room.power_levels"

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -254,7 +254,7 @@ describe("Bridge", function() {
                     body: "oh noes!",
                     msgtype: "m.text"
                 },
-                user_id: "@virtual_foo:bar",
+                sender: "@virtual_foo:bar",
                 room_id: "!flibble:bar",
                 type: "m.room.message"
             };
@@ -273,7 +273,7 @@ describe("Bridge", function() {
                     body: "oh noes!",
                     msgtype: "m.text"
                 },
-                user_id: "@foo:bar",
+                sender: "@foo:bar",
                 room_id: "!flibble:bar",
                 type: "m.room.message"
             };
@@ -300,7 +300,7 @@ describe("Bridge", function() {
                     body: "oh noes!",
                     msgtype: "m.text"
                 },
-                user_id: "@alice:bar",
+                sender: "@alice:bar",
                 room_id: "!flibble:bar",
                 type: "m.room.message"
             };
@@ -332,7 +332,7 @@ describe("Bridge", function() {
                     membership: "invite"
                 },
                 state_key: "@bob:bar",
-                user_id: "@alice:bar",
+                sender: "@alice:bar",
                 room_id: "!flibble:bar",
                 type: "m.room.member"
             };
@@ -364,7 +364,7 @@ describe("Bridge", function() {
                     membership: "invite"
                 },
                 state_key: "@bob:bar",
-                user_id: "@alice:bar",
+                sender: "@alice:bar",
                 room_id: "!flibble:bar",
                 type: "m.room.member"
             };
@@ -396,7 +396,7 @@ describe("Bridge", function() {
                     body: "oh noes!",
                     msgtype: "m.text"
                 },
-                user_id: "@alice:bar",
+                sender: "@alice:bar",
                 room_id: "!flibble:bar",
                 type: "m.room.message"
             };
@@ -530,7 +530,7 @@ describe("Bridge", function() {
                     membership: "join"
                 },
                 state_key: "@foo:bar",
-                user_id: "@foo:bar",
+                sender: "@foo:bar",
                 room_id: "!flibble:bar",
                 type: "m.room.member"
             };
@@ -557,7 +557,7 @@ describe("Bridge", function() {
                     membership: "join"
                 },
                 state_key: "@foo:bar",
-                user_id: "@foo:bar",
+                sender: "@foo:bar",
                 room_id: "!flibble:bar",
                 type: "m.room.member"
             };
@@ -707,7 +707,6 @@ describe("Bridge", function() {
                 return bridge._onEvent({
                     type: "m.room.tombstone",
                     state_key: undefined,
-                    user_id: "@foo:bar",
                     sender: "@foo:bar",
                 });
             }).then(() => {
@@ -724,7 +723,6 @@ describe("Bridge", function() {
                 return bridge._onEvent({
                     type: "m.room.tombstone",
                     state_key: "fooobar",
-                    user_id: "@foo:bar",
                     sender: "@foo:bar",
                 });
             }).then(() => {
@@ -732,7 +730,6 @@ describe("Bridge", function() {
                 return bridge._onEvent({
                     type: "m.room.tombstone",
                     state_key: 212345,
-                    user_id: "@foo:bar",
                     sender: "@foo:bar",
                 });
             }).then(() => {
@@ -740,7 +737,6 @@ describe("Bridge", function() {
                 return bridge._onEvent({
                     type: "m.room.tombstone",
                     state_key: null,
-                    user_id: "@foo:bar",
                     sender: "@foo:bar",
                 });
             }).then(() => {
@@ -757,7 +753,6 @@ describe("Bridge", function() {
                 return bridge._onEvent({
                     type: "m.room.tombstone",
                     state_key: "",
-                    user_id: "@foo:bar",
                     sender: "@foo:bar",
                 });
             }).then(() => {

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -189,7 +189,7 @@ describe("Intent", function() {
                 },
                 state_key: "",
                 room_id: roomId,
-                user_id: "@example:localhost",
+                sender: "@example:localhost",
                 type: "m.room.power_levels",
                 event_id: "test2"
             };


### PR DESCRIPTION
Which in practice is just `user_id`.

Will also depend on https://github.com/matrix-org/matrix-appservice-node/pull/20, when it lands.

~This will require a version bump to 2.0 as existing bridges may depend on the user_id behavior.~ Actually, it won't. Synapse will send bridges V2 events regardless of the version of this library, so meh.