### PR TITLE
Await for a Bridge to listen to its port

### DIFF
--- a/changelog.d/191.bugfix
+++ b/changelog.d/191.bugfix
@@ -1,0 +1,1 @@
+Bridge.run() now throws if it fails to listen to a port instead of creating a floating promise

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -376,11 +376,10 @@ Bridge.prototype.run = function(port, config, appServiceInstance, hostname) {
     }
 
     // We MUST return a Bluebird-Promise instead of a Promise.
-    // This is needed by many tests in this repo.
-    return new Bluebird(async() => {
+    // promise.done() is used by many tests in this repo.
+    return this.loadDatabases().then(async() => {
         await this.appService.listen(port, hostname);
-        return this.loadDatabases();
-    })
+    });
 };
 
 /**

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -289,7 +289,7 @@ Bridge.prototype.loadDatabases = function() {
  * If not provided, one will be created.
  * @param {String} hostname Optional hostname to bind to. (e.g. 0.0.0.0)
  */
-Bridge.prototype.run = function(port, config, appServiceInstance, hostname) {
+Bridge.prototype.run = async function(port, config, appServiceInstance, hostname) {
     var self = this;
 
     // Load the registration file into an AppServiceRegistration object.
@@ -374,7 +374,7 @@ Bridge.prototype.run = function(port, config, appServiceInstance, hostname) {
         this._metrics.addAppServicePath(this);
     }
 
-    this.appService.listen(port, hostname);
+    await this.appService.listen(port, hostname);
     return this.loadDatabases();
 };
 


### PR DESCRIPTION
Fixes #192 

This allows for errors of `.listen` to bubble up and get handled.