### PR TITLE
Run build on local install

### DIFF
--- a/changelog.d/178.misc
+++ b/changelog.d/178.misc
@@ -1,0 +1,1 @@
+Run NPM `build` on `prepublish`.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:ts": "eslint -c .eslintrcts.json --max-warnings 0 src/**/*.ts",
     "test": "BLUEBIRD_DEBUG=1 jasmine --stop-on-failure=true",
     "check": "npm run lint && npm test",
-    "ci-test": "BLUEBIRD_DEBUG=1 nyc -x \"**/spec/**\" --report text jasmine"
+    "ci-test": "BLUEBIRD_DEBUG=1 nyc -x \"**/spec/**\" --report text jasmine",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This runs the build step before publishing AND when the repository is installed standalone, which will fix the test failures.