### PR TITLE
Check m.room.create event on room upgrade

### DIFF
--- a/changelog.d/330.bugfix
+++ b/changelog.d/330.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where the room upgrade handler would not check the `m.room.create` event when traversing an upgrade.

--- a/src/components/room-upgrade-handler.ts
+++ b/src/components/room-upgrade-handler.ts
@@ -145,6 +145,13 @@ export class RoomUpgradeHandler {
     private async onJoinedNewRoom(oldRoomId: string, newRoomId: string) {
         log.debug(`Joined ${newRoomId}`);
         const intent = this.bridge.getIntent();
+        const { predecessor } = await intent.getStateEvent(newRoomId, 'm.room.create');
+        if (predecessor.room_id !== oldRoomId) {
+            log.error(
+    `Room doesn't have a matching predecessor (expected: ${oldRoomId}, got: ${predecessor.room_id}), not bridging.`
+            );
+            return false;
+        }
         const asBot = this.bridge.getBot();
         if (this.opts.migrateStoreEntries) {
             const success = await this.migrateStoreEntries(oldRoomId, newRoomId);


### PR DESCRIPTION
The room upgrade code previously did not check to see if the new room ID referred back to the old room ID when traversing an upgrade.