### PR TITLE
Be more explicit about return types

### DIFF
--- a/changelog.d/292.misc
+++ b/changelog.d/292.misc
@@ -1,0 +1,1 @@
+Improve some TypeScript return types

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -968,18 +968,18 @@ export class Bridge {
      * user provided rules and the room state. Will default to true
      * if no rules have been provided.
      * @param roomId The room to check.
-     * @param cache Should the validator check it's cache.
+     * @param cache Should the validator check its cache.
      * @returns resolves if can and rejects if it cannot.
      *          A status code is returned on both.
      */
-    public async canProvisionRoom(roomId: string, cache=true) {
+    public async canProvisionRoom(roomId: string, cache=true): Promise<RoomLinkValidatorStatus> {
         if (!this.roomLinkValidator) {
             return RoomLinkValidatorStatus.PASSED;
         }
         return this.roomLinkValidator.validateRoom(roomId, cache);
     }
 
-    public getRoomLinkValidator() {
+    public getRoomLinkValidator(): RoomLinkValidator | undefined {
         return this.roomLinkValidator;
     }
 

--- a/src/components/client-factory.ts
+++ b/src/components/client-factory.ts
@@ -120,7 +120,7 @@ export class ClientFactory {
             });
         });
 
-        // matrix-js-sdk uses the `loglevel` logging library for it's logging
+        // matrix-js-sdk uses the `loglevel` logging library for its logging
         // but the only way to get it to log to winston is to modify the
         // global methodFactory.
         loglevel.methodFactory = (methodName, _logLevel, loggerName) => {

--- a/src/components/room-link-validator.ts
+++ b/src/components/room-link-validator.ts
@@ -59,7 +59,7 @@ export interface Rules {
 /**
  * The RoomLinkValidator checks if a room should be linked to a remote
  * channel, given a set of rules supplied in a config. The ruleset is maintained
- * in a seperate config from the bridge config. It can be reloaded by triggering
+ * in a separate config from the bridge config. It can be reloaded by triggering
  * an endpoint specified in the {@link Bridge} class.
  */
 export class RoomLinkValidator {
@@ -135,10 +135,10 @@ export class RoomLinkValidator {
         return newRules;
     }
 
-    public async validateRoom (roomId: string, cache=true) {
+    public async validateRoom (roomId: string, cache=true): Promise<RoomLinkValidatorStatus> {
         const status = cache ? this.checkConflictCache(roomId) : undefined;
         if (status !== undefined) {
-            return Promise.reject(status);
+            throw status;
         }
         // Get all users in the room.
         const joined = await this.asBot.getJoinedMembers(roomId);
@@ -160,7 +160,7 @@ export class RoomLinkValidator {
         throw RoomLinkValidatorStatus.ERROR_USER_CONFLICT;
     }
 
-    private checkConflictCache (roomId: string) {
+    private checkConflictCache (roomId: string): RoomLinkValidatorStatus.ERROR_CACHED | undefined {
         const cacheTime = this.conflictCache.get(roomId);
         if (!cacheTime) {
             return undefined;

--- a/src/components/room-upgrade-handler.ts
+++ b/src/components/room-upgrade-handler.ts
@@ -39,7 +39,7 @@ export interface RoomUpgradeHandlerOpts {
     migrateStoreEntries: boolean;
 
     /**
-     * Invoked after a room has been upgraded and it's entries updated.
+     * Invoked after a room has been upgraded and its entries updated.
      *
      * @param oldRoomId The old roomId.
      * @param newRoomId The new roomId.


### PR DESCRIPTION
Adds return type annotations and fixes a few grammatical mistakes.