### PR TITLE
Add support for ephemeral events from the AS API 

### DIFF
--- a/changelog.d/238.feature
+++ b/changelog.d/238.feature
@@ -1,0 +1,1 @@
+Add support for ephemeral events from the AS api (MSC2409)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2954,9 +2954,9 @@
       "dev": true
     },
     "matrix-appservice": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/matrix-appservice/-/matrix-appservice-0.5.0.tgz",
-      "integrity": "sha512-TzfoXdZCFbwnjHFwkmpxWEDN0SWu4Sgho8Jaa47wTei+Kg8/hLCc/JvRN3AXNtx419+tolsXYX8KO0JJorQSpA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/matrix-appservice/-/matrix-appservice-0.6.0.tgz",
+      "integrity": "sha512-MkM4PzBeNBi/AcSDWgUD6zWlGY2ckBSF3dn8IgXWf44uHDx6WZfWyIt4E/KKsx9iy3EO78IfWmK+7Qva4eug5A==",
       "requires": {
         "@types/express": "^4.17.8",
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "extend": "^3.0.2",
     "is-my-json-valid": "^2.20.5",
     "js-yaml": "^3.14.0",
-    "matrix-appservice": "^0.5.0",
+    "matrix-appservice": "matrix-org/matrix-appservice-node#hs/ephemeral",
     "matrix-js-sdk": "^8.4.1",
     "nedb": "^1.8.0",
     "nopt": "^4.0.3",
@@ -44,16 +44,16 @@
     "@types/express": "^4.17.8",
     "@types/extend": "^3.0.1",
     "@types/js-yaml": "^3.12.5",
+    "@types/nedb": "^1.8.10",
     "@types/node": "^10",
     "@types/nopt": "^3.0.29",
-    "@types/nedb": "^1.8.10",
     "@typescript-eslint/eslint-plugin": "^4.1.0",
     "@typescript-eslint/parser": "^4.1.0",
     "eslint": "^7.9.0",
     "jasmine": "^3.6.0",
     "nyc": "^15.1.0",
+    "typedoc": "^0.19.0",
     "typescript": "^4.0.2",
-    "winston-transport": "^4.4.0",
-    "typedoc": "^0.19.0"
+    "winston-transport": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "extend": "^3.0.2",
     "is-my-json-valid": "^2.20.5",
     "js-yaml": "^3.14.0",
-    "matrix-appservice": "matrix-org/matrix-appservice-node#hs/ephemeral",
+    "matrix-appservice": "^0.6.0",
     "matrix-js-sdk": "^8.4.1",
     "nedb": "^1.8.0",
     "nopt": "^4.0.3",

--- a/spec/integ/cli.spec.js
+++ b/spec/integ/cli.spec.js
@@ -27,6 +27,7 @@ const registrationFileContent = {
     },
     rate_limited: false,
     protocols: [],
+    "de.sorunome.msc2409.push_ephemeral": undefined,
 };
 async function writeRegistrationFile(content=registrationFileContent, filename="registration.yaml") {
     const filePath = path.join(tempDir, filename);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -577,7 +577,8 @@ export class Bridge {
                 this.membershipCache,
                 this.appServiceBot,
                 this.onEvent.bind(this),
-                this.onEphemeralEvent.bind(this),
+                // If the bridge supports pushEphemeral, don't use sync data.
+                !this.registration.pushEphemeral ? this.onEphemeralEvent.bind(this) : undefined,
                 this.getIntent.bind(this),
             );
         }
@@ -634,6 +635,9 @@ export class Bridge {
             }
             return undefined;
         });
+        this.appservice.on("ephemeral", async (event) =>
+            this.onEphemeralEvent(event as unknown as EphemeralEvent)
+        );
         this.appservice.on("http-log", (line) => {
             this.onLog(line, false);
         });


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-appservice-node/pull/32, https://github.com/matrix-org/synapse/pull/8437

Most of the interesting things are in those two PRs, but this means we can handle ephemeral data from the AS api rather than just /sync.