### PR TITLE
Authenticate requests to bridge endpoints

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1010,7 +1010,10 @@ Bridge.prototype.registerBridgeGauges = function(counterFunc) {
 };
 
 Bridge.prototype._requestCheckToken = function(req, res) {
-    if (req.query.access_token !== this.opts.registration.hs_token) {
+    if (
+        req.query.access_token !== this.opts.registration.hs_token &&
+        req.headers["Authorization"] !== `Bearer ${this.opts.registration.hs_token}`
+    ) {
         res.status(403).send({
             errcode: "M_FORBIDDEN",
             error: "Bad token supplied,"

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -441,7 +441,7 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/(unstable|v1)/thirdparty/protocol/:protocol",
+            path: "/_matrix/app/:version/thirdparty/protocol/:protocol",
             handler: function(req, res) {
                 const protocol = req.params.protocol;
 
@@ -463,7 +463,7 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/(unstable|v1)/thirdparty/location/:protocol",
+            path: "/_matrix/app/:version/thirdparty/location/:protocol",
             handler: function(req, res) {
                 const protocol = req.params.protocol;
 
@@ -485,7 +485,7 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/(unstable|v1)/thirdparty/location",
+            path: "/_matrix/app/:version/thirdparty/location",
             handler: function(req, res) {
                 const alias = req.query.alias;
                 if (!alias) {
@@ -506,7 +506,7 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/(unstable|v1)/thirdparty/user/:protocol",
+            path: "/_matrix/app/:version/thirdparty/user/:protocol",
             handler: function(req, res) {
                 const protocol = req.params.protocol;
 
@@ -528,7 +528,7 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/(unstable|v1)/thirdparty/user",
+            path: "/_matrix/app/:version/thirdparty/user",
             handler: function(req, res) {
                 const userid = req.query.userid;
                 if (!userid) {

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -441,16 +441,9 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/:ver/thirdparty/protocol/:protocol",
+            path: "/_matrix/app/(unstable|v1)/thirdparty/protocol/:protocol",
             handler: function(req, res) {
-                if (req.params.ver !== "unstable") {
-                    res.status(404).json(
-                        {err: "Unrecognised API version " + req.params.ver}
-                    );
-                    return;
-                }
-
-                var protocol = req.params.protocol;
+                const protocol = req.params.protocol;
 
                 if (protocols.length && protocols.indexOf(protocol) === -1) {
                     res.status(404).json({err: "Unknown 3PN protocol " + protocol});
@@ -470,16 +463,9 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/:ver/thirdparty/location/:protocol",
+            path: "/_matrix/app/(unstable|v1)/thirdparty/location/:protocol",
             handler: function(req, res) {
-                if (req.params.ver !== "unstable") {
-                    res.status(404).json(
-                        {err: "Unrecognised API version " + req.params.ver}
-                    );
-                    return;
-                }
-
-                var protocol = req.params.protocol;
+                const protocol = req.params.protocol;
 
                 if (protocols.length && protocols.indexOf(protocol) === -1) {
                     res.status(404).json({err: "Unknown 3PN protocol " + protocol});
@@ -499,16 +485,9 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/:ver/thirdparty/location",
+            path: "/_matrix/app/(unstable|v1)/thirdparty/location",
             handler: function(req, res) {
-                if (req.params.ver !== "unstable") {
-                    res.status(404).json(
-                        {err: "Unrecognised API version " + req.params.ver}
-                    );
-                    return;
-                }
-
-                var alias = req.query.alias;
+                const alias = req.query.alias;
                 if (!alias) {
                     res.status(400).send({err: "Missing 'alias' parameter"});
                     return;
@@ -527,16 +506,9 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/:ver/thirdparty/user/:protocol",
+            path: "/_matrix/app/(unstable|v1)/thirdparty/user/:protocol",
             handler: function(req, res) {
-                if (req.params.ver !== "unstable") {
-                    res.status(404).json(
-                        {err: "Unrecognised API version " + req.params.ver}
-                    );
-                    return;
-                }
-
-                var protocol = req.params.protocol;
+                const protocol = req.params.protocol;
 
                 if (protocols.length && protocols.indexOf(protocol) === -1) {
                     res.status(404).json({err: "Unknown 3PN protocol " + protocol});
@@ -556,16 +528,9 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
 
         this.addAppServicePath({
             method: "GET",
-            path: "/_matrix/app/:ver/thirdparty/user",
+            path: "/_matrix/app/(unstable|v1)/thirdparty/user",
             handler: function(req, res) {
-                if (req.params.ver !== "unstable") {
-                    res.status(404).json(
-                        {err: "Unrecognised API version " + req.params.ver}
-                    );
-                    return;
-                }
-
-                var userid = req.query.userid;
+                const userid = req.query.userid;
                 if (!userid) {
                     res.status(400).send({err: "Missing 'userid' parameter"});
                     return;

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -566,7 +566,7 @@ Bridge.prototype.addAppServicePath = function(opts) {
     //     unrecognised API versions
     // Consider automatic "/_matrix/app/:version" path prefix
     app[opts.method.toLowerCase()](opts.path, (req, res, ...args) => {
-        if (opts.checkToken && !this._requestCheckToken(req)) {
+        if (opts.checkToken && !this.requestCheckToken(req)) {
             return res.status(403).send({
                 errcode: "M_FORBIDDEN",
                 error: "Bad token supplied,"
@@ -977,7 +977,13 @@ Bridge.prototype.registerBridgeGauges = function(counterFunc) {
     });
 };
 
-Bridge.prototype._requestCheckToken = function(req) {
+/**
+ * Check a express Request to see if it's correctly
+ * authenticated (includes the hsToken). The query parameter `access_token`
+ * and the Authorization header are checked.
+ * @returns {Boolean} True if authenticated, False if not.
+ */
+Bridge.prototype.requestCheckToken = function(req) {
     if (
         req.query.access_token !== this.opts.registration.hs_token &&
         req.headers["Authorization"] !== `Bearer ${this.opts.registration.hs_token}`

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -142,7 +142,7 @@ const INTENT_CULL_EVICT_AFTER_MS = 1000 * 60 * 15; // 15 minutes
  * to trigger a reload of the rules file.
  * Default: false
  * @param {string} opts.authenticateThirdpartyEndpoints Should the bridge authenticate
- * requests to thirdparty endpoints. This is false by default to be backwards compatible
+ * requests to third party endpoints. This is false by default to be backwards-compatible
  * with Synapse.
  * @param {RoomUpgradeHandler~Options} opts.roomUpgradeOpts Options to supply to
  * the room upgrade handler. If not defined then upgrades are NOT handled by the bridge.

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -478,6 +478,9 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
                     return;
                 }
 
+                // Do not leak access token to function
+                delete req.query.access_token;
+
                 getLocationFunc(protocol, req.query).then(
                     function(result) { res.status(200).json(result) },
                     function(e) { _respondErr(e, res) }
@@ -522,6 +525,9 @@ Bridge.prototype._customiseAppserviceThirdPartyLookup = function(lookupControlle
                     res.status(404).json({err: "Unknown 3PN protocol " + protocol});
                     return;
                 }
+
+                // Do not leak access token to function
+                delete req.query.access_token;
 
                 getUserFunc(protocol, req.query).then(
                     function(result) { res.status(200).json(result) },

--- a/src/components/prometheusmetrics.js
+++ b/src/components/prometheusmetrics.js
@@ -333,6 +333,9 @@ PrometheusMetrics.prototype.addAppServicePath = function(bridge) {
     bridge.addAppServicePath({
         method: "GET",
         path: "/metrics",
+        // TODO: Ideally these metrics would be on a different port.
+        // For now, leave this unauthenticated.
+        checkToken: false,
         handler: function(req, res) {
             this.refresh();
 


### PR DESCRIPTION
This fixes a bug where we were previously not checking the hsToken on several bridge endpoints. 