### PR TITLE
Fix usage of deferPromise

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -41,7 +41,7 @@ const RoomUpgradeHandler = require("./components/room-upgrade-handler");
 const EventNotHandledError = require("./errors").EventNotHandledError;
 const InternalError = require("./errors").InternalError;
 const EventQueue = require("./components/event-queue").EventQueue;
-const defer = require("./utils/promiseutil").defer;
+const deferPromise = require("./utils/promiseutil").defer;
 
 const log = require("./components/logging").get("bridge");
 
@@ -1010,7 +1010,7 @@ Bridge.prototype.requestCheckToken = function(req) {
 }
 
 function loadDatabase(path, Cls) {
-    const defer = defer();
+    const defer = deferPromise();
     var db = new Datastore({
         filename: path,
         autoload: true,


### PR DESCRIPTION
In the function loadDatabase we use `const defer = defer()`. This means the second `defer` is not the imported function, but the undefined variable of the local scope.