### PR TITLE
Use actual homeserver URL for the bridge bot

### DIFF
--- a/changelog.d/233.bugfix
+++ b/changelog.d/233.bugfix
@@ -1,0 +1,1 @@
+Ensure that the bridge bot uses the real homeserver URL when encryption is enabled

--- a/src/components/client-factory.ts
+++ b/src/components/client-factory.ts
@@ -120,7 +120,7 @@ export class ClientFactory {
      * resolved.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public getClientAs(userId?: string, request?: any, usingE2E = false) {
+    public getClientAs(userId?: string, request?: any, urlOverride?: string, usingE2E = false) {
         const reqId = request ? request.getId() : "-";
         const userIdKey = userId || "bot";
 
@@ -144,7 +144,7 @@ export class ClientFactory {
         queryParams.access_token = this.token;
         const clientOpts = {
             accessToken: this.token,
-            baseUrl: this.url,
+            baseUrl: urlOverride || this.url,
             userId: userId || this.botUserId, // NB: no clobber so we don't set ?user_id=BOT
             queryParams: queryParams,
             scheduler:  this.clientSchedulerBuilder ? this.clientSchedulerBuilder() : undefined,

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -49,7 +49,6 @@ export interface IntentOpts {
         sessionPromise: Promise<ClientEncryptionSession|null>;
         sessionCreatedCallback: (session: ClientEncryptionSession) => Promise<void>;
         ensureClientSyncingCallback: () => Promise<void>;
-        homeserverUrl: string;
     };
 }
 
@@ -118,7 +117,6 @@ export class Intent {
         sessionPromise: Promise<ClientEncryptionSession|null>;
         sessionCreatedCallback: (session: ClientEncryptionSession) => Promise<void>;
         ensureClientSyncingCallback: () => Promise<void>;
-        homeserverUrl: string;
     };
     private readyPromise?: Promise<unknown>;
 


### PR DESCRIPTION
The bridge bot cannot sync and should never encrypt its messages. Ensure the bridge bot goes via the homeserver URL, while ghosts use the E2E proxy.