### PR TITLE
Don't ignoreCache in Intent.join

### DIFF
--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -494,7 +494,7 @@ export class Intent {
      * addition to those that are automatically chosen.
      */
     public async join(roomId: string, viaServers?: string[]) {
-        await this._ensureJoined(roomId, false, viaServers);
+        await this._ensureJoined(roomId, true, viaServers);
     }
 
     /**


### PR DESCRIPTION
This fixes a race condition where joining a room immediately after leaving it does not actually result in a join.

This is consistently reproducable on my setup, where this change fixes the issue. However, extracting the offending code is probably difficult. I believe the cause is that `Intent.leave` acts via the client, which doesn't update the cache.