### PR TITLE
Support extensible events

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "js-yaml": "^4.0.0",
     "matrix-appservice": "^0.10.0",
     "matrix-bot-sdk": "^0.6.0-beta.2",
+    "matrix-events-sdk": "^0.0.1-beta.6",
     "matrix-js-sdk": "^12.4.1",
     "nedb": "^1.8.0",
     "nopt": "^5.0.0",

--- a/src/components/request-factory.ts
+++ b/src/components/request-factory.ts
@@ -33,8 +33,8 @@ export class RequestFactory {
      * @param opts The options to pass to the Request constructor, if any.
      * @return A new request object
      */
-    public newRequest<T>(opts?: RequestOpts<T>) {
-        const req = new Request(opts || {data: null});
+    public newRequest<T, R extends unknown>(opts?: RequestOpts<T>): Request<T, R> {
+        const req = new Request(opts);
         req.getPromise().then((res) => {
             this._resolves.forEach((resolveFn) => {
                 resolveFn(req, res);

--- a/src/utils/promiseutil.ts
+++ b/src/utils/promiseutil.ts
@@ -34,6 +34,6 @@ export function defer<T>(): Defer<T> {
     };
 }
 
-export function delay(delayMs: number) {
+export function delay(delayMs: number): Promise<void> {
     return new Promise((r) => setTimeout(r, delayMs));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,6 +2428,11 @@ matrix-bot-sdk@^0.6.0-beta.2:
   optionalDependencies:
     better-sqlite3 "^7.4.3"
 
+matrix-events-sdk@^0.0.1-beta.6:
+  version "0.0.1-beta.6"
+  resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1-beta.6.tgz#9001090ed2e2bf29efc113d6b29871bcc6520749"
+  integrity sha512-VMqPXe3Bg4R9yC9PNqGv6bDFwWlVYadYxp0Ke1ihhXUCpGcx7e28kOYcqK2T3RxLXK4KK7VH4JRbY53Do3r+Fw==
+
 matrix-js-sdk@^12.4.1:
   version "12.4.1"
   resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-12.4.1.tgz#966f506b4146e4fafffa5bbe80f5c53515e1bc78"


### PR DESCRIPTION
Closes #390 

Matrix is moving to a new model for events where by messages no longer contain one representation, but a series of fallbacks (known as extensible events) so that applications can choose the best representation.

The bridge sdk will make use of the `matrix-events-sdk` to automatically parse and represent these events, and then use a new controller callback to emit these events. This is currently unstable, and so bridges need to explicitly opt in to this behavior to use it.

See https://github.com/matrix-org/matrix-events-sdk#readme
See https://github.com/matrix-org/matrix-doc/pull/1767