### PR TITLE
Remove option to disable authentication of the 3pid endpoints

### DIFF
--- a/changelog.d/409.removal
+++ b/changelog.d/409.removal
@@ -1,0 +1,1 @@
+The bridge now always authenticates requests made to `/_matrix/app/v1/thirdparty/...`. The `Bridge` options flag `authenticateThirdpartyEndpoints` has been removed.

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -825,7 +825,6 @@ export class Bridge {
             this.addAppServicePath({
                 method: "GET",
                 path: "/_matrix/app/:version(v1|unstable)/thirdparty/protocol/:protocol",
-                checkToken: true,
                 handler: async (req, res) => {
                     const protocol = req.params.protocol;
 
@@ -967,7 +966,6 @@ export class Bridge {
      */
     public addAppServicePath(opts: {
         method: "GET"|"PUT"|"POST"|"DELETE",
-        checkToken?: boolean,
         path: string,
         handler: (req: ExRequest, respose: ExResponse, next: NextFunction) => void,
     }): void {
@@ -975,10 +973,9 @@ export class Bridge {
             throw Error('Cannot call addAppServicePath before calling .run()');
         }
         const app: Application = this.appservice.expressApp;
-        opts.checkToken = opts.checkToken ?? true;
 
         app[opts.method.toLowerCase() as "get"|"put"|"post"|"delete"](opts.path, (req, res, ...args) => {
-            if (opts.checkToken && !this.requestCheckToken(req)) {
+            if (!this.requestCheckToken(req)) {
                 return res.status(403).send({
                     errcode: "M_FORBIDDEN",
                     error: "Bad token supplied,"

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -253,7 +253,6 @@ export interface BridgeOpts {
     roomLinkValidation?: {
         rules: Rules;
     };
-    authenticateThirdpartyEndpoints?: boolean;
     roomUpgradeOpts?: RoomUpgradeHandlerOpts;
 
     bridgeEncryption?: {
@@ -406,7 +405,6 @@ interface VettedBridgeOpts {
     roomLinkValidation?: {
         rules: Rules;
     };
-    authenticateThirdpartyEndpoints: boolean;
     roomUpgradeOpts?: RoomUpgradeHandlerOpts;
     bridgeEncryption?: {
         homeserverUrl: string;
@@ -499,7 +497,6 @@ export class Bridge {
             ...opts,
             disableContext: opts.disableStores ? true : (opts.disableContext ?? false),
             disableStores: opts.disableStores ?? false,
-            authenticateThirdpartyEndpoints: opts.authenticateThirdpartyEndpoints ?? false,
             userStore: opts.userStore || "user-store.db",
             userActivityStore: opts.userActivityStore || "user-activity-store.db",
             roomStore: opts.roomStore || "room-store.db",
@@ -828,7 +825,7 @@ export class Bridge {
             this.addAppServicePath({
                 method: "GET",
                 path: "/_matrix/app/:version(v1|unstable)/thirdparty/protocol/:protocol",
-                checkToken: this.opts.authenticateThirdpartyEndpoints,
+                checkToken: true,
                 handler: async (req, res) => {
                     const protocol = req.params.protocol;
 
@@ -854,7 +851,6 @@ export class Bridge {
             this.addAppServicePath({
                 method: "GET",
                 path: "/_matrix/app/:version(v1|unstable)/thirdparty/location/:protocol",
-                checkToken: this.opts.authenticateThirdpartyEndpoints,
                 handler: async (req, res) => {
                     const protocol = req.params.protocol;
 
@@ -883,7 +879,6 @@ export class Bridge {
             this.addAppServicePath({
                 method: "GET",
                 path: "/_matrix/app/:version(v1|unstable)/thirdparty/location",
-                checkToken: this.opts.authenticateThirdpartyEndpoints,
                 handler: async (req, res) => {
                     const alias = req.query.alias;
                     if (!alias) {
@@ -912,7 +907,6 @@ export class Bridge {
             this.addAppServicePath({
                 method: "GET",
                 path: "/_matrix/app/:version(v1|unstable)/thirdparty/user/:protocol",
-                checkToken: this.opts.authenticateThirdpartyEndpoints,
                 handler: async (req, res) => {
                     const protocol = req.params.protocol;
 
@@ -941,7 +935,6 @@ export class Bridge {
             this.addAppServicePath({
                 method: "GET",
                 path: "/_matrix/app/:version(v1|unstable)/thirdparty/user",
-                checkToken: this.opts.authenticateThirdpartyEndpoints,
                 handler: async (req, res) => {
                     const userid = req.query.userid;
                     if (!userid) {
@@ -985,7 +978,7 @@ export class Bridge {
             throw Error('Cannot call addAppServicePath before calling .run()');
         }
         const app: Application = this.appservice.expressApp;
-        opts.checkToken = opts.checkToken !== undefined ? opts.checkToken : true;
+        opts.checkToken = opts.checkToken ?? true;
         // TODO(paul): Consider more options:
         //   opts.versions - automatic version filtering and rejecting of
         //     unrecognised API versions

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -915,9 +915,6 @@ export class Bridge {
                         return;
                     }
 
-                    // Do not leak access token to function
-                    delete req.query.access_token;
-
                     try {
                         const result = await getUserFunc(protocol, req.query as Record<string, string[]|string>);
                         res.status(200).json(result);
@@ -979,10 +976,7 @@ export class Bridge {
         }
         const app: Application = this.appservice.expressApp;
         opts.checkToken = opts.checkToken ?? true;
-        // TODO(paul): Consider more options:
-        //   opts.versions - automatic version filtering and rejecting of
-        //     unrecognised API versions
-        // Consider automatic "/_matrix/app/:version(v1|unstable)" path prefix
+
         app[opts.method.toLowerCase() as "get"|"put"|"post"|"delete"](opts.path, (req, res, ...args) => {
             if (opts.checkToken && !this.requestCheckToken(req)) {
                 return res.status(403).send({
@@ -990,6 +984,10 @@ export class Bridge {
                     error: "Bad token supplied,"
                 });
             }
+
+            // Do not leak access token to function
+            delete req.query.access_token;
+
             return opts.handler(req, res, ...args);
         });
     }

--- a/src/components/prometheusmetrics.ts
+++ b/src/components/prometheusmetrics.ts
@@ -399,9 +399,6 @@ export class PrometheusMetrics {
         bridge.addAppServicePath({
             method: "GET",
             path: "/metrics",
-            // TODO: Ideally these metrics would be on a different port.
-            // For now, leave this unauthenticated.
-            checkToken: false,
             handler: async (_req: Request, res: Response) => {
                 try {
                     await this.refresh();


### PR DESCRIPTION
Fixes #76 

As of https://github.com/matrix-org/synapse/pull/12746, Synapse now correctly sends us an access token when handling third party requests. There is no longer any need leave these endpoints unauthenticated.