### PR TITLE
Explicitly reference our TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.13.2",
   "description": "Bridging infrastructure for Matrix Application Services",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "prepare": "npm run build",


### PR DESCRIPTION
Apparently that's how you tell other projects that you included the types in your NPM bundle.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package