### PR TITLE
Do not default to port 8090 if explicitly opted out of

### DIFF
--- a/changelog.d/344.feature
+++ b/changelog.d/344.feature
@@ -1,0 +1,1 @@
+The `port` option for `Cli` can be set to `null` to explicity opt out of using the default `8090` port.

--- a/changelog.d/344.feature
+++ b/changelog.d/344.feature
@@ -1,1 +1,2 @@
-The `port` option for `Cli` can be set to `null` to explicity opt out of using the default `8090` port.
+**Breaking**: The `Cli` will no longer specify a default port of `8090` if one is not provided as an command line argument. instead `run` will be called with `null`. Bridge developers **MUST** now handle
+this case.

--- a/spec/integ/cli.spec.js
+++ b/spec/integ/cli.spec.js
@@ -54,7 +54,7 @@ describe("Cli", () => {
             run: (...args) => { runCalledWith = args; }
         });
         cli.run();
-        expect(runCalledWith[0]).toEqual(Cli.DEFAULT_PORT);
+        expect(runCalledWith[0]).toEqual(null);
     });
 
     it("should be able to start the bridge with a custom port", async () => {
@@ -80,7 +80,7 @@ describe("Cli", () => {
             run: (...args) => { runCalledWith = args; }
         });
         cli.run({config: configFile});
-        expect(runCalledWith[0]).toEqual(Cli.DEFAULT_PORT);
+        expect(runCalledWith[0]).toEqual(null);
         expect(runCalledWith[1]).toEqual(configData);
         expect(runCalledWith[2].getOutput()).toEqual(registrationFileContent);
     });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -434,11 +434,11 @@ export class Bridge {
 
     public readonly opts: VettedBridgeOpts;
 
-    public get appService(): AppService|undefined {
+    public get appService() {
         return this.appservice;
     }
 
-    public get botUserId(): string {
+    public get botUserId() {
         if (!this.registration) {
             throw Error('Registration not defined yet');
         }
@@ -703,12 +703,13 @@ export class Bridge {
      * Run the bridge (start listening). This calls `initalise()` and `listen()`.
      * @deprecated Prefer calling initalise and listen seperately.
      * @param port The port to listen on.
+     * @param config Configuration options. NOT USED
      * @param appServiceInstance The AppService instance to attach to.
      * If not provided, one will be created.
      * @param hostname Optional hostname to bind to. (e.g. 0.0.0.0)
      * @return A promise resolving when the bridge is ready
      */
-    public async run(port: number, appServiceInstance?: AppService, hostname = "0.0.0.0", backlog = 10) {
+    public async run<T>(port: number, config: T, appServiceInstance?: AppService, hostname = "0.0.0.0", backlog = 10) {
         await this.initalise();
         await this.listen(port, hostname, backlog, appServiceInstance);
     }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -434,11 +434,11 @@ export class Bridge {
 
     public readonly opts: VettedBridgeOpts;
 
-    public get appService() {
+    public get appService(): AppService|undefined {
         return this.appservice;
     }
 
-    public get botUserId() {
+    public get botUserId(): string {
         if (!this.registration) {
             throw Error('Registration not defined yet');
         }
@@ -703,13 +703,12 @@ export class Bridge {
      * Run the bridge (start listening). This calls `initalise()` and `listen()`.
      * @deprecated Prefer calling initalise and listen seperately.
      * @param port The port to listen on.
-     * @param config Configuration options. NOT USED
      * @param appServiceInstance The AppService instance to attach to.
      * If not provided, one will be created.
      * @param hostname Optional hostname to bind to. (e.g. 0.0.0.0)
      * @return A promise resolving when the bridge is ready
      */
-    public async run<T>(port: number, config: T, appServiceInstance?: AppService, hostname = "0.0.0.0", backlog = 10) {
+    public async run(port: number, appServiceInstance?: AppService, hostname = "0.0.0.0", backlog = 10) {
         await this.initalise();
         await this.listen(port, hostname, backlog, appServiceInstance);
     }

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -25,7 +25,7 @@ import * as logging from "./logging";
 const log = logging.get("cli");
 
 export interface CliOpts<ConfigType extends Record<string, unknown>> {
-    run: (port: number, config: ConfigType|null, registration: AppServiceRegistration|null) => void;
+    run: (port: number|undefined, registration: AppServiceRegistration|null) => void;
     onConfigChanged?: (config: ConfigType) => void,
     generateRegistration?: (reg: AppServiceRegistration, cb: (finalReg: AppServiceRegistration) => void) => void;
     bridgeConfig?: {
@@ -41,21 +41,10 @@ export interface CliOpts<ConfigType extends Record<string, unknown>> {
     defaultPort?: number;
 }
 
-interface VettedCliOpts<ConfigType extends Record<string, unknown>> {
-    run: (port: number, config: ConfigType | null, registration: AppServiceRegistration | null) => void;
-    onConfigChanged?: (config: ConfigType) => void,
-    generateRegistration?: (reg: AppServiceRegistration, cb: (finalReg: AppServiceRegistration) => void) => void;
-    bridgeConfig?: {
-        affectsRegistration?: boolean;
-        schema: string | Record<string, unknown>;
-        defaults: Record<string, unknown>;
-    };
+interface VettedCliOpts<ConfigType extends Record<string, unknown>> extends CliOpts<ConfigType> {
     registrationPath: string;
     enableRegistration: boolean;
     enableLocalpart: boolean;
-    port?: number;
-    noUrl?: boolean;
-    defaultPort?: number;
 }
 
 interface CliArgs {
@@ -95,7 +84,7 @@ export class Cli<ConfigType extends Record<string, unknown>> {
         let defaultPort = opts.defaultPort;
         if (!opts.hasOwnProperty("defaultPort")) {
             // If this explicity hasn't been set, it's 8090
-            defaultPort = Cli.DEFAULT_PORT
+            defaultPort = Cli.DEFAULT_PORT;
         }
 
         this.opts = {
@@ -110,14 +99,14 @@ export class Cli<ConfigType extends Record<string, unknown>> {
      * Get the parsed arguments. Only set after run is called and arguments parsed.
      * @return The parsed arguments
      */
-    public getArgs() {
+    public getArgs(): CliArgs | null {
         return this.args;
     }
     /**
      * Get the loaded and parsed bridge config. Only set after run() has been called.
      * @return The config
      */
-    public getConfig() {
+    public getConfig(): ConfigType|null {
         return this.bridgeConfig;
     }
 
@@ -126,14 +115,14 @@ export class Cli<ConfigType extends Record<string, unknown>> {
      * in the constructor if the user passed a -f flag.
      * @return The path to the registration file.
      */
-    public getRegistrationFilePath() {
+    public getRegistrationFilePath(): string {
         return this.opts.registrationPath;
     }
 
     /**
      * Run the app from the command line. Will parse sys args.
      */
-    public run(args?: CliArgs) {
+    public run(args?: CliArgs): void {
         this.args = args || nopt({
             "generate-registration": Boolean,
             "config": path,
@@ -273,7 +262,7 @@ export class Cli<ConfigType extends Record<string, unknown>> {
         }
 
         this.opts.run(
-            this.opts.port, config,
+            this.opts.port,
             AppServiceRegistration.fromObject(yamlObj as AppServiceOutput)
         );
     }

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -77,25 +77,6 @@ export class Cli<ConfigType extends Record<string, unknown>> {
     /**
      * @constructor
      * @param opts CLI options
-     * @param opts.run The function called when you should run the bridge.
-     * @param opts.generateRegistration The function
-     * called when you should generate a registration.
-     * @param opts.bridgeConfig Bridge-specific config info. If null, no
-     * --config option will be present in the CLI. Default: null.
-     * @param opts.bridgeConfig.affectsRegistration True to make the
-     * --config option required when generating the registration. The parsed config
-     * can be accessed via <code>Cli.getConfig()</code>.
-     * @param opts.bridgeConfig.schema Path to a schema YAML file
-     * (string) or the parsed schema file (Object).
-     * @param opts.bridgeConfig.defaults The default options for the
-     * config file.
-     * @param opts.noUrl Don't ask user for appservice url when generating
-     * registration.
-     * @param opts.enableRegistration Enable '--generate-registration'.
-     * Default True.
-     * @param opts.registrationPath The path to write the registration
-     * file to. Users can overwrite this with -f.
-     * @param opts.enableLocalpart Enable '--localpart [-l]'. Default: false.
      */
     constructor(opts: CliOpts<ConfigType>) {
         if (!opts.run || typeof opts.run !== "function") {

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -25,7 +25,7 @@ import * as logging from "./logging";
 const log = logging.get("cli");
 
 export interface CliOpts<ConfigType extends Record<string, unknown>> {
-    run: (port: number|undefined, registration: AppServiceRegistration|null) => void;
+    run: (port: number|undefined, config: ConfigType|null, registration: AppServiceRegistration|null) => void;
     onConfigChanged?: (config: ConfigType) => void,
     generateRegistration?: (reg: AppServiceRegistration, cb: (finalReg: AppServiceRegistration) => void) => void;
     bridgeConfig?: {
@@ -263,6 +263,7 @@ export class Cli<ConfigType extends Record<string, unknown>> {
 
         this.opts.run(
             this.opts.port,
+            this.bridgeConfig,
             AppServiceRegistration.fromObject(yamlObj as AppServiceOutput)
         );
     }

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -86,13 +86,13 @@ interface VettedCliOpts<ConfigType extends Record<string, unknown>> extends CliO
 }
 
 interface CliArgs {
-    "generate-registration": boolean;
-    config: string;
+    "generate-registration"?: boolean;
+    config?: string;
     url?: string;
-    localpart: string;
-    port: number;
-    file: string;
-    help: boolean;
+    localpart?: string;
+    port?: number;
+    file?: string;
+    help?: boolean;
 }
 
 export class Cli<ConfigType extends Record<string, unknown>> {
@@ -222,7 +222,7 @@ export class Cli<ConfigType extends Record<string, unknown>> {
         this.startWithConfig(this.args.config, this.args.port || null);
     }
 
-    private assignConfigFile(configFilePath: string) {
+    private assignConfigFile(configFilePath?: string) {
         const configFile = (this.opts.bridgeConfig && configFilePath) ? configFilePath : undefined;
         if (!configFile) {
             return;
@@ -250,7 +250,7 @@ export class Cli<ConfigType extends Record<string, unknown>> {
         return validator.validate(cfg, this.opts.bridgeConfig.defaults) as ConfigType;
     }
 
-    private generateRegistration(appServiceUrl: string | undefined, localpart: string) {
+    private generateRegistration(appServiceUrl?: string, localpart?: string) {
         let reg = new AppServiceRegistration(appServiceUrl || "");
         if (localpart) {
             reg.setSenderLocalpart(localpart);
@@ -269,19 +269,21 @@ export class Cli<ConfigType extends Record<string, unknown>> {
     private startWithConfig(configFilename: string|undefined, port: number|null) {
         if (this.opts.onConfigChanged && this.opts.bridgeConfig) {
             log.info("Will listen for SIGHUP");
-            process.on("SIGHUP",
+            if (configFilename) {
+                process.on("SIGHUP",
                 () => {
-                log.info("Got SIGHUP, reloading config file");
-                try {
-                    const newConfig = this.loadConfig(configFilename);
-                    if (this.opts.onConfigChanged) {
-                        this.opts.onConfigChanged(newConfig);
+                    log.info("Got SIGHUP, reloading config file");
+                    try {
+                        const newConfig = this.loadConfig(configFilename);
+                        if (this.opts.onConfigChanged) {
+                            this.opts.onConfigChanged(newConfig);
+                        }
                     }
-                }
-                catch (ex) {
-                    log.warn("Failed to reload config file:", ex);
-                }
-            });
+                    catch (ex) {
+                        log.warn("Failed to reload config file:", ex);
+                    }
+                });
+            }
         }
         const yamlObj = this.loadYaml(this.opts.registrationPath);
         if (typeof yamlObj !== "object") {

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -38,6 +38,7 @@ export interface CliOpts<ConfigType extends Record<string, unknown>> {
     enableLocalpart?: boolean;
     port?: number;
     noUrl?: boolean;
+    defaultPort?: number;
 }
 
 interface VettedCliOpts<ConfigType extends Record<string, unknown>> {
@@ -52,8 +53,9 @@ interface VettedCliOpts<ConfigType extends Record<string, unknown>> {
     registrationPath: string;
     enableRegistration: boolean;
     enableLocalpart: boolean;
-    port: number;
+    port?: number;
     noUrl?: boolean;
+    defaultPort?: number;
 }
 
 interface CliArgs {
@@ -90,12 +92,18 @@ export class Cli<ConfigType extends Record<string, unknown>> {
             );
         }
 
+        let defaultPort = opts.defaultPort;
+        if (!opts.hasOwnProperty("defaultPort")) {
+            // If this explicity hasn't been set, it's 8090
+            defaultPort = Cli.DEFAULT_PORT
+        }
+
         this.opts = {
             ...opts,
             enableRegistration: typeof opts.enableRegistration === 'boolean' ? opts.enableRegistration : true,
             enableLocalpart: Boolean(opts.enableLocalpart),
             registrationPath: opts.registrationPath || Cli.DEFAULT_FILENAME,
-            port: opts.port || Cli.DEFAULT_PORT,
+            port: opts.port || defaultPort,
         };
     }
     /**


### PR DESCRIPTION
Fixes #313

**This breaks the format of Cli.run**

~~We still default to `8090` if no default is given in Cli, but we now allow bridge developers to set their own default port. If the bridge dev explicitly sets `undefined` then **no** default will be set.~~

We now set the port to null if no port is provided.