### PR TITLE
Add ActivityTracker component

### DIFF
--- a/changelog.d/594.feature
+++ b/changelog.d/594.feature
@@ -1,0 +1,1 @@
+Add tracking of last active Matrix users (previously maintained in https://github.com/Half-Shot/matrix-lastactive)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepare": "npm run build",
     "gendoc": "typedoc",
     "lint": "eslint -c .eslintrc.json src/**/*.ts",
-    "test": "jasmine --stop-on-failure=true",
+    "test": "ts-node node_modules/jasmine/bin/jasmine --stop-on-failure=true",
     "check": "npm run lint && npm test",
     "ci-test": "nyc -x \"**/spec/**\" --report text jasmine"
   },
@@ -34,8 +34,8 @@
     "extend": "^3.0.2",
     "is-my-json-valid": "^2.20.5",
     "js-yaml": "^4.0.0",
-    "matrix-bot-sdk": "^0.5.19",
     "matrix-appservice": "^0.8.0",
+    "matrix-bot-sdk": "^0.5.19",
     "matrix-js-sdk": "^9.9.0",
     "nedb": "^1.8.0",
     "nopt": "^5.0.0",
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@types/express": "^4.17.11",
     "@types/extend": "^3.0.1",
+    "@types/jasmine": "^3.8.2",
     "@types/js-yaml": "^4.0.0",
     "@types/nedb": "^1.8.11",
     "@types/node": "^12",
@@ -56,6 +57,7 @@
     "eslint": "^7.22.0",
     "jasmine": "^3.7.0",
     "nyc": "^15.1.0",
+    "ts-node": "^10.2.1",
     "typedoc": "^0.20.36",
     "typescript": "^4.2.3",
     "winston-transport": "^4.4.0"

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,7 +1,8 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "**/*[sS]pec.js"
+    "**/*[sS]pec.js",
+    "**/*[sS]pec.ts"
   ],
   "helpers": [
     "helpers/**/*.js"

--- a/spec/unit/activity-tracker.spec.ts
+++ b/spec/unit/activity-tracker.spec.ts
@@ -27,8 +27,7 @@ function createTracker(canUseWhois: boolean = false, presence?: PresenceEventCon
         }
         throw Error("Path/Method is wrong");
     }
-    const tracker = new ActivityTracker({
-        client,
+    const tracker = new ActivityTracker(client, {
         serverName: "example.com",
         usePresence: !!presence,
         defaultOnline,
@@ -38,10 +37,11 @@ function createTracker(canUseWhois: boolean = false, presence?: PresenceEventCon
 
 describe("ActivityTracker", () => {
     it("constructs", () => {
-        const tracker: any = new ActivityTracker({
-            client: new MatrixClient("http://example.com", "foo"),
-            serverName: "example.com",
-            defaultOnline: false,
+        const tracker: any = new ActivityTracker(
+            new MatrixClient("http://example.com", "foo"),
+            {
+                serverName: "example.com",
+                defaultOnline: false,
         });
     });
     describe("isUserOnline", () => {

--- a/spec/unit/activity-tracker.spec.ts
+++ b/spec/unit/activity-tracker.spec.ts
@@ -1,0 +1,205 @@
+import "jasmine";
+import { ActivityTracker } from "../../src/index";
+import { WhoisInfo, PresenceEventContent, MatrixClient } from "matrix-bot-sdk";
+
+const TEST_USER = "@foobar:example.com";
+
+function createTracker(canUseWhois: boolean = false, presence?: PresenceEventContent, whois?: WhoisInfo, defaultOnline: boolean = false) {
+    const client = new MatrixClient("http://example.com", "foo");
+    client.doRequest = async function (method: string, path: string) {
+        if (method === "GET" && path === "/_synapse/admin/v1/users/@foo:bar/admin") {
+            if (canUseWhois) {
+                throw {statusCode: 400}
+            }
+            throw {statusCode: 403}; // 403 - not an admin
+        }
+        if (method === "GET" && path.startsWith("/_matrix/client/r0/presence/")) {
+            if (!presence) {
+                throw Error("Presence is disabled");
+            }
+            return presence;
+        }
+        if (method === "GET" && path.startsWith("/_matrix/client/r0/admin/whois")) {
+            if (!whois) {
+                throw Error("Whois is disabled");
+            }
+            return whois;
+        }
+        throw Error("Path/Method is wrong");
+    }
+    const tracker = new ActivityTracker({
+        client,
+        serverName: "example.com",
+        usePresence: !!presence,
+        defaultOnline,
+    });
+    return {tracker: tracker as ActivityTracker}
+}
+
+describe("ActivityTracker", () => {
+    it("constructs", () => {
+        const tracker: any = new ActivityTracker({
+            client: new MatrixClient("http://example.com", "foo"),
+            serverName: "example.com",
+            defaultOnline: false,
+        });
+    });
+    describe("isUserOnline", () => {
+        it("will enable whois if it can be used", async () => {
+            const {tracker} = createTracker(true);
+            tracker.setLastActiveTime(TEST_USER);
+            await tracker.isUserOnline(TEST_USER, 1000);
+            expect(tracker.usingWhois).toBeTrue();
+        });
+        it("will disable whois if it can't be used", async () => {
+            const {tracker} = createTracker(false);
+            tracker.setLastActiveTime(TEST_USER);
+            await tracker.isUserOnline(TEST_USER, 1000);
+            expect(tracker.usingWhois).toBeFalse();
+        });
+        it("Will return online if user was bumped recently", async () => {
+            const {tracker} = createTracker(false);
+            tracker.setLastActiveTime(TEST_USER);
+            const res = await tracker.isUserOnline(TEST_USER, 100);
+            expect(res.online).toBeTrue();
+            expect(res.inactiveMs).toBeLessThan(10);
+        });
+        it("will return online if presence is currently active", async () => {
+            const {tracker} = createTracker(false, {
+                currently_active: true,
+                presence: "online",
+            });
+            const res = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res.online).toBeTrue();
+            expect(res.inactiveMs).toEqual(0);
+        });
+        it("will return online if presence status is online", async () => {
+            const {tracker} = createTracker(false, {
+                currently_active: false,
+                presence: "online"
+            });
+            const res = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res.online).toBeTrue();
+            expect(res.inactiveMs).toEqual(0);
+        });
+        it("will return offline if presence last_active_ago > maxTime", async () => {
+            const {tracker} = createTracker(false, {
+                currently_active: false,
+                presence: "offline",
+                last_active_ago: 1001
+            });
+            const res = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res.online).toBeFalse();
+            expect(res.inactiveMs).toEqual(1001);
+        });
+        it("will return offline if canUseWhois is false and presence couldn't be used", async () => {
+            const {tracker} = createTracker(false);
+            const res = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res.online).toBeFalse();
+            expect(res.inactiveMs).toEqual(-1);
+        });
+        it("will return online if the user's time is set appropriately", async () => {
+            const {tracker} = createTracker(false);
+            const res = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res.online).toBeFalse();
+            expect(res.inactiveMs).toEqual(-1);
+            const time = Date.now();
+            await tracker.setLastActiveTime(TEST_USER, time);
+            const res2 = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res2.online).toBeTrue();
+            expect(res2.inactiveMs).toBeLessThan(100); // Account for some time spent.
+        });
+        it("will return online if presence couldn't be used and a device was recently seen", async () => {
+            const now = Date.now();
+            const response: WhoisInfo = {
+                user_id: "@foobar:notexample.com",
+                devices: {
+                    foobar: {
+                        sessions: [{
+                            connections: [{
+                                ip: "127.0.0.1",
+                                last_seen: now - 500,
+                                user_agent: "FakeDevice/1.0.0",
+                            },{
+                                ip: "127.0.0.1",
+                                last_seen: now - 1500,
+                                user_agent: "FakeDevice/2.0.0",
+                            }],
+                        }],
+                    },
+                    foobar500: {
+                        sessions: [{
+                            connections: [{
+                                ip: "127.0.0.1",
+                                last_seen: now - 2500,
+                                user_agent: "FakeDevice/3.0.0",
+                            }],
+                        }],
+                    },
+                },
+            };
+            const {tracker} = createTracker(true, undefined, response);
+
+            const res = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res.online).toBeTrue();
+        });
+        it("will return offline if presence couldn't be used and a device was not recently seen", async () => {
+            const now = Date.now();
+            const response: WhoisInfo = {
+                user_id: "@foobar:notexample.com",
+                devices: {
+                    foobar: {
+                        sessions: [{
+                            connections: [{
+                                ip: "127.0.0.1",
+                                last_seen: now - 1000,
+                                user_agent: "FakeDevice/1.0.0",
+                            },{
+                                ip: "127.0.0.1",
+                                last_seen: now - 1500,
+                                user_agent: "FakeDevice/2.0.0",
+                            }],
+                        }],
+                    },
+                    foobar500: {
+                        sessions: [{
+                            connections: [{
+                                ip: "127.0.0.1",
+                                last_seen: now - 2500,
+                                user_agent: "FakeDevice/3.0.0",
+                            }],
+                        }],
+                    },
+                },
+            };
+            const {tracker} = createTracker(true, undefined, response);
+
+            const res = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res.online).toBeFalse();
+        });
+        it("will default to offline if configured to", async () => {
+            const {tracker} = createTracker(false, undefined, undefined, false);
+            const res = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res.online).toBeFalse();
+            expect(res.inactiveMs).toEqual(-1);
+        });
+        it("will default to online if configured to", async () => {
+            const {tracker} = createTracker(false, undefined, undefined, true);
+            const res = await tracker.isUserOnline(TEST_USER, 1000);
+            expect(res.online).toBeTrue();
+            expect(res.inactiveMs).toEqual(-1);
+        });
+        it("will be online if defaultOnline is overriden", async () => {
+            const {tracker} = createTracker(false, undefined, undefined, false);
+            const res = await tracker.isUserOnline(TEST_USER, 1000, true);
+            expect(res.online).toBeTrue();
+            expect(res.inactiveMs).toEqual(-1);
+        });
+        it("will be offline if defaultOnline is overriden", async () => {
+            const {tracker} = createTracker(false, undefined, undefined, true);
+            const res = await tracker.isUserOnline(TEST_USER, 1000, false);
+            expect(res.online).toBeFalse();
+            expect(res.inactiveMs).toEqual(-1);
+        });
+    })
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -448,7 +448,7 @@ export class Bridge {
 
     private internalActivityTracker?: ActivityTracker;
 
-    public get activityTracker(): ActivityTracker {
+    public get activityTracker(): ActivityTracker|undefined {
         return this.internalActivityTracker;
     }
 

--- a/src/components/activity-tracker.ts
+++ b/src/components/activity-tracker.ts
@@ -1,0 +1,117 @@
+import { MatrixClient } from "matrix-bot-sdk";
+
+interface MatrixActivityTrackerOpts {
+    client: MatrixClient,
+    /**
+     * Matrix server name. Used for determining local and remote users.
+     * @example matrix.org
+     */
+    serverName: string;
+    /**
+     * Should the tracker assume offline or online if it doesn't have enough information.
+     */
+    defaultOnline: boolean;
+    /**
+     * Should presence be used. Set to false if the homeserver has presence disabled.
+     */
+    usePresence?: boolean;
+}
+
+/**
+ * This class provides a "one stop shop" to determine if a user is online. It uses a combination of a
+ * local cache, presence endpoints and admin APIs in that order.
+ */
+export class ActivityTracker {
+    private lastActiveTime: Map<string, number>;
+    private canUseWhois: boolean|null = null;
+    constructor(private opts: MatrixActivityTrackerOpts) {
+        opts.usePresence = opts.usePresence !== undefined ? opts.usePresence : true;
+        this.lastActiveTime = new Map();
+    }
+
+    private get client(): MatrixClient {
+        return this.opts.client;
+    }
+
+    public get usingWhois(): boolean|null {
+        return this.canUseWhois;
+    }
+
+    /**
+     * Sets the last active time of the user to `ts`. By default this is the current time.
+     * @param userId The userId of a user who performed an action.
+     * @param ts The timestamp to set in milliseconds.
+     */
+    public setLastActiveTime(userId: string, ts: number = Date.now()): void {
+        this.lastActiveTime.set(userId, ts);
+    }
+
+    /**
+     * Determine if a user is online or offline using a range of metrics.
+     * @param userId The userId to check
+     * @param maxTimeMs The maximum time a user may be inactive for before they are considered offline.
+     * @param defaultOnline Should the user be online or offline if no data is found. Defaults to `opts.defaultOnline`
+     */
+    public async isUserOnline(
+        userId: string, maxTimeMs: number, defaultOnline?: boolean): Promise<{online: boolean, inactiveMs: number}> {
+        defaultOnline = defaultOnline === undefined ? this.opts.defaultOnline : defaultOnline;
+        if (this.canUseWhois === null) {
+            try {
+                // HACK: Synapse exposes no way to directly determine if a user is an admin, so we use this auth check.
+                await this.client.doRequest("GET", "/_synapse/admin/v1/users/@foo:bar/admin");
+                this.canUseWhois = false; // This should never succeed, but prevent it from trying anyway.
+            }
+            catch (ex) {
+                // We expect this to fail
+                this.canUseWhois = (ex.statusCode === 200 || ex.statusCode === 400);
+            }
+        }
+
+        // First, check if the user has bumped recently.
+        const now = Date.now();
+        const lastActiveTime = this.lastActiveTime.get(userId);
+        if (lastActiveTime) {
+            if (now - lastActiveTime < maxTimeMs) {
+                // Return early, user has bumped recently.
+                return {online: true, inactiveMs: now - lastActiveTime};
+            }
+        }
+        // The user hasn't interacted with the bridge, or it was too long ago.
+        // Check the user's presence.
+        try {
+            if (this.opts.usePresence) {
+                const presence = await this.client.getPresenceStatusFor(userId);
+                if (presence.currentlyActive || presence.state === "online") {
+                    return {online: true, inactiveMs: presence.lastActiveAgo || 0};
+                }
+                else if (presence.lastActiveAgo && presence.lastActiveAgo > maxTimeMs) {
+                    return {online: false, inactiveMs: presence.lastActiveAgo};
+                } // Otherwise, we can't know conclusively.
+            }
+        }
+        catch {
+            // Failed to get presence, going to fallback to admin api.
+        }
+
+        const canUseWhois = this.canUseWhois && userId.split(":")[1] === this.opts.serverName;
+        if (canUseWhois) {
+            try {
+                const whois = await this.client.adminApis.whoisUser(userId);
+                const connections = Object.values(whois.devices).flatMap(
+                    (device) => device.sessions.flatMap((session => session.connections))
+                );
+                const bestConnection = connections.sort((conA, conB) => conB.last_seen - conA.last_seen)[0];
+                return {
+                    online: (now - bestConnection.last_seen) < maxTimeMs, inactiveMs: now - bestConnection.last_seen
+                };
+            }
+            catch (ex) {
+                // Failed to use whois, fall back.
+            }
+        }
+
+        // The user is remote, we don't have any presence for them and they've
+        // not interacted with us so we are going to have to treat them as offline.
+        return {online: defaultOnline, inactiveMs: -1};
+    }
+}

--- a/src/components/activity-tracker.ts
+++ b/src/components/activity-tracker.ts
@@ -46,12 +46,18 @@ export class ActivityTracker {
      */
     public setLastActiveTime(userId: string, ts: number = Date.now()): void {
         this.lastActiveTime.set(userId, ts);
-        if (this.opts.onLastActiveTimeUpdated) {
-            this.opts.onLastActiveTimeUpdated(userId, ts)?.catch((ex) => {
+        (async () => {
+            if (!this.opts.onLastActiveTimeUpdated) {
+                return;
+            }
+            try {
+                await this.opts.onLastActiveTimeUpdated(userId, ts);
+            }
+            catch (ex) {
                 // Not considered fatal, but disappointing.
                 log.debug(`onLastActiveTimeUpdated failed to run for ${userId}`, ex);
-            });
-        }
+            }
+        })();
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export * from "./components/room-link-validator";
 export * from "./components/room-upgrade-handler";
 export * from "./components/app-service-bot";
 export * from "./components/state-lookup";
+export * from "./components/activity-tracker";
 
 // Config and CLI
 export * from "./components/cli";

--- a/yarn.lock
+++ b/yarn.lock
@@ -207,6 +207,18 @@
     "@babel/helper-validator-identifier" "^7.12.11"
     to-fast-properties "^2.0.0"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz#118511f316e2e87ee4294761868e254d3da47960"
+  integrity sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
@@ -268,6 +280,26 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/body-parser@*":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
@@ -275,6 +307,11 @@
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
+
+"@types/chai@^4.2.21":
+  version "4.2.21"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.21.tgz#9f35a5643129df132cf3b5c1ec64046ea1af0650"
+  integrity sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==
 
 "@types/connect@*":
   version "3.4.34"
@@ -306,6 +343,11 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/extend/-/extend-3.0.1.tgz#923dc2d707d944382433e01d6cc0c69030ab2c75"
   integrity sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw==
+
+"@types/jasmine@^3.8.2":
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.8.2.tgz#27ab0aaac29581bcbde5774e1843f90df977078e"
+  integrity sha512-u5h7dqzy2XpXTzhOzSNQUQpKGFvROF8ElNX9P/TJvsHnTg/JvsAseVsGWQAQQldqanYaM+5kwxW909BBFAUYsg==
 
 "@types/js-yaml@^4.0.0":
   version "4.0.1"
@@ -450,10 +492,20 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
+acorn-walk@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.1.1.tgz#3ddab7f84e4a7e2313f6c414c5b7dac85f4e3ebc"
+  integrity sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==
+
 acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
+  integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -523,6 +575,11 @@ archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -873,6 +930,11 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -944,6 +1006,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2107,6 +2174,11 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 marked@~2.0.3:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.7.tgz#bc5b857a09071b48ce82a1f7304913a993d4b7d1"
@@ -3105,6 +3177,24 @@ triple-beam@^1.2.0, triple-beam@^1.3.0:
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
+ts-node@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.1.tgz#4cc93bea0a7aba2179497e65bb08ddfc198b3ab5"
+  integrity sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==
+  dependencies:
+    "@cspotcode/source-map-support" "0.6.1"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -3382,3 +3472,8 @@ yargs@^15.0.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
This has been surgically removed from https://github.com/Half-Shot/matrix-lastactive and added as a component. The bindings to the bridge class follow what we do in https://github.com/matrix-org/matrix-appservice-irc/blob/develop/src/bridge/IrcBridge.ts, with a hook to allow us to update the IRC bridge datastore.

Once this is merged, I'll deprecate matrix-lastactive.

As a side effect, our tests now support being written in TS.