### PR TITLE
Use provided register for metrics

### DIFF
--- a/changelog.d/201.bugfix
+++ b/changelog.d/201.bugfix
@@ -1,0 +1,1 @@
+Fix issue where providing a custom Registry to getPrometheusMetrics would cause /metrics to emit no response

--- a/src/components/prometheusmetrics.ts
+++ b/src/components/prometheusmetrics.ts
@@ -383,7 +383,7 @@ export class PrometheusMetrics {
                 this.refresh();
 
                 try {
-                    const exposition = PromClient.register.metrics();
+                    const exposition = this.register.metrics();
 
                     res.set("Content-Type", "text/plain");
                     res.send(exposition);


### PR DESCRIPTION
This bug caused the irc bridge to provide no metrics.