### PR TITLE
Fix runtime conversion

### DIFF
--- a/src/components/client-factory.ts
+++ b/src/components/client-factory.ts
@@ -125,7 +125,7 @@ export class ClientFactory {
         // global methodFactory.
         loglevel.methodFactory = (methodName, _logLevel, loggerName) => {
             return (...args) => {
-                const loggerInstance = logging.get(`js-sdk:${loggerName}`);
+                const loggerInstance = logging.get(`js-sdk:${String(loggerName)}`);
                 if (methodName === "debug" ||
                     methodName == "warn" || methodName === "error") {
                     loggerInstance[methodName](...args);


### PR DESCRIPTION
Fixes
```log
src/components/client-factory.ts:128:62 - error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.

128                 const loggerInstance = logging.get(`js-sdk:${loggerName}`);
                                                                 ~~~~~~~~~~


Found 1 error.
```