### PR TITLE
Allow for returning roomId in onAliasQuery

### DIFF
--- a/changelog.d/288.feature.txt
+++ b/changelog.d/288.feature.txt
@@ -1,0 +1,1 @@
+Allow for returning `roomId` in `onAliasQuery` which facilitates handling room creation yourself.

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -187,6 +187,20 @@ describe("Bridge", function() {
             });
         });
 
+        it("should not create a room if roomId is returned from the function but should still store it",
+        async function() {
+            bridgeCtrl.onAliasQuery.and.returnValue({ roomId: "!abc123:bar" });
+            await bridge.run(101, {}, appService);
+
+            await appService.onAliasQuery("#foo:bar");
+
+            expect(clients["bot"].createRoom).not.toHaveBeenCalled();
+
+            const room = await bridge.getRoomStore().getMatrixRoom("!abc123:bar");
+            expect(room).toBeDefined();
+            expect(room.getId()).toEqual("!abc123:bar");
+        });
+
     it("should provision the room from the returned object", async() => {
             const provisionedRoom = {
                 creationOpts: {

--- a/src/components/client-factory.ts
+++ b/src/components/client-factory.ts
@@ -125,7 +125,7 @@ export class ClientFactory {
         // global methodFactory.
         loglevel.methodFactory = (methodName, _logLevel, loggerName) => {
             return (...args) => {
-                const loggerInstance = logging.get(`js-sdk:${loggerName}`);
+                const loggerInstance = logging.get(`js-sdk:${String(loggerName)}`);
                 if (methodName === "debug" ||
                     methodName == "warn" || methodName === "error") {
                     loggerInstance[methodName](...args);


### PR DESCRIPTION
Allow for returning `roomId` in `onAliasQuery`.

Instead of needing to return `creationOpts`, you can now create the room yourself and return the new `roomId` you made.

---

MR for context where we want this feature: https://gitlab.com/gitterHQ/webapp/-/merge_requests/2088

As discussed in https://matrix.to/#/!ViClwbclMrgQwyPuvH:matrix.org/$VgYNMvbNXI8wjhwD5y9kI_vuQbgWgfF1-akf2VnAaNQ?via=half-shot.uk&via=matrix.org&via=tchncs.de


## Dev notes

```
npm run test -- spec/integ/bridge.spec.js
```