### PR TITLE
Add membership queue metrics

### DIFF
--- a/changelog.d/276.feature
+++ b/changelog.d/276.feature
@@ -1,0 +1,1 @@
+Add function `registerMetrics` to `MembershipQueue` to track metrics.

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -171,9 +171,6 @@ export class MembershipQueue {
             this.pendingGauge?.dec({
                 type: item.kickUser ? "kick" : item.type
             });
-            this.pendingGauge?.dec({
-                type: item.kickUser ? "kick" : item.type
-            });
             this.processedCounter?.inc({
                 type: item.kickUser ? "kick" : item.type,
                 outcome: "success",

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -81,7 +81,7 @@ export class MembershipQueue {
             labels: ["errcode", "http_status"],
         });
 
-        this.ageOfLastProcessedGauge = metrics.addCounter({
+        this.ageOfLastProcessedGauge = metrics.addGauge({
             name: "membershipqueue_lastage",
             help: "Gauge to measure the age of the last processed event",
         });


### PR DESCRIPTION
Fixes #259 

This PR creates 3 new metrics entries for prometheus:
- `membershipqueue_pending(type)` which will show which types of membership are waiting in the queue
- `membershipqueue_processed(type, outcome)` will show the number of completed (success & failed) membership actions
- `membershipqueue_reason(type, errcode, http_status)` will be a count of the failures for the actions
- `membershipqueue_lastage` is the age of the last processed request, in MS

Output looks good:
```
# HELP bridge_membershipqueue_pending Count of membership actions in the queue by type
# TYPE bridge_membershipqueue_pending gauge
bridge_membershipqueue_pending{type="leave"} 0
bridge_membershipqueue_pending{type="kick"} 0
bridge_membershipqueue_pending{type="join"} 0

# HELP bridge_membershipqueue_processed Count of membership actions processed by type and outcome
# TYPE bridge_membershipqueue_processed counter
bridge_membershipqueue_processed{type="leave",outcome="success"} 6
bridge_membershipqueue_processed{type="kick",outcome="success"} 4
bridge_membershipqueue_processed{type="join",outcome="success"} 1

# HELP bridge_membershipqueue_reason Count of failures to process membership, by matrix errcode and http status
# TYPE bridge_membershipqueue_reason counter

# HELP bridge_membershipqueue_lastage Gauge to measure the age of the last processed event
# TYPE bridge_membershipqueue_lastage gauge
bridge_membershipqueue_lastage 0
```