### PR TITLE
Allow info to be null on getProfileInfo

### DIFF
--- a/changelog.d/232.bugfix
+++ b/changelog.d/232.bugfix
@@ -1,0 +1,1 @@
+Reinstate ability to call getProfileInfo without specifying a profile key.

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -520,7 +520,7 @@ export class Intent {
      * @return A Promise that resolves with the requested user's profile
      * information
      */
-    public async getProfileInfo(userId: string, info: string, useCache=true) {
+    public async getProfileInfo(userId: string, info: "avatar_url"|"displayname"|null = null, useCache = true) {
         await this._ensureRegistered();
         if (useCache) {
             return this._requestCaches.profile.get(`${userId}:${info}`, userId, info);

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -82,9 +82,11 @@ export type PowerLevelContent = {
     }
 };
 
+type UserProfileKeys = "avatar_url"|"displayname"|null;
+
 export class Intent {
     private _requestCaches: {
-        profile: ClientRequestCache<unknown, [string, string]>,
+        profile: ClientRequestCache<unknown, [string, UserProfileKeys]>,
         roomstate: ClientRequestCache<unknown, []>,
         event: ClientRequestCache<unknown, [string, string]>
     }
@@ -189,7 +191,7 @@ export class Intent {
             profile: new ClientRequestCache(
                 this.opts.caching.ttl,
                 this.opts.caching.size,
-                (_: string, userId: string, info: string) => {
+                (_: string, userId: string, info: UserProfileKeys) => {
                     return this.getProfileInfo(userId, info, false);
                 }
             ),
@@ -520,7 +522,7 @@ export class Intent {
      * @return A Promise that resolves with the requested user's profile
      * information
      */
-    public async getProfileInfo(userId: string, info: "avatar_url"|"displayname"|null = null, useCache = true) {
+    public async getProfileInfo(userId: string, info: UserProfileKeys = null, useCache = true) {
         await this._ensureRegistered();
         if (useCache) {
             return this._requestCaches.profile.get(`${userId}:${info}`, userId, info);


### PR DESCRIPTION
We use this in various places on the Slack bridge to get the full profile of a user.