### PR TITLE
Fix uploadContent

### DIFF
--- a/changelog.d/279.bugfix
+++ b/changelog.d/279.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where `intent.uploadContent` would return the full JSON response of an upload rather than it's MXC url.

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -707,7 +707,7 @@ export class Intent {
      */
     public async uploadContent(content: Buffer|string|ReadStream, opts: FileUploadOpts = {}): Promise<string> {
         await this.ensureRegistered();
-        return this.client.uploadContent(content, {...opts, onlyContentUri: true});
+        return this.client.uploadContent(content, {...opts, rawResponse: false, onlyContentUri: true});
     }
 
     /**


### PR DESCRIPTION
We didn't set this flag, which meant that the raw body was being returned regardless of the other argument.