### PR TITLE
Add option for a time to live for membership queue items

### DIFF
--- a/changelog.d/276.feature
+++ b/changelog.d/276.feature
@@ -1,0 +1,1 @@
+Add function `registerMetrics` to `MembershipQueue` to track metrics.

--- a/changelog.d/277.feature
+++ b/changelog.d/277.feature
@@ -1,0 +1,1 @@
+Add `defaultTtl` option to `MembershipQueue` to expire membership that is too old.

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -171,9 +171,6 @@ export class MembershipQueue {
             this.pendingGauge?.dec({
                 type: item.kickUser ? "kick" : item.type
             });
-            this.pendingGauge?.dec({
-                type: item.kickUser ? "kick" : item.type
-            });
             this.processedCounter?.inc({
                 type: item.kickUser ? "kick" : item.type,
                 outcome: "success",

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -55,6 +55,9 @@ export interface MembershipQueueOpts {
     defaultTtlMs?: number;
 }
 
+/**
+ * Default values used by the queue if not specified.
+ */
 export const DEFAULT_OPTS: MembershipQueueOptsWithDefaults = {
     concurrentRoomLimit: 8,
     maxAttempts: 10,

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -49,10 +49,10 @@ export interface MembershipQueueOpts {
      */
     maxActionDelayMs?: number;
     /**
-     * How long a request can "live" for before it is discarded. This
-     * will override `maxAttempts`.
+     * How long a request can "live" for before it is discarded in
+     * milliseconds. This will override `maxAttempts`.
      */
-    defaultTtl?: number;
+    defaultTtlMs?: number;
 }
 
 export const DEFAULT_OPTS: MembershipQueueOptsWithDefaults = {
@@ -60,14 +60,14 @@ export const DEFAULT_OPTS: MembershipQueueOptsWithDefaults = {
     maxAttempts: 10,
     actionDelayMs: 500,
     maxActionDelayMs: 30 * 60 * 1000, // 30 mins
-    defaultTtl: 2 * 60 * 1000, // 2 mins
+    defaultTtlMs: 2 * 60 * 1000, // 2 mins
 };
 
 interface MembershipQueueOptsWithDefaults extends MembershipQueueOpts {
     maxActionDelayMs: number;
     actionDelayMs: number;
     concurrentRoomLimit: number;
-    defaultTtl: number;
+    defaultTtlMs: number;
     maxAttempts: number;
 }
 
@@ -143,7 +143,8 @@ export class MembershipQueue {
      * @param userId Leave empty to act as the bot user.
      * @param req The request entry for logging context
      * @param retry Should the request retry if it fails
-     * @param ttl How long should this request remain queued before it's discarded. Defaults to `opts.defaultTTL`
+     * @param ttl How long should this request remain queued in milliseconds
+     * before it's discarded. Defaults to `opts.defaultTtlMs`
      */
     public async join(roomId: string, userId: string|undefined, req: ThinRequest, retry = true, ttl?: number) {
         return this.queueMembership({
@@ -154,7 +155,7 @@ export class MembershipQueue {
             attempts: 0,
             type: "join",
             ts: Date.now(),
-            ttl: ttl || this.opts.defaultTtl,
+            ttl: ttl || this.opts.defaultTtlMs,
         });
     }
 
@@ -166,7 +167,8 @@ export class MembershipQueue {
      * @param retry Should the request retry if it fails
      * @param reason Reason for leaving/kicking
      * @param kickUser The user to be kicked. If left blank, this will be a leave.
-     * @param ttl How long should this request remain queued before it's discarded. Defaults to `opts.defaultTTL`
+     * @param ttl How long should this request remain queued in milliseconds
+     * before it's discarded. Defaults to `opts.defaultTtlMs`
      */
     public async leave(roomId: string, userId: string, req: ThinRequest,
                        retry = true, reason?: string, kickUser?: string,
@@ -181,7 +183,7 @@ export class MembershipQueue {
             kickUser,
             type: "leave",
             ts: Date.now(),
-            ttl: ttl || this.opts.defaultTtl,
+            ttl: ttl || this.opts.defaultTtlMs,
         })
     }
 

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -81,7 +81,7 @@ export class MembershipQueue {
             labels: ["errcode", "http_status"],
         });
 
-        this.ageOfLastProcessedGauge = metrics.addCounter({
+        this.ageOfLastProcessedGauge = metrics.addGauge({
             name: "membershipqueue_lastage",
             help: "Gauge to measure the age of the last processed event",
         });

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -19,25 +19,62 @@ interface QueueUserItem {
     retry: boolean;
     req: ThinRequest;
     ts: number;
+    ttl: number;
 }
 
 export interface MembershipQueueOpts {
-    concurrentRoomLimit: number;
-    maxAttempts: number;
-    joinDelayMs: number;
-    maxJoinDelayMs: number;
+    /**
+     * The number of concurrent operations to perform.
+     */
+    concurrentRoomLimit?: number;
+    /**
+     * The number of attempts to retry an operation before it is discarded.
+     */
+    maxAttempts?: number;
+    /**
+     * @deprecated Use `actionDelayMs`
+     */
+    joinDelayMs?: number;
+    /**
+     * How long to delay a request for in milliseconds, multiplied by the number of attempts made
+     * if a request failed.
+     */
+    actionDelayMs?: number;
+    /**
+     * @deprecated Use `maxActionDelayMs`
+     */
+    maxJoinDelayMs?: number;
+    /**
+     * The maximum number of milliseconds a request may be delayed for.
+     */
+    maxActionDelayMs?: number;
+    /**
+     * How long a request can "live" for before it is discarded. This
+     * will override `maxAttempts`.
+     */
+    defaultTtl?: number;
 }
 
-const DEFAULT_OPTS = {
+export const DEFAULT_OPTS: MembershipQueueOptsWithDefaults = {
     concurrentRoomLimit: 8,
     maxAttempts: 10,
-    joinDelayMs: 500,
-    maxJoinDelayMs: 30 * 60 * 1000, // 30 mins
+    actionDelayMs: 500,
+    maxActionDelayMs: 30 * 60 * 1000, // 30 mins
+    defaultTtl: 2 * 60 * 1000, // 2 mins
 };
 
+interface MembershipQueueOptsWithDefaults extends MembershipQueueOpts {
+    maxActionDelayMs: number;
+    actionDelayMs: number;
+    concurrentRoomLimit: number;
+    defaultTtl: number;
+    maxAttempts: number;
+}
 
 /**
  * This class sends membership changes for rooms in a linearized queue.
+ * The queue is lineaized based upon the hash value of the roomId, so that two
+ * operations for the same roomId may never happen concurrently.
  */
 export class MembershipQueue {
     private queues: Map<number, PQueue> = new Map();
@@ -45,14 +82,27 @@ export class MembershipQueue {
     private processedCounter?: Counter<"type"|"instance_id"|"outcome">;
     private failureReasonCounter?: Counter<"errcode"|"http_status"|"type">;
     private ageOfLastProcessedGauge?: Gauge<string>;
+    private opts: MembershipQueueOptsWithDefaults;
 
-    constructor(private bridge: Bridge, private opts: MembershipQueueOpts) {
-        this.opts = { ...DEFAULT_OPTS, ...this.opts};
+    constructor(private bridge: Bridge, opts: MembershipQueueOpts) {
+        this.opts = { ...DEFAULT_OPTS, ...opts};
         for (let i = 0; i < this.opts.concurrentRoomLimit; i++) {
             this.queues.set(i, new PQueue({
                 autoStart: true,
                 concurrency: 1,
             }));
+        }
+
+        if (opts.actionDelayMs === undefined && opts.joinDelayMs) {
+            log.warn("MembershipQueue configured with deprecated config option `joinDelayMs`. Use `actionDelayMs`");
+            this.opts.actionDelayMs = opts.joinDelayMs;
+        }
+
+        if (opts.maxActionDelayMs === undefined && opts.maxJoinDelayMs) {
+            log.warn(
+                "MembershipQueue configured with deprecated config option `maxJoinDelayMs`. Use `maxActionDelayMs`"
+            );
+            this.opts.maxActionDelayMs = opts.maxJoinDelayMs;
         }
     }
 
@@ -93,8 +143,9 @@ export class MembershipQueue {
      * @param userId Leave empty to act as the bot user.
      * @param req The request entry for logging context
      * @param retry Should the request retry if it fails
+     * @param ttl How long should this request remain queued before it's discarded. Defaults to `opts.defaultTTL`
      */
-    public async join(roomId: string, userId: string|undefined, req: ThinRequest, retry = true) {
+    public async join(roomId: string, userId: string|undefined, req: ThinRequest, retry = true, ttl?: number) {
         return this.queueMembership({
             roomId,
             userId: userId || this.bridge.botUserId,
@@ -103,6 +154,7 @@ export class MembershipQueue {
             attempts: 0,
             type: "join",
             ts: Date.now(),
+            ttl: ttl || this.opts.defaultTtl,
         });
     }
 
@@ -114,9 +166,11 @@ export class MembershipQueue {
      * @param retry Should the request retry if it fails
      * @param reason Reason for leaving/kicking
      * @param kickUser The user to be kicked. If left blank, this will be a leave.
+     * @param ttl How long should this request remain queued before it's discarded. Defaults to `opts.defaultTTL`
      */
     public async leave(roomId: string, userId: string, req: ThinRequest,
-                       retry = true, reason?: string, kickUser?: string) {
+                       retry = true, reason?: string, kickUser?: string,
+                       ttl?: number) {
         return this.queueMembership({
             roomId,
             userId: userId || this.bridge.botUserId,
@@ -127,6 +181,7 @@ export class MembershipQueue {
             kickUser,
             type: "leave",
             ts: Date.now(),
+            ttl: ttl || this.opts.defaultTtl,
         })
     }
 
@@ -153,11 +208,22 @@ export class MembershipQueue {
     }
 
     private async serviceQueue(item: QueueUserItem) {
-        const { req, roomId, userId, reason, kickUser, attempts, type } = item;
+        const { req, roomId, userId, reason, kickUser, attempts, type, ttl, ts } = item;
+        const age = Date.now() - ts;
+        if (age > ttl) {
+            this.processedCounter?.inc({
+                type: kickUser ? "kick" : type,
+                outcome: "dead",
+            });
+            this.pendingGauge?.dec({
+                type: kickUser ? "kick" : type
+            });
+            return;
+        }
         const reqIdStr = req.getId() ? `[${req.getId()}]`: "";
         log.debug(`${reqIdStr} ${userId}@${roomId} -> ${type} (reason: ${reason || "none"}, kicker: ${kickUser})`);
         const intent = this.bridge.getIntent(kickUser || userId);
-        this.ageOfLastProcessedGauge?.set(Date.now() - item.ts);
+        this.ageOfLastProcessedGauge?.set(age);
         try {
             if (type === "join") {
                 await intent.join(roomId);
@@ -169,39 +235,39 @@ export class MembershipQueue {
                 await intent.leave(roomId, reason);
             }
             this.pendingGauge?.dec({
-                type: item.kickUser ? "kick" : item.type
+                type: kickUser ? "kick" : type
             });
             this.processedCounter?.inc({
-                type: item.kickUser ? "kick" : item.type,
+                type: kickUser ? "kick" : type,
                 outcome: "success",
             });
         }
         catch (ex) {
             if (ex.errcode && ex.httpStatus) {
                 this.failureReasonCounter?.inc({
-                    type: item.kickUser ? "kick" : item.type,
+                    type: kickUser ? "kick" : type,
                     errcode: ex.errcode,
                     http_status: ex.httpStatus
                 });
             }
             if (!this.shouldRetry(ex, attempts)) {
                 this.pendingGauge?.dec({
-                    type: item.kickUser ? "kick" : item.type
+                    type: kickUser ? "kick" : type
                 });
                 this.processedCounter?.inc({
-                    type: item.kickUser ? "kick" : item.type,
+                    type: kickUser ? "kick" : type,
                     outcome: "fail",
                 });
                 throw ex;
             }
             const delay = Math.min(
-                (this.opts.joinDelayMs * attempts) + (Math.random() * 500),
-                this.opts.maxJoinDelayMs
+                (this.opts.actionDelayMs * attempts) + (Math.random() * 500),
+                this.opts.actionDelayMs
             );
             log.warn(`${reqIdStr} Failed to ${type} ${roomId}, delaying for ${delay}ms`);
             log.debug(`${reqIdStr} Failed with: ${ex.errcode} ${ex.message}`);
             await new Promise((r) => setTimeout(r, delay));
-            this.queueMembership({...item, attempts: item.attempts + 1});
+            this.queueMembership({...item, attempts: attempts + 1});
         }
     }
 

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -218,7 +218,7 @@ export class MembershipQueue {
             this.pendingGauge?.dec({
                 type: kickUser ? "kick" : type
             });
-            return;
+            throw Error('Request failed. TTL exceeded');
         }
         const reqIdStr = req.getId() ? `[${req.getId()}]`: "";
         log.debug(`${reqIdStr} ${userId}@${roomId} -> ${type} (reason: ${reason || "none"}, kicker: ${kickUser})`);


### PR DESCRIPTION
Needed for https://github.com/matrix-org/matrix-appservice-irc/issues/1184

Depends on #276 

This change allows us to specify a maximum ttl of a request before we just consider it stale and drop it. I've also renamed `joinDelayMs` to `actionDelayMs` because it doesn't just affect joins.