### PR TITLE
Add ability to watch config for changes

### DIFF
--- a/changelog.d/207.feature
+++ b/changelog.d/207.feature
@@ -1,0 +1,1 @@
+Add ability to watch the bridge config for changes.

--- a/changelog.d/207.feature
+++ b/changelog.d/207.feature
@@ -1,1 +1,2 @@
-Add ability to watch the bridge config for changes.
+The bridge can now optionally reload the config file on a `SIGHUP` signal. Developers should define the `onConfigChanged` callback
+when constructing `Cli` to make use of this feature.

--- a/spec/integ/cli.spec.js
+++ b/spec/integ/cli.spec.js
@@ -1,0 +1,108 @@
+const fs = require("fs").promises;
+const os = require("os");
+const { Cli } = require("../..");
+const { Logging } = require("../..");
+const path = require('path');
+
+Logging.configure();
+
+let tempDir;
+
+const registrationFileContent = {
+    id: "cli-test",
+    url: "http://127.0.0.1:1234",
+    as_token: "a_as_token",
+    hs_token: "a_hs_token",
+    sender_localpart: "the_sender",
+    namespaces: {
+        users: [{
+            exclusive: true,
+            regex: "@_the_bridge.*",
+        }],
+        aliases: [{
+            exclusive: true,
+            regex: "@_the_bridge.*",
+        }],
+        rooms: [],
+    },
+    rate_limited: false,
+    protocols: [],
+};
+async function writeRegistrationFile(content=registrationFileContent, filename="registration.yaml") {
+    const filePath = path.join(tempDir, filename);
+    await fs.writeFile(filePath, JSON.stringify(content), "utf-8");
+    return filePath;
+}
+
+async function writeConfigFile(content={}) {
+    const filePath = path.join(tempDir, "config.yaml");
+    await fs.writeFile(filePath, JSON.stringify(content), "utf-8");
+    return filePath;
+}
+
+describe("Cli", () => {
+    beforeEach(async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bridge-test"));
+    });
+    afterEach(async () => {
+        await fs.rmdir(tempDir, {recursive: true});
+    });
+
+    it("should be able to start the bridge with just a registration file", async () => {
+        let runCalledWith = false;
+        const cli = new Cli({
+            enableRegistration: false,
+            registrationPath: await writeRegistrationFile({}, "reg.yml"),
+            run: (...args) => { runCalledWith = args; }
+        });
+        cli.run();
+        expect(runCalledWith[0]).toEqual(Cli.DEFAULT_PORT);
+    });
+
+    it("should be able to start the bridge with a custom port", async () => {
+        const port = 1234;
+        let runCalledWith = null;
+        const cli = new Cli({
+            enableRegistration: false,
+            registrationPath: await writeRegistrationFile(),
+            run: (...args) => { runCalledWith = args; }
+        });
+        cli.run({port});
+        expect(runCalledWith[0]).toEqual(port);
+    });
+
+    it("should be able to start the bridge with a registration file and config file", async () => {
+        const configData = {"a": "var", "b": true};
+        const configFile = await writeConfigFile(configData);
+        let runCalledWith = null;
+        const cli = new Cli({
+            enableRegistration: false,
+            registrationPath: await writeRegistrationFile(),
+            bridgeConfig: {},
+            run: (...args) => { runCalledWith = args; }
+        });
+        cli.run({config: configFile});
+        expect(runCalledWith[0]).toEqual(Cli.DEFAULT_PORT);
+        expect(runCalledWith[1]).toEqual(configData);
+        expect(runCalledWith[2].getOutput()).toEqual(registrationFileContent);
+    });
+
+    it("should detect config file changes", async () => {
+        const newConfigData = {"b": "var", "c": false};
+        const configFile = await writeConfigFile({"a": "var", "b": true});
+        let newConfigFile = null;
+        const cli = new Cli({
+            enableRegistration: false,
+            registrationPath: await writeRegistrationFile(),
+            bridgeConfig: { watchConfig: true, watchInterval: 100 },
+            onConfigChanged: (config) => { newConfigFile = config },
+            run: (...args) => { }
+        });
+        cli.run({config: configFile});
+        await writeConfigFile(newConfigData);
+
+        // Wait for changes, 3 x the interval to be safe.
+        await new Promise(r => setTimeout(r, 300));
+        expect(newConfigFile).toEqual(newConfigData);
+    });
+})

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -249,7 +249,7 @@ export class Cli<ConfigType extends Record<string, unknown>> {
             fs.watchFile(this.args.config, {
                 persistent: false,
                 interval: this.opts.bridgeConfig.watchInterval || Cli.DEFAULT_WATCH_INTERVAL },
-                (curr: fs.Stats) => {
+                () => {
                 log.info("Config file change detected, reloading");
                 try {
                     const newConfig = this.loadConfig(this.args?.config);
@@ -257,7 +257,8 @@ export class Cli<ConfigType extends Record<string, unknown>> {
                     if (newConfig && this.opts.onConfigChanged) {
                         this.opts.onConfigChanged(newConfig);
                     }
-                } catch (ex) {
+                }
+                catch (ex) {
                     log.warn("Failed to reload config file:", ex);
                 }
             });

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -195,7 +195,7 @@ export class Cli<ConfigType extends Record<string, unknown>> {
     private assignConfigFile(configFilePath: string) {
         const configFile = (this.opts.bridgeConfig && configFilePath) ? configFilePath : undefined;
         if (!configFile) {
-            return null;
+            return;
         }
         const config = this.loadConfig(configFile);
         this.bridgeConfig = config;

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -241,7 +241,6 @@ export class Cli<ConfigType extends Record<string, unknown>> {
                 log.info("Got SIGHUP, reloading config file");
                 try {
                     const newConfig = this.loadConfig(configFilename);
-                    // onConfigChanged is checked above, but for Typescript's sake.
                     if (this.opts.onConfigChanged) {
                         this.opts.onConfigChanged(newConfig);
                     }

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -22,8 +22,6 @@ import { AppServiceRegistration } from "matrix-appservice";
 import ConfigValidator from "./config-validator";
 import * as logging from "./logging";
 
-const DEFAULT_PORT = 8090;
-const DEFAULT_FILENAME = "registration.yaml";
 const log = logging.get("cli");
 
 interface CliOpts<ConfigType extends Record<string, unknown>> {
@@ -60,7 +58,9 @@ interface CliArgs {
 }
 
 export class Cli<ConfigType extends Record<string, unknown>> {
+    public static DEFAULT_PORT = 8090;
     public static DEFAULT_WATCH_INTERVAL = 2500;
+    public static DEFAULT_FILENAME = "registration.yaml";
     private bridgeConfig: ConfigType|null = null;
     private args: CliArgs|null = null;
 
@@ -106,8 +106,8 @@ export class Cli<ConfigType extends Record<string, unknown>> {
         }
         this.opts.enableLocalpart = Boolean(this.opts.enableLocalpart);
 
-        this.opts.registrationPath = this.opts.registrationPath || DEFAULT_FILENAME;
-        this.opts.port = this.opts.port || DEFAULT_PORT;
+        this.opts.registrationPath = this.opts.registrationPath || Cli.DEFAULT_FILENAME;
+        this.opts.port = this.opts.port || Cli.DEFAULT_PORT;
     }
     /**
      * Get the parsed arguments. Only set after run is called and arguments parsed.
@@ -212,7 +212,7 @@ export class Cli<ConfigType extends Record<string, unknown>> {
 
     private loadConfig(filename?: string): ConfigType|null {
         if (!filename) { return null; }
-        log.info("Loading config file %s", filename);
+        log.info("Loading config file", filename);
         const cfg = this.loadYaml(filename);
         if (!cfg || typeof cfg === "string") {
             throw Error("Config file " + filename + " isn't valid YAML.");


### PR DESCRIPTION
This allows bridge developers to listen for config changes, which can be bubbled up to the bridge logic to support small changes without restarting the whole bridge. This is useful for things like the irc bridge, where restarts are costly.

I've also added some minimal Cli tests to ensure that config behaviour continues to work as expected.