### PR TITLE
Drop request library

### DIFF
--- a/changelog.d/197.misc
+++ b/changelog.d/197.misc
@@ -1,0 +1,1 @@
+Remove `request` dependency

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "nedb": "^1.8.0",
     "nopt": "^4.0.3",
     "p-queue": "^6.6.0",
-    "prom-client": "^12.0.0",
-    "request": "^2.88.2"
+    "prom-client": "^12.0.0"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.32",


### PR DESCRIPTION
Just like https://github.com/matrix-org/matrix-appservice-node/pull/25, we don't use it.