### PR TITLE
Hook into the matrix-js-sdk logger and output through winston

### DIFF
--- a/changelog.d/280.feature
+++ b/changelog.d/280.feature
@@ -1,0 +1,1 @@
+Logs from `matrix-js-sdk` will now be passed through the bridge `Logger` to keep logging in one place.

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,9 +236,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -788,9 +788,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2278,9 +2278,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -2966,19 +2966,26 @@
       }
     },
     "matrix-js-sdk": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-8.4.1.tgz",
-      "integrity": "sha512-AfA2y/dt10ysXKzngwqzajzxTL0Xq8lW5bBr0mq21JUKndBP1f1AOOiIkX5nLA9IZGzVoe0anKV+cU2aGWcdkw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-9.1.0.tgz",
+      "integrity": "sha512-4swrPb93qF2lid9mqzCDPMIvUlgS/MIUVxxD0EfNQoapdekFtnf7pMimYs+lMpRk3VDfa01FEsUu1k0q8O+Utw==",
       "requires": {
-        "@babel/runtime": "^7.8.3",
+        "@babel/runtime": "^7.11.2",
         "another-json": "^0.2.0",
         "browser-request": "^0.3.3",
         "bs58": "^4.0.1",
-        "content-type": "^1.0.2",
-        "loglevel": "^1.6.4",
-        "qs": "^6.5.2",
-        "request": "^2.88.0",
-        "unhomoglyph": "^1.0.2"
+        "content-type": "^1.0.4",
+        "loglevel": "^1.7.0",
+        "qs": "^6.9.4",
+        "request": "^2.88.2",
+        "unhomoglyph": "^1.0.6"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+        }
       }
     },
     "media-typer": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jasmine": "^3.6.0",
     "nyc": "^15.1.0",
     "typedoc": "^0.19.0",
-    "typescript": "^4.0.2",
+    "typescript": "4.0",
     "winston-transport": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "is-my-json-valid": "^2.20.5",
     "js-yaml": "^3.14.0",
     "matrix-appservice": "^0.7.1",
-    "matrix-js-sdk": "^8.4.1",
+    "matrix-js-sdk": "^9.1.0",
     "nedb": "^1.8.0",
     "nopt": "^4.0.3",
     "p-queue": "^6.6.2",
@@ -41,7 +41,7 @@
     "winston-daily-rotate-file": "^4.5.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.8",
+    "@types/express": "^4.17",
     "@types/extend": "^3.0.1",
     "@types/js-yaml": "^3.12.5",
     "@types/nedb": "^1.8.10",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -18,6 +18,7 @@ import * as util from "util";
 import yaml from "js-yaml";
 import { Application, Request as ExRequest, Response as ExResponse, NextFunction } from "express";
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const MatrixScheduler = require("matrix-js-sdk").MatrixScheduler;
 
 import { AppServiceRegistration, AppService, AppServiceOutput } from "matrix-appservice";
@@ -1000,7 +1001,8 @@ export class Bridge {
                 throw Error('Cannot call getIntent before calling .run()');
             }
             return this.botIntent;
-        } else if (userId === this.botUserId) {
+        }
+        else if (userId === this.botUserId) {
             if (!this.botIntent) {
                 // This will be defined when .run is called.
                 throw Error('Cannot call getIntent before calling .run()');
@@ -1311,6 +1313,7 @@ export class Bridge {
             const content = event.content as {
                 membership: UserMembership;
                 displayname?: string;
+                // eslint-disable-next-line camelcase
                 avatar_url?: string;
             };
             const profile: UserProfile = {};

--- a/src/components/client-factory.ts
+++ b/src/components/client-factory.ts
@@ -131,7 +131,7 @@ export class ClientFactory {
                     loggerInstance[methodName](...args);
                 }
                 else {
-                    loggerInstance.info(...args)
+                    loggerInstance.debug(...args)
                 }
             }
         }
@@ -145,7 +145,7 @@ export class ClientFactory {
         loggerInstance.debug = loglevel.methodFactory("debug", 1, "matrix");
         loggerInstance.error = loglevel.methodFactory("error", 1, "matrix");
         loggerInstance.trace = loglevel.methodFactory("trace", 1, "matrix");
-        loggerInstance.log = loglevel.methodFactory("info", 1, "matrix");
+        loggerInstance.log = loglevel.methodFactory("debug", 1, "matrix");
     }
 
     /**

--- a/src/components/client-factory.ts
+++ b/src/components/client-factory.ts
@@ -123,11 +123,10 @@ export class ClientFactory {
         // matrix-js-sdk uses the `loglevel` logging library for it's logging
         // but the only way to get it to log to winston is to modify the
         // global methodFactory.
-        // To avoid potentially breaking other bridges, this is off by default.
         loglevel.methodFactory = (methodName, _logLevel, loggerName) => {
             return (...args) => {
                 const loggerInstance = logging.get(`js-sdk:${loggerName}`);
-                if (methodName === "info" || methodName === "debug" ||
+                if (methodName === "debug" ||
                     methodName == "warn" || methodName === "error") {
                     loggerInstance[methodName](...args);
                 }


### PR DESCRIPTION
This fixes a longstanding bug where the js-sdk would log directly to the console which would cause spam in stdout. To solve this, we now log to winston.