### PR TITLE
Use m.login.application_service when registering

### DIFF
--- a/changelog.d/315.bugfix
+++ b/changelog.d/315.bugfix
@@ -1,0 +1,1 @@
+Use `type=m.login.application` when registering appservice users, to comply with the spec.

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -1050,7 +1050,7 @@ export class Intent {
             const username = (new MatrixUser(userId)).localpart;
             try {
                 registerRes = await this.botClient.registerRequest({
-                    type: "APPSERVICE_REGISTER_TYPE",
+                    type: APPSERVICE_REGISTER_TYPE,
                     username,
                 });
                 this.opts.registered = true;

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -79,6 +79,7 @@ const returnFirstNumber = (...args: unknown[]) => {
 
 const DEFAULT_CACHE_TTL = 90000;
 const DEFAULT_CACHE_SIZE = 1024;
+export const APPSERVICE_REGISTER_TYPE = "m.login.application_service";
 
 export type PowerLevelContent = {
     // eslint-disable-next-line camelcase
@@ -1046,9 +1047,12 @@ export class Intent {
         }
         let registerRes;
         if (forceRegister || !this.opts.registered) {
-            const localpart = (new MatrixUser(userId)).localpart;
+            const username = (new MatrixUser(userId)).localpart;
             try {
-                registerRes = await this.botClient.register(localpart);
+                registerRes = await this.botClient.registerRequest({
+                    type: "APPSERVICE_REGISTER_TYPE",
+                    username,
+                });
                 this.opts.registered = true;
             }
             catch (err) {


### PR DESCRIPTION
Fixes #314 

This has been a long time coming.

Spec is https://spec.matrix.org/unstable/application-service-api/#client-server-api-extensions