### PR TITLE
Fix bug on PL events without `events` property

### DIFF
--- a/lib/components/intent.js
+++ b/lib/components/intent.js
@@ -761,7 +761,7 @@ Intent.prototype._ensureHasPowerLevelFor = function(roomId, eventType) {
         if (STATE_EVENT_TYPES.indexOf(eventType) !== -1) {
             defaultLevel = event.content.state_default;
         }
-        var requiredLevel = event.content.events[eventType] || defaultLevel;
+        var requiredLevel = (event.content.events && event.content.events[eventType]) ? event.content.events[eventType] : defaultLevel;
 
         // Parse out what level the client has by abusing the JS SDK
         var roomMember = new RoomMember(roomId, userId);


### PR DESCRIPTION
Ran into this while working on a bridge of my own, thanks to `@david:vovo.id.au` in the Matrix Bridging room for confirming.