### PR TITLE
use winston.format.splat instead of util.inspect

### DIFF
--- a/lib/components/logging.js
+++ b/lib/components/logging.js
@@ -1,5 +1,3 @@
-const util = require("util");
-
 let winston = null;
 try {
     winston = require("winston");
@@ -43,17 +41,7 @@ class LogWrapper {
 
     error(...messageParts) { this._log(messageParts, 'error') }
 
-    _formatParts(messageParts) {
-        return messageParts.map((part) => {
-            if (typeof(part) === "object") {
-                return util.inspect(part);
-            }
-            return part;
-        });
-    }
-
     _log(messageParts, type) {
-        messageParts = this._formatParts(messageParts).join(" ");
         if (this.logger === null) {
             this.messages.push({type, messageParts});
             return;
@@ -64,10 +52,10 @@ class LogWrapper {
          * is emptied. */
         while (this.messages.length > 0) {
             const msg = this.messages[0];
-            this.logger[msg.type](msg.messageParts);
+            this.logger[msg.type](...msg.messageParts);
             this.messages.splice(0, 1);
         }
-        this.logger[type](messageParts);
+        this.logger[type](...messageParts);
     }
 }
 
@@ -129,6 +117,7 @@ class Logging {
                 name: "console",
                 level: config.console,
                 format: format.combine(
+                    format.splat(),
                     colorFn(),
                     formatterFn
                 )
@@ -172,6 +161,7 @@ class Logging {
         const logger = winston.createLogger({
             transports: this.transports,
             format: format.combine(
+                format.splat(),
                 format.timestamp({
                     format: this.config.timestampFormat,
                 }),


### PR DESCRIPTION
Not a lot of differences, but winston's splat is a bit more powerful than straight up utils.inspect, and maintained by others

see https://github.com/winstonjs/logform/blob/master/splat.js