### PR TITLE
Update matrix-appservice to 0.10.0 and fix a js-sdk bug

### DIFF
--- a/changelog.d/374.misc
+++ b/changelog.d/374.misc
@@ -1,0 +1,1 @@
+Update `matrix-appservice` to 0.10.0

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "extend": "^3.0.2",
     "is-my-json-valid": "^2.20.5",
     "js-yaml": "^4.0.0",
-    "matrix-appservice": "^0.8.0",
+    "matrix-appservice": "^0.10.0",
     "matrix-bot-sdk": "^0.6.0-beta.2",
     "matrix-js-sdk": "^12.4.1",
     "nedb": "^1.8.0",

--- a/spec/unit/app-service-bot.spec.js
+++ b/spec/unit/app-service-bot.spec.js
@@ -14,7 +14,7 @@ describe("AppServiceBot", function() {
         client.credentials = {
             userId: botUserId
         };
-        client._http = jasmine.createSpyObj("MatrixHttpApi", ["authedRequest"]);
+        client.http = jasmine.createSpyObj("MatrixHttpApi", ["authedRequest"]);
         reg = jasmine.createSpyObj("AppServiceRegistration", ["getOutput"]);
         reg.getOutput.and.returnValue({
             namespaces: {

--- a/src/components/client-factory.ts
+++ b/src/components/client-factory.ts
@@ -191,7 +191,7 @@ export class ClientFactory {
             localTimeoutMs: 1000 * 60 * 2, // Time out CS-API calls after 2mins
         };
         client = this.sdk.createClient(clientOpts);
-        client._http.opts._reqId = reqId; // FIXME gut wrenching
+        client.http.opts._reqId = reqId; // FIXME gut wrenching
 
         // add a listener for the completion of this request so we can cleanup
         // the clients we've made

--- a/yarn.lock
+++ b/yarn.lock
@@ -2173,7 +2173,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.14.0:
+js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -2181,7 +2181,7 @@ js-yaml@^3.13.1, js-yaml@^3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.0.0:
+js-yaml@^4.0.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -2381,15 +2381,15 @@ marked@~2.0.3:
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.7.tgz#bc5b857a09071b48ce82a1f7304913a993d4b7d1"
   integrity sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==
 
-matrix-appservice@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/matrix-appservice/-/matrix-appservice-0.8.0.tgz#c366cd9e38ff1c02594f37d5851a7fc57761ccae"
-  integrity sha512-mfgMpmV3dWLtzrd4V/3XtqUD0P44I/mTgsRreW5jMhSaUnnRGZbpptBw2q4/axbLjw2FarlWtOVgertDGMtccA==
+matrix-appservice@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/matrix-appservice/-/matrix-appservice-0.10.0.tgz#11b96dfda4567c04c8d14cd7b51110a3c6991c29"
+  integrity sha512-bxkvPaFXzuuRfqSQgIBbA6M+nKXeRJEeZlJfzjhP0RBBMl62HQTXqNLSVHhLRCdzKbr1OayrbDKL+BnmoghDDA==
   dependencies:
     "@types/express" "^4.17.8"
     body-parser "^1.19.0"
     express "^4.17.1"
-    js-yaml "^3.14.0"
+    js-yaml "^4.1.0"
     morgan "^1.10.0"
 
 matrix-bot-sdk@^0.6.0-beta.2:


### PR DESCRIPTION
Ho hum, because we gut wrench the JS SDK. At some point we're going to need to kill it off, but not yet.