### PR TITLE
Add healthz endpoint

### DIFF
--- a/changelog.d/305.feature
+++ b/changelog.d/305.feature
@@ -1,0 +1,1 @@
+Add `/healthz` endpoint

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -673,6 +673,12 @@ export class Bridge {
         if (this.metrics) {
             this.metrics.addAppServicePath(this);
         }
+        this.addAppServicePath({
+            method: "GET",
+            checkToken: false,
+            path: "/healthz",
+            handler: this.onHealthz.bind(this)
+        });
         await this.appservice.listen(port, hostname, backlog);
     }
 
@@ -1521,6 +1527,10 @@ export class Bridge {
         await this.selfPingDeferred.defer.promise;
         clearTimeout(this.selfPingDeferred.timeout);
         return Date.now() - sentTs;
+    }
+
+    private onHealthz(_req: ExRequest, res: ExResponse) {
+        res.sendStatus(200);
     }
 
 }


### PR DESCRIPTION
Fixes #228 

In the end I couldn't find a way to separate health from ready -- the last thing the bridge does to ready up is listen for HTTP connections so there wasn't much point.