### PR TITLE
Do not retry membership on a 404 error

### DIFF
--- a/changelog.d/371.bugfix
+++ b/changelog.d/371.bugfix
@@ -1,0 +1,1 @@
+Do not retry membership queue operations after a 404 response.

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -280,10 +280,14 @@ export class MembershipQueue {
     }
 
     private shouldRetry(ex: {body: {code: string; errcode: string;}, statusCode: number}, attempts: number): boolean {
+        const { errcode } = ex.body;
         return !(
             attempts === this.opts.maxAttempts ||
-            ex.body.errcode === "M_FORBIDDEN" ||
-            ex.statusCode === 403
+            // Forbidden
+            errcode === "M_FORBIDDEN" ||
+            ex.statusCode === 403 ||
+            // Not found
+            ex.statusCode === 404
         );
     }
 }


### PR DESCRIPTION
Fixes #370  

This usually means the room doesn't exist for ex: https://github.com/matrix-org/synapse/blob/c01bc5f43d1c7d0a25f397b542ced57894395519/synapse/handlers/room_member.py#L812.