### PR TITLE
Provisioner small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
- 3.2.0 (2021-11-23)
+4.0.0 (2022-03-31)
+==================
+
+Features
+--------
+
+- Add new `Provisioning and Widgets API`, so that bridges can provide richer integration APIs ([\#365](https://github.com/matrix-org/matrix-appservice-bridge/issues/365), [\#388](https://github.com/matrix-org/matrix-appservice-bridge/issues/388))
+
+
+Deprecations and Removals
+-------------------------
+
+- Drop support for Node 12. Support Node 14+. ([\#382](https://github.com/matrix-org/matrix-appservice-bridge/issues/382))
+
+
+Internal Changes
+----------------
+
+- Update typedoc to 0.22.9 ([\#377](https://github.com/matrix-org/matrix-appservice-bridge/issues/377))
+- Logging in as an appservice user (for encryption support) now uses `m.login.application_service` rather than the unstable prefix. This may break on homeservers that are not up to date with Matrix v1.2. ([\#389](https://github.com/matrix-org/matrix-appservice-bridge/issues/389))
+- Replace Buildkite with GitHub Actions for CI. ([\#392](https://github.com/matrix-org/matrix-appservice-bridge/issues/392))
+
+
+3.2.0 (2021-11-23)
 ===================
 
 Features

--- a/changelog.d/365.feature
+++ b/changelog.d/365.feature
@@ -1,1 +1,0 @@
-Add new `Provisioning and Widgets API`, so that bridges can provide richer integration APIs

--- a/changelog.d/377.misc
+++ b/changelog.d/377.misc
@@ -1,1 +1,0 @@
-Update typedoc to 0.22.9

--- a/changelog.d/382.removal
+++ b/changelog.d/382.removal
@@ -1,1 +1,0 @@
-Drop support for Node 12. Support Node 14+.

--- a/changelog.d/388.feature
+++ b/changelog.d/388.feature
@@ -1,1 +1,0 @@
-Add new `Provisioning and Widgets API`, so that bridges can provide richer integration APIs

--- a/changelog.d/389.misc
+++ b/changelog.d/389.misc
@@ -1,1 +1,0 @@
-Logging in as an appservice user (for encryption support) now uses `m.login.application_service` rather than the unstable prefix. This may break on homeservers that are not up to date with Matrix v1.2.

--- a/changelog.d/392.misc
+++ b/changelog.d/392.misc
@@ -1,1 +1,0 @@
-Replace Buildkite with GitHub Actions for CI.

--- a/changelog.d/397.bugfix
+++ b/changelog.d/397.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where the provisioner API's `/v1/exchange_openid` route would sometimes fail.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-appservice-bridge",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Bridging infrastructure for Matrix Application Services",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/provisioning/api.ts
+++ b/src/provisioning/api.ts
@@ -349,7 +349,8 @@ export class ProvisioningApi {
 
         // Now do the token exchange
         try {
-            const response = await axios.get<{sub: string}>(`${url}/_matrix/federation/v1/openid/userinfo`, {
+            const requestUrl = new URL("/_matrix/federation/v1/openid/userinfo", url);
+            const response = await axios.get<{sub: string}>(requestUrl.toString(), {
                 params: {
                     access_token: openIdToken,
                 },

--- a/src/provisioning/api.ts
+++ b/src/provisioning/api.ts
@@ -11,6 +11,7 @@ import IPCIDR from "ip-cidr";
 import { isIP } from "net";
 import { promises as dns } from "dns";
 import ratelimiter, { RateLimitInfo, Options as RatelimitOptions, AugmentedRequest } from "express-rate-limit";
+import { Methods } from "./request";
 
 // Borrowed from
 // https://github.com/matrix-org/synapse/blob/91221b696156e9f1f9deecd425ae58af03ebb5d3/docs/sample_config.yaml#L215
@@ -196,7 +197,7 @@ export class ProvisioningApi {
     }
 
     public addRoute(
-        method: "get"|"post"|"delete"|"put",
+        method: Methods,
         path: string,
         handler: (req: ProvisioningRequest, res: Response, next?: NextFunction) => void|Promise<void>,
         fnName?: string): void {

--- a/src/provisioning/request.ts
+++ b/src/provisioning/request.ts
@@ -1,16 +1,51 @@
 import Logging, { LogWrapper } from "../components/logging";
 import crypto from "crypto";
 import { ThinRequest } from "..";
+import { Request } from "express";
+import { ParsedQs } from "qs";
+
+// Methods supported by a express.Router
+export type Methods = 'all' |
+'get' |
+'post' |
+'put' |
+'delete' |
+'patch' |
+'options' |
+'head' |
+'checkout' |
+'connect' |
+'copy' |
+'lock' |
+'merge' |
+'mkactivity' |
+'mkcol' |
+'move' |
+'m-search' |
+'notify' |
+'propfind' |
+'proppatch' |
+'purge' |
+'report' |
+'search' |
+'subscribe' |
+'trace' |
+'unlock' |
+'unsubscribe';
 
 export class ProvisioningRequest<
-    Body = Record<string, unknown>, Params = Record<string, unknown>
-    > implements ThinRequest {
+    // These types are taken from express.Request
+    Params = {[key: string]: string},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ResBody = any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ReqBody = any,
+    ReqQuery = ParsedQs> implements ThinRequest {
     public readonly log: LogWrapper;
     public readonly id: string;
 
-
     constructor(
-        private expressReq: {body: Body, params: Params, path?: string},
+        public readonly expressReq: Request<Params, ResBody, ReqBody, ReqQuery>,
         public readonly userId: string|null,
         public readonly requestSource: "widget"|"provisioner",
         public readonly widgetToken?: string,
@@ -21,18 +56,22 @@ export class ProvisioningRequest<
         this.log = Logging.get(
             `ProvisionRequest ${[this.id, fnName].filter(n => !!n).join(" ")}`
         );
-        this.log.info(`New request from ${userId} via ${requestSource}`);
+        this.log.debug(`Request ${userId} (${requestSource}) ${this.fnName}`);
     }
 
     public getId(): string {
         return this.id;
     }
 
-    get body(): Body {
+    get body(): ReqBody {
         return this.expressReq.body;
     }
 
     get params(): Params {
         return this.expressReq.params;
+    }
+
+    get query(): ReqQuery {
+        return this.expressReq.query;
     }
 }

--- a/src/utils/matrix-host-resolver.ts
+++ b/src/utils/matrix-host-resolver.ts
@@ -105,7 +105,17 @@ export class MatrixHostResolver {
         if (wellKnown.status !== 200) {
             throw Error('Well known request returned non-200');
         }
-        const mServer = wellKnown.data["m.server"];
+        let data: MatrixServerWellKnown;
+        if (typeof wellKnown.data === "object") {
+            data = wellKnown.data;
+        }
+        else if (typeof wellKnown.data === "string") {
+            data = JSON.parse(wellKnown.data);
+        }
+        else {
+            throw Error('Invalid datatype for well-known response');
+        }
+        const mServer = data["m.server"];
         if (typeof mServer !== "string") {
             throw Error("Missing 'm.server' in well-known response");
         }


### PR DESCRIPTION
A few things I found annoying when working on the hookshot widget stuff:
 - `addRoute` had only a few supported methods, this has now been increased to all supported methods by `Router`
 - The openID handling code wasn't correctly concatenating the homeserver base URL and the request path.
 - The request logging felt too noisy at info, so I reduced it down to `debug`. I'm still 50/50 on that change.
 - The matrix-host-resolver would die if the well known Content-Type was not `application/json`. While we could be strict, it appears Synapse is not and we should attempt to parse strings as JSON.