### PR TITLE
Remove bluebird dependency

### DIFF
--- a/changelog.d/216.feature
+++ b/changelog.d/216.feature
@@ -1,0 +1,1 @@
+**Breaking**: Remove Bluebird Promise support. Promises returned by the library will now be native.

--- a/package-lock.json
+++ b/package-lock.json
@@ -425,6 +425,7 @@
       "version": "1.8.10",
       "resolved": "https://registry.npmjs.org/@types/nedb/-/nedb-1.8.10.tgz",
       "integrity": "sha512-M0ISm1qsNvkdXNZml1r/1bEVqt5SJHF/LFcCtH5dHfsSIG0LEj5FhwK0f4fZy9WPCsXjmrKfpzgEW/bdQuKqmQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,12 +343,6 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
-    "@types/bluebird": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
-      "integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==",
-      "dev": true
-    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -810,11 +804,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "body-parser": {
       "version": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "prepare": "npm run build",
     "gendoc": "typedoc",
     "lint": "eslint -c .eslintrc.json src/**/*.ts",
-    "test": "BLUEBIRD_DEBUG=1 jasmine --stop-on-failure=true",
+    "test": "jasmine --stop-on-failure=true",
     "check": "npm run lint && npm test",
-    "ci-test": "BLUEBIRD_DEBUG=1 nyc -x \"**/spec/**\" --report text jasmine"
+    "ci-test": "nyc -x \"**/spec/**\" --report text jasmine"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/matrix-org/matrix-appservice-bridge#readme",
   "dependencies": {
     "@types/express": "^4.17.7",
-    "bluebird": "^3.7.2",
     "chalk": "^4.1.0",
     "extend": "^3.0.2",
     "is-my-json-valid": "^2.20.5",
@@ -42,7 +41,6 @@
     "winston-daily-rotate-file": "^4.5.0"
   },
   "devDependencies": {
-    "@types/bluebird": "^3.5.32",
     "@types/extend": "^3.0.1",
     "@types/js-yaml": "^3.12.5",
     "@types/node": "^10",

--- a/scripts/upgrade-db-0.3-to-1.0.js
+++ b/scripts/upgrade-db-0.3-to-1.0.js
@@ -7,9 +7,9 @@
 // ** customise it for your application service.                       **
 // **********************************************************************
 
-const Bluebird = require("bluebird");
 const Datastore = require("nedb");
-Bluebird.promisifyAll(Datastore.prototype);
+const util = require("util");
+util.promisifyAll(Datastore.prototype);
 const nopt = require("nopt");
 const path = require("path");
 const fs = require("fs");
@@ -83,7 +83,7 @@ function generateLinkId(opts)
     return opts.matrix_id + " " + opts.remote_id;
 }
 
-var upgradeRooms = Bluebird.coroutine(function*(db) {
+const upgradeRooms = async function(db) {
     console.log("Upgrading rooms database");
     // 0.3 rooms.db format:
     // type=matrix, id=<matrix_id> data={...}  -- UNIQUE(id)
@@ -205,9 +205,9 @@ var upgradeRooms = Bluebird.coroutine(function*(db) {
     } catch (err) {
         console.error(JSON.stringify(err));
     }
-});
+}
 
-Bluebird.coroutine(function*() {
+(async function() {
     try {
         fs.mkdirSync("1.0-db");
     }

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -95,10 +95,10 @@ describe("Bridge", function() {
             return defer.promise;
         }
 
-        Bluebird.all([
+        Promise.all([
             loadDatabase(TEST_USER_DB_PATH, UserBridgeStore),
             loadDatabase(TEST_ROOM_DB_PATH, RoomBridgeStore)
-        ]).spread(function(userDb, roomDb) {
+        ]).then(([userDb, roomDb]) => {
             userStore = userDb;
             roomStore = roomDb;
             bridge = new Bridge({

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -1,5 +1,4 @@
 "use strict";
-const Bluebird = require("bluebird");
 const Datastore = require("nedb");
 const fs = require("fs");
 const log = require("../log");

--- a/spec/unit/client-request-cache.spec.js
+++ b/spec/unit/client-request-cache.spec.js
@@ -1,5 +1,5 @@
 const { ClientRequestCache } = require("../../lib/components/client-request-cache");
-const Bluebird = require("bluebird");
+const promiseutil = require("../../lib/utils/promiseutil");
 
 describe("ClientRequestCache", function() {
     describe("constructor", function() {
@@ -52,7 +52,7 @@ describe("ClientRequestCache", function() {
                 return "Behold, the *thing*";
             });
             return crc.get("athing").then(() => {
-                return Bluebird.delay(100);
+                return promiseutil.delay(100);
             }).then(() => {
                 return crc.get("athing");
             }).then((res) => {

--- a/spec/unit/state-lookup.spec.js
+++ b/spec/unit/state-lookup.spec.js
@@ -1,5 +1,4 @@
 "use strict";
-const Bluebird = require("bluebird");
 const log = require("../log");
 const StateLookup = require("../..").StateLookup;
 const promiseutil = require("../../lib/utils/promiseutil");

--- a/spec/unit/state-lookup.spec.js
+++ b/spec/unit/state-lookup.spec.js
@@ -2,6 +2,7 @@
 const Bluebird = require("bluebird");
 const log = require("../log");
 const StateLookup = require("../..").StateLookup;
+const promiseutil = require("../../lib/utils/promiseutil");
 
 describe("StateLookup", function() {
     var lookup, cli;
@@ -25,7 +26,7 @@ describe("StateLookup", function() {
             cli.roomState.and.returnValue(statePromise.promise);
             var p = lookup.trackRoom("!foo:bar");
             expect(p.isPending()).toBe(true); // not resolved HTTP call yet
-            await Bluebird.delay(5);
+            await promiseutil.delay(5);
             expect(p.isPending()).toBe(true); // still not resolved HTTP call
             statePromise.resolve();
             await p; // Should resolve now HTTP call is resolved

--- a/spec/unit/state-lookup.spec.js
+++ b/spec/unit/state-lookup.spec.js
@@ -25,9 +25,9 @@ describe("StateLookup", function() {
             var statePromise = createStatePromise([]);
             cli.roomState.and.returnValue(statePromise.promise);
             var p = lookup.trackRoom("!foo:bar");
-            expect(p.isPending()).toBe(true); // not resolved HTTP call yet
+            expect(statePromise.isPending).toBe(true); // not resolved HTTP call yet
             await promiseutil.delay(5);
-            expect(p.isPending()).toBe(true); // still not resolved HTTP call
+            expect(statePromise.isPending).toBe(true); // still not resolved HTTP call
             statePromise.resolve();
             await p; // Should resolve now HTTP call is resolved
         });
@@ -57,7 +57,7 @@ describe("StateLookup", function() {
             const promiseB = lookup.trackRoom("!b:foobar");
             stateA.resolve();
             await promiseA;
-            expect(promiseB.isPending()).toBe(true);
+            expect(stateB.isPending).toBe(true);
             stateB.resolve();
             await promiseB;
         });
@@ -135,7 +135,7 @@ describe("StateLookup", function() {
             ]);
             cli.roomState.and.returnValue(statePromise.promise);
             var p = lookup.trackRoom("!foo:bar");
-            expect(p.isPending()).toBe(true); // not resolved HTTP call yet
+            expect(statePromise.isPending).toBe(true); // not resolved HTTP call yet
             // this event should clobber response from HTTP call
             statePromise.resolve();
             await lookup.onEvent(
@@ -205,13 +205,17 @@ function createStatePromise(returnedStateEvents, rejectErr) {
         resolver = resolve;
         rejecter = reject;
     });
+    let isPending = true;
     return {
         resolve: function() {
+            isPending = false;
             resolver(returnedStateEvents);
         },
         reject: function() {
+            isPending = false;
             rejecter(rejectErr);
         },
+        isPending,
         promise: p
     };
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import Datastore from "nedb";
-import Bluebird from "bluebird";
 import * as fs from "fs";
 import * as util from "util";
 import yaml from "js-yaml";

--- a/src/components/event-queue.ts
+++ b/src/components/event-queue.ts
@@ -12,8 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import Bluebird from "bluebird";
-
 type DataReady = Promise<Record<string, unknown>>;
 
 // It's an event, which has no type yet.
@@ -92,7 +90,7 @@ export class EventQueue {
             return;
         }
 
-        Bluebird.resolve(entry.dataReady).asCallback(this.consumeFn);
+        entry.dataReady.then((r) => this.consumeFn(null, r)).catch((error) => this.consumeFn(error, null));
         entry.dataReady.finally(() => this.takeNext(identifier));
     }
 
@@ -155,7 +153,7 @@ export class EventQueueNone extends EventQueue {
 
     push(event: unknown, dataReady: DataReady) {
         // consume the event instantly
-        Bluebird.resolve(dataReady).asCallback(this.consumeFn);
+        dataReady.then((r) => this.consumeFn(null, r)).catch((error) => this.consumeFn(error, null));
     }
 
     consume() {

--- a/src/components/state-lookup.ts
+++ b/src/components/state-lookup.ts
@@ -153,8 +153,8 @@ export class StateLookup {
         }
         r.events = {};
 
+        r.syncPending = true;
         r.syncPromise = (async () => {
-            r.syncPending = true;
             const res = await this.getInitialState(roomId);
             r.syncPending = false;
             return res;

--- a/src/utils/promiseutil.ts
+++ b/src/utils/promiseutil.ts
@@ -33,3 +33,7 @@ export function defer<T>(): Defer<T> {
         promise: promise,
     };
 }
+
+export function delay(delayMs: number) {
+    return new Promise((r) => setTimeout(r, delayMs));
+}


### PR DESCRIPTION
This is a breaking change to enforce the use of **pure** Bluebird promises. Since we've already made breaking changes in other areas of the library, we might as well remove the use of these as well.