### PR TITLE
Add greedy regex for the bridge namespace

### DIFF
--- a/changelog.d/366.bugfix
+++ b/changelog.d/366.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where bridges could not register multiple user namespaces

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -639,7 +639,13 @@ export class Bridge {
                 url: rawReg.url || undefined,
                 protocols: rawReg.protocols || undefined,
                 namespaces: {
-                    users: rawReg.namespaces?.users || [],
+                    users: [{
+                        // Deliberately greedy regex to fix https://github.com/turt2live/matrix-bot-sdk/issues/159
+                        // Note: We don't use the localpart generating functionality of the bot-sdk,
+                        // so this is okay to do.
+                        regex: "@.+_.+:.*",
+                        exclusive: true,
+                    }],
                     rooms: rawReg.namespaces?.rooms || [],
                     aliases: rawReg.namespaces?.aliases || [],
                 }


### PR DESCRIPTION
We don't use the namespace login in the bot-sdk for anything, so this should be safe to do. We don't use this namespace to inform Synapse, so there isn't a risk to security either.

A solution for https://github.com/turt2live/matrix-bot-sdk/issues/159

Hopefully helps solve https://github.com/matrix-org/matrix-appservice-irc/issues/1490