### PR TITLE
Fix issue where ghosts would not be registered

### DIFF
--- a/changelog.d/249.bugfix
+++ b/changelog.d/249.bugfix
@@ -1,0 +1,1 @@
+Fix issue where ghost users would not be registered if they've never used the bridge

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -878,7 +878,8 @@ export class Intent {
     public async ensureRegistered(forceRegister = false) {
         const userId: string = this.client.credentials.userId;
         log.debug(`Checking if user ${this.client.credentials.userId} is registered`);
-        // We want to skip if and only if all of these are true
+        // We want to skip if and only if all of these conditions are met.
+        // Calling /register twice isn't disasterous, but not calling it *at all* IS.
         if (!forceRegister && this.opts.registered && !this.encryption) {
             log.debug("ensureRegistered: Registered, and not encrypted");
             return "registered=true";

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -878,13 +878,13 @@ export class Intent {
     public async ensureRegistered(forceRegister = false) {
         const userId: string = this.client.credentials.userId;
         log.debug(`Checking if user ${this.client.credentials.userId} is registered`);
-        forceRegister = forceRegister || !this.opts.registered;
-        if (!forceRegister && !this.encryption) {
+        // We want to skip if and only if all of these are true
+        if (!forceRegister && this.opts.registered && !this.encryption) {
             log.debug("ensureRegistered: Registered, and not encrypted");
             return "registered=true";
         }
         let registerRes;
-        if (forceRegister) {
+        if (forceRegister || !this.opts.registered) {
             const localpart = (new MatrixUser(userId)).localpart;
             try {
                 registerRes = await this.botClient.register(localpart);


### PR DESCRIPTION
This function tries to determine if a user should be /registered, and only calls the method if it thinks it needs to be done. We also want to force registration sometimes (e.g. for the bridge bot), and we also want to do extra steps for encryption enabled users. This causes a bit of gnarly logic to determine if we need to skip registration.

Previously, we were seeing that users who were NOT registered were not being registered due to encryption not being enabled and forceRegister being false.