### PR TITLE
Fix queue metrics

### DIFF
--- a/changelog.d/283.bugfix
+++ b/changelog.d/283.bugfix
@@ -1,0 +1,1 @@
+Fixed a issue the membership queue where a failed action would cause the `membershipqueue_pending` metric to increase.

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -239,9 +239,6 @@ export class MembershipQueue {
             else {
                 await intent.leave(roomId, reason);
             }
-            this.pendingGauge?.dec({
-                type: kickUser ? "kick" : type
-            });
             this.processedCounter?.inc({
                 type: kickUser ? "kick" : type,
                 outcome: "success",
@@ -255,9 +252,6 @@ export class MembershipQueue {
                     http_status: ex.httpStatus || "none"
                 });
             }
-            this.pendingGauge?.dec({
-                type: kickUser ? "kick" : type
-            });
             if (!this.shouldRetry(ex, attempts)) {
                 this.processedCounter?.inc({
                     type: kickUser ? "kick" : type,
@@ -273,6 +267,11 @@ export class MembershipQueue {
             log.debug(`${reqIdStr} Failed with: ${ex.errcode} ${ex.message}`);
             await new Promise((r) => setTimeout(r, delay));
             this.queueMembership({...item, attempts: attempts + 1});
+        }
+        finally {
+            this.pendingGauge?.dec({
+                type: kickUser ? "kick" : type
+            });
         }
     }
 

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -268,7 +268,9 @@ export class MembershipQueue {
             log.warn(`${reqIdStr} Failed to ${type} ${roomId}, delaying for ${delay}ms`);
             log.debug(`${reqIdStr} Failed with: ${ex.errcode} ${ex.message}`);
             await new Promise((r) => setTimeout(r, delay));
-            this.queueMembership({...item, attempts: attempts + 1});
+            this.queueMembership({...item, attempts: attempts + 1}).catch((innerEx) => {
+                log.error(`Failed to handle membership change:`, innerEx);
+            });
         }
         finally {
             this.pendingGauge?.dec({

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -248,17 +248,17 @@ export class MembershipQueue {
             });
         }
         catch (ex) {
-            if (ex.errcode && ex.httpStatus) {
+            if (ex.errcode || ex.httpStatus) {
                 this.failureReasonCounter?.inc({
                     type: kickUser ? "kick" : type,
-                    errcode: ex.errcode,
-                    http_status: ex.httpStatus
+                    errcode: ex.errcode || "none",
+                    http_status: ex.httpStatus || "none"
                 });
             }
+            this.pendingGauge?.dec({
+                type: kickUser ? "kick" : type
+            });
             if (!this.shouldRetry(ex, attempts)) {
-                this.pendingGauge?.dec({
-                    type: kickUser ? "kick" : type
-                });
                 this.processedCounter?.inc({
                     type: kickUser ? "kick" : type,
                     outcome: "fail",

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -148,6 +148,7 @@ export class MembershipQueue {
      * @param retry Should the request retry if it fails
      * @param ttl How long should this request remain queued in milliseconds
      * before it's discarded. Defaults to `opts.defaultTtlMs`
+     * @returns A promise that resolves when the membership has completed
      */
     public async join(roomId: string, userId: string|undefined, req: ThinRequest, retry = true, ttl?: number) {
         return this.queueMembership({
@@ -172,6 +173,7 @@ export class MembershipQueue {
      * @param kickUser The user to be kicked. If left blank, this will be a leave.
      * @param ttl How long should this request remain queued in milliseconds
      * before it's discarded. Defaults to `opts.defaultTtlMs`
+     * @returns A promise that resolves when the membership has completed
      */
     public async leave(roomId: string, userId: string, req: ThinRequest,
                        retry = true, reason?: string, kickUser?: string,
@@ -196,10 +198,10 @@ export class MembershipQueue {
             if (!queue) {
                 throw Error("Could not find queue for hash");
             }
-            queue.add(() => this.serviceQueue(item));
             this.pendingGauge?.inc({
                 type: item.kickUser ? "kick" : item.type
             });
+            return queue.add(() => this.serviceQueue(item));
         }
         catch (ex) {
             log.error(`Failed to handle membership: ${ex}`);


### PR DESCRIPTION
Fixes #282 by decreasing the value of `pendingGauge` regardless of the outcome of the membership action, as a call to `queueMembership` will increase it.

Also ensures we log a failure reason if either `httpStatus` or `errcode` exists on the exception.