### PR TITLE
Export matrix-appservice

### DIFF
--- a/changelog.d/317.feature
+++ b/changelog.d/317.feature
@@ -1,0 +1,1 @@
+Export `matrix-appservice` classes and interfaces

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ export { unstable } from "./errors";
 export * from "./components/event-types";
 export * from "./components/bridge-info-state";
 
+export { AppServiceRegistration, AppService, AppServiceOutput } from "matrix-appservice";
+
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 const jsSdk = require("matrix-js-sdk");


### PR DESCRIPTION
This was actually done a long time ago but got lost when we moved to TS. We have a recurring problem that every time we release a new `matrix-appservice` and `matrix-appservice-bridge`, every maintainer must update both projects otherwise Typescript will complain about a version mismatch. Let's avoid developers having to import both versions by just exporting it here.