### PR TITLE
Clarify help of matrix_api_calls_failed metric

### DIFF
--- a/changelog.d/372.misc
+++ b/changelog.d/372.misc
@@ -1,0 +1,1 @@
+Clarify help text of matrix_api_calls_failed metric

--- a/src/components/prometheusmetrics.ts
+++ b/src/components/prometheusmetrics.ts
@@ -124,12 +124,12 @@ export class PrometheusMetrics {
     public registerMatrixSdkMetrics(appservice: BotSdkAppservice): void {
         const callCounts = this.addCounter({
             name: "matrix_api_calls",
-            help: "Count of the number of Matrix client API calls made",
+            help: "The number of Matrix client API calls made",
             labels: ["method"],
         });
         const callCountsFailed = this.addCounter({
             name: "matrix_api_calls_failed",
-            help: "Count of the number of Matrix client API calls made",
+            help: "The number of Matrix client API calls which failed",
             labels: ["method"],
         });
 


### PR DESCRIPTION
* "Count of the number" seems like a duplication to me. Though please keep it if it's not apparent which Prometheus values are a Counter.
* `…_calls_failed` had the same help text as `…_calls`