### PR TITLE
Remove master branch

### DIFF
--- a/changelog.d/316.removal
+++ b/changelog.d/316.removal
@@ -1,2 +1,1 @@
-The `master` branch for `https://github.com/matrix-org/matrix-appservice-bridge` is being removed. Users should use the latest release/tag when depending on this library. The latest bleeding edge changes will continue to
-exist on `develop`.
+The `master` branch for `https://github.com/matrix-org/matrix-appservice-bridge` has been deleted. Projects should use the latest release/tag if currently depending on `master`. `develop` will continue to serve as the bleeding edge.

--- a/changelog.d/316.removal
+++ b/changelog.d/316.removal
@@ -1,0 +1,2 @@
+The `master` branch for `https://github.com/matrix-org/matrix-appservice-bridge` is being removed. Users should use the latest release/tag when depending on this library. The latest bleeding edge changes will continue to
+exist on `develop`.

--- a/changelog.d/316.removal
+++ b/changelog.d/316.removal
@@ -1,1 +1,0 @@
-The `master` branch for `https://github.com/matrix-org/matrix-appservice-bridge` has been deleted. Projects should use the latest release/tag if currently depending on `master`. `develop` will continue to serve as the bleeding edge.

--- a/changelog.d/320.removal
+++ b/changelog.d/320.removal
@@ -1,0 +1,1 @@
+The `master` branch for `https://github.com/matrix-org/matrix-appservice-bridge` has been deleted. Projects should use the latest release/tag if currently depending on `master`. `develop` will continue to serve as the bleeding edge.


### PR DESCRIPTION
Note: This will actually be removed when we do a release, but the note must come first.