### PR TITLE
Fix onAliasQuery tests which would pass no matter if they failed

### DIFF
--- a/changelog.d/289.bugfix
+++ b/changelog.d/289.bugfix
@@ -1,0 +1,1 @@
+Fix onAliasQuery tests which would pass no matter if they failed


### PR DESCRIPTION
Fix `onAliasQuery` tests which would pass no matter if they failed. Removing all of the broken `done` code in favor of `async`/`await`

Found while working on https://github.com/matrix-org/matrix-appservice-bridge/pull/288#discussion_r533950805