### PR TITLE
Add support for alternative registers for metrics

### DIFF
--- a/changelog.d/169.feature
+++ b/changelog.d/169.feature
@@ -1,0 +1,2 @@
+Allow bridges to provide their own prometheus metrics Register
+and disable the default metrics endpoint

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -938,20 +938,22 @@ Bridge.prototype._getPowerLevelEntry = function(roomId) {
  * serve the "/metrics" page in the usual way.
  * The instance will automatically register the Matrix SDK metrics by calling
  * {PrometheusMetrics~registerMatrixSdkMetrics}.
+ * @param {boolean} registerEndpoint Register the /metrics endpoint on the appservice HTTP server. Defaults to true.
+ * @param {Registry?} registry Optionally provide an alternative registry for metrics.
  */
-Bridge.prototype.getPrometheusMetrics = function() {
+Bridge.prototype.getPrometheusMetrics = function(registerEndpoint = true, registry = undefined) {
     if (this._metrics) {
         return this._metrics;
     }
 
-    var metrics = this._metrics = new PrometheusMetrics();
+    const metrics = this._metrics = new PrometheusMetrics(registry);
 
     metrics.registerMatrixSdkMetrics();
 
     // TODO(paul): register some bridge-wide standard ones here
 
     // In case we're called after .run()
-    if (this.appService) {
+    if (this.appService && registerEndpoint) {
         metrics.addAppServicePath(this);
     }
 

--- a/src/components/prometheusmetrics.ts
+++ b/src/components/prometheusmetrics.ts
@@ -276,7 +276,7 @@ export class PrometheusMetrics {
             labelNames: opts.labels || [],
             help: opts.help,
             name: name,
-            registers: [ this.register ]
+            registers: [this.register]
         });
 
         if (refresh) {
@@ -306,7 +306,7 @@ export class PrometheusMetrics {
                 name,
                 help: opts.help,
                 labelNames: opts.labels || [],
-                registers: [ this.register ]
+                registers: [this.register]
             });
 
         return counter;
@@ -345,7 +345,7 @@ export class PrometheusMetrics {
                 name,
                 help: opts.help,
                 labelNames: opts.labels || [],
-                registers: [ this.register ]
+                registers: [this.register]
             });
 
         return timer;


### PR DESCRIPTION
This allows us to provide a alternative register for bridges, for example a threaded register on a different worker thread :). This change also allows bridges to opt out of binding /metrics to the appservice server.