### PR TITLE
Import @types of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
   },
   "homepage": "https://github.com/matrix-org/matrix-appservice-bridge#readme",
   "dependencies": {
+    "@types/extend": "^3.0.1",
+    "@types/js-yaml": "^3.12.5",
+    "@types/nedb": "^1.8.10",
+    "@types/nopt": "^3.0.29",
     "chalk": "^4.1.0",
     "extend": "^3.0.2",
     "is-my-json-valid": "^2.20.5",
@@ -41,11 +45,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.8",
-    "@types/extend": "^3.0.1",
-    "@types/js-yaml": "^3.12.5",
     "@types/node": "^10",
-    "@types/nopt": "^3.0.29",
-    "@types/nedb": "^1.8.10",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
     "eslint": "^7.5.0",


### PR DESCRIPTION
According to the TypeScript docs, we should also make the `@types` of our dependencies direct dependencies.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies