### PR TITLE
Use m.login.application_service

### DIFF
--- a/changelog.d/389.misc
+++ b/changelog.d/389.misc
@@ -1,0 +1,1 @@
+Logging in as an appservice user (for encryption support) now uses `m.login.application_service` rather than the unstable prefix. This may break on homeservers that are not up to date with Matrix v1.2.

--- a/src/components/encryption.ts
+++ b/src/components/encryption.ts
@@ -8,7 +8,7 @@ import LRU from "@alloc/quick-lru"
 
 const log = Logging.get("EncryptedEventBroker");
 
-export const APPSERVICE_LOGIN_TYPE = "uk.half-shot.msc2778.login.application_service";
+export const APPSERVICE_LOGIN_TYPE = "m.login.application_service";
 const EVENT_CACHE_FOR_MS = 5 * 60000; // 5 minutes
 
 interface PantalaimonWeakEvent extends WeakEvent {


### PR DESCRIPTION
This is now part of the Matrix spec, we don't need to use the unstable prefix. Suggest the next version of this library is breaking to support this.