### PR TITLE
Don't join on kicking yourself

### DIFF
--- a/changelog.d/250.bugfix
+++ b/changelog.d/250.bugfix
@@ -1,0 +1,1 @@
+Don't join the room when doing a self-kick

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -783,7 +783,7 @@ export class Intent {
         const deferredPromise = defer<string>();
 
         const mark = (room: string, state: UserMembership) => {
-            this.opts.backingStore.setMembership(room, userId, state, {});
+            this.opts.backingStore.setMembership(room, this.userId, state, {});
             if (state === "join") {
                 deferredPromise.resolve(room);
             }
@@ -811,7 +811,7 @@ export class Intent {
                         throw Error("Can't invite via an alias");
                     }
                     // Try bot inviting client
-                    await this.botClient.invite(roomIdOrAlias, userId);
+                    await this.botClient.invite(roomIdOrAlias, this.userId);
                     // eslint-disable-next-line camelcase
                     const { room_id } = await this.client.joinRoom(roomIdOrAlias, opts);
                     mark(room_id, "join");
@@ -820,7 +820,7 @@ export class Intent {
                     // Try bot joining
                     // eslint-disable-next-line camelcase
                     const { room_id } = await this.botClient.joinRoom(roomIdOrAlias, opts)
-                    await this.botClient.invite(room_id, userId);
+                    await this.botClient.invite(room_id, this.userId);
                     await this.client.joinRoom(room_id, opts);
                     mark(room_id, "join");
                 }

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -433,18 +433,19 @@ export class Intent {
     // eslint-disable-next-line camelcase
     public async createRoom(opts: RoomCreationOpts): Promise<{room_id: string}> {
         const cli = opts.createAsClient ? this.client : this.botClient;
+        const { userId } = cli.credentials;
         const options = opts.options || {};
         if (!opts.createAsClient) {
             // invite the client if they aren't already
             options.invite = options.invite || [];
-            if (Array.isArray(options.invite) && !options.invite.includes(this.userId)) {
-                options.invite.push(this.userId);
+            if (Array.isArray(options.invite) && !options.invite.includes(userId)) {
+                options.invite.push(userId);
             }
         }
         // make sure that the thing doing the room creation isn't inviting itself
         // else Synapse hard fails the operation with M_FORBIDDEN
-        if (Array.isArray(options.invite) && options.invite.includes(cli.userId)) {
-            options.invite.splice(options.invite.indexOf(cli.userId), 1);
+        if (Array.isArray(options.invite) && options.invite.includes(userId)) {
+            options.invite.splice(options.invite.indexOf(userId), 1);
         }
 
         await this.ensureRegistered();
@@ -464,7 +465,7 @@ export class Intent {
             return res;
         }
         const users: Record<string, number> = {};
-        users[cli.userId] = 100;
+        users[userId] = 100;
         this.opts.backingStore.setPowerLevelContent(roomId, {
             users_default: 0,
             events_default: 0,


### PR DESCRIPTION
I've also taken the liberty to add a `userId` getter to the class, as we use it all over the place. I've also added support for folks to leave with a reason. Eventually we could use the leave call, but the JS SDK doesn't let us use a reason. You can leave with a reason in the matrix spec, so it's fine to send a kick instead for now.