### PR TITLE
Logging system refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ many virtual / real users are in each, etc.
 ## `Logging`
 
 This component exposes access to the bridges log reporter.
-To use the component, use `Logging.configure` to setup 
+To use the component, use `Logger.configure` to setup 
 the logger.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ components you use, though some components depend upon other components.
 All components operate on data models defined in the bridge. You can directly
 construct components: the bridge exposes the class constructor.
 
+### `Bridge`
+The component which orchestrates other components: a "glue" component. Provides
+a way to start the bridge. This is the component most examples use. Has
+dependencies on most of the components listed above.
+
 ### `BridgeStore`
 Provides basic document store (key-value) CRUD operations.
 
@@ -92,50 +97,26 @@ A wrapper around the JS SDK `MatrixClient` designed for use by the application
 service *itself*. Contains helper methods to get all rooms the AS is in, how
 many virtual / real users are in each, etc.
 
-### `Bridge`
-The component which orchestrates other components: a "glue" component. Provides
-a way to start the bridge. This is the component most examples use. Has
-dependencies on most of the components listed above.
-
 ## `Logging`
-This component exposes access to the bridges log reporter. To use, you should
-install the optional packages `winston@3`, `winston-daily-rotate-file@2` and
-`chalk@2` to get nice formatted log lines, otherwise it will default to the JS
-console. To use the component, use `Logging.configure(configObject)` to setup
-the logger, which takes the following options:
-```javascript
-{
-    // A level to set the console reporter to.
-    console: "error|warn|info|debug|off",
 
-    // Format to append to log files.
-    fileDatePattern: "YYYY-MM-DD",
+This component exposes access to the bridges log reporter.
+To use the component, use `Logging.configure` to setup 
+the logger.
 
-    // Format of the timestamp in log files.
-    timestampFormat: "MMM-D HH:mm:ss.SSS",
+```js
+// Configure the logger by providing these options
+Logger.configure({ level: "info" });
 
-    // Log files to emit to, keyed of the minimum level they report.
-    // You can leave this out, or set it to false to disable files.
-    files: {
-        // File paths can be relative or absolute, the date is appended onto the end.
-        "abc.log" => "error|warn|info|debug|off",
-    },
+// In each module, instantiate the Logger class with a module name.
+const log = new Logger('MyModule');
 
-    // The maximum number of files per level before old files get cleaned
-    // up. Use 0 to disable.
-    maxFiles: 5,
-}
+// Then log away!
+log.info('Hello, this is a log from my module');
+log.debug('Some debug info');
+log.error('Oh no, something went wrong!', new Error('an error'));
 ```
 
-
 You **MUST** configure the logger before anything will be emitted to the console.
-
-You can then use `const log = Logging.Get(ModuleName)` to start logging to the reporter,
-using the `log.error`, `log.warn`, `log.info` or `log.debug` functions. Arguments to these functions will
-automatically be seralized if they aren't strings.
-
-NOTE: ``opts.controller.onLog`` will override this, but if not set then the logging
-transport is used.
 
 ## `RoomLinkValidator`
 This component validates if a room can be linked to a remote channel based on

--- a/changelog.d/412.feature
+++ b/changelog.d/412.feature
@@ -1,0 +1,2 @@
+Port the Logger class from `matrix-hookshot` to this SDK, granting JSON logging support and less noisy logs.
+**Note**: This change is breaking. `Logging.get(...)` becomes `new Logger(...)` and `Logging.configure` becomes `Logger.configure`.

--- a/examples/encryption/yarn.lock
+++ b/examples/encryption/yarn.lock
@@ -871,6 +871,13 @@ is-arrayish@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
+is-core-module@^2.8.1:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
+  integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
+  dependencies:
+    has "^1.0.3"
+
 is-my-ip-valid@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz#f7220d1146257c98672e6fba097a9f3f2d348442"
@@ -1280,6 +1287,16 @@ parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-to-regexp@0.1.7:
   version "0.1.7"

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -310,7 +310,7 @@ describe("Bridge", function() {
             const event = {
                 content: {
                     body: "oh noes!",
-                    LogEntryPart: "m.text"
+                    msgtype: "m.text"
                 },
                 sender: "@virtual_foo:bar",
                 room_id: "!flibble:bar",
@@ -351,12 +351,12 @@ describe("Bridge", function() {
                 const event = {
                     content: {
                         body: ' * my message edit',
-                        'm.new_content': { body: 'my message edit', LogEntryPart: 'm.text' },
+                        'm.new_content': { body: 'my message edit', msgtype: 'm.text' },
                         'm.relates_to': { 
                             event_id: '$ZrXenSQt4TbtHnMclrWNJdiP7SrRCSdl3tAYS81H2bs',
                             rel_type: 'm.replace' 
                         },
-                    LogEntryPart: 'm.text'
+                    msgtype: 'm.text'
                     },
                     event_id: '$tagvjsXZqBOBWtHijq2qg0Un-uqVunrFLxiJyOIVGQ8',
                     room_id: '!dtJaPyDtsoOLTgJVmy:my.matrix.host',
@@ -446,7 +446,7 @@ describe("Bridge", function() {
             const event = {
                 content: {
                     body: "oh noes!",
-                    LogEntryPart: "m.text"
+                    msgtype: "m.text"
                 },
                 sender: "@foo:bar",
                 room_id: "!flibble:bar",
@@ -472,7 +472,7 @@ describe("Bridge", function() {
             const event = {
                 content: {
                     body: "oh noes!",
-                    LogEntryPart: "m.text"
+                    msgtype: "m.text"
                 },
                 sender: "@alice:bar",
                 room_id: "!flibble:bar",
@@ -555,7 +555,7 @@ describe("Bridge", function() {
             const event = {
                 content: {
                     body: "oh noes!",
-                    LogEntryPart: "m.text"
+                    msgtype: "m.text"
                 },
                 sender: "@alice:bar",
                 room_id: "!flibble:bar",

--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -310,7 +310,7 @@ describe("Bridge", function() {
             const event = {
                 content: {
                     body: "oh noes!",
-                    msgtype: "m.text"
+                    LogEntryPart: "m.text"
                 },
                 sender: "@virtual_foo:bar",
                 room_id: "!flibble:bar",
@@ -351,12 +351,12 @@ describe("Bridge", function() {
                 const event = {
                     content: {
                         body: ' * my message edit',
-                        'm.new_content': { body: 'my message edit', msgtype: 'm.text' },
+                        'm.new_content': { body: 'my message edit', LogEntryPart: 'm.text' },
                         'm.relates_to': { 
                             event_id: '$ZrXenSQt4TbtHnMclrWNJdiP7SrRCSdl3tAYS81H2bs',
                             rel_type: 'm.replace' 
                         },
-                    msgtype: 'm.text'
+                    LogEntryPart: 'm.text'
                     },
                     event_id: '$tagvjsXZqBOBWtHijq2qg0Un-uqVunrFLxiJyOIVGQ8',
                     room_id: '!dtJaPyDtsoOLTgJVmy:my.matrix.host',
@@ -446,7 +446,7 @@ describe("Bridge", function() {
             const event = {
                 content: {
                     body: "oh noes!",
-                    msgtype: "m.text"
+                    LogEntryPart: "m.text"
                 },
                 sender: "@foo:bar",
                 room_id: "!flibble:bar",
@@ -472,7 +472,7 @@ describe("Bridge", function() {
             const event = {
                 content: {
                     body: "oh noes!",
-                    msgtype: "m.text"
+                    LogEntryPart: "m.text"
                 },
                 sender: "@alice:bar",
                 room_id: "!flibble:bar",
@@ -555,7 +555,7 @@ describe("Bridge", function() {
             const event = {
                 content: {
                     body: "oh noes!",
-                    msgtype: "m.text"
+                    LogEntryPart: "m.text"
                 },
                 sender: "@alice:bar",
                 room_id: "!flibble:bar",

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -258,7 +258,7 @@ describe("Intent", function() {
     describe("sending message events", function() {
         const content = {
             body: "hello world",
-            msgtype: "m.text",
+            LogEntryPart: "m.text",
         };
 
         beforeEach(function() {

--- a/spec/unit/intent.spec.js
+++ b/spec/unit/intent.spec.js
@@ -258,7 +258,7 @@ describe("Intent", function() {
     describe("sending message events", function() {
         const content = {
             body: "hello world",
-            LogEntryPart: "m.text",
+            msgtype: "m.text",
         };
 
         beforeEach(function() {

--- a/spec/unit/logging.spec.ts
+++ b/spec/unit/logging.spec.ts
@@ -1,0 +1,86 @@
+import { Writable } from "stream";
+import { Logger, GlobalLogger } from "../../src/index";
+
+const tortureArgs: [unknown, ...unknown[]][] = [
+    ["test-msg"],
+    [Number.MAX_VALUE],
+    [false],
+    [Buffer.from('foo')],
+    [new Error('Test')],
+    [undefined],
+    [null],
+    [NaN],
+    [[]],
+    [() => { /*dummy*/}],
+    ["Foo", "test-msg"],
+    ["Foo", Number.MAX_VALUE],
+    ["Foo", false],
+    ["Foo", Buffer.from('foo')],
+    ["Foo", new Error('Test')],
+    ["Foo", undefined],
+    ["Foo", null],
+    ["Foo", NaN],
+    ["Foo", []],
+    ["Foo", () => { /*dummy*/}],
+]
+
+const MODULE_NAME = 'LogTesting';
+
+describe('Logger', () => {
+    describe('text logger torture test', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let data: any;
+        const global = new GlobalLogger();
+        global.configureLogging({
+            json: false,
+            console: 'debug',
+        }, new Writable({
+            write(chunk, _encoding, callback) {
+                data = chunk.toString();
+                callback();
+            },
+        }));
+
+        const log = new Logger(MODULE_NAME, {}, global);
+        for (const args of tortureArgs) {
+            it(`handles logging '${args.map(t => typeof t).join(', ')}'`, () => {
+                for (const level of ['debug', 'info', 'warn', 'error']) {
+                    log[level as 'debug'|'info'|'warn'|'error'](args[0], ...args.slice(1));
+                    expect(data).toBeDefined();
+                    expect(data).toContain(level.toUpperCase());
+                    expect(data).toContain(MODULE_NAME);
+                }
+            })
+        }
+    });
+    describe('JSON logger torture test', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let data: any;
+        const global = new GlobalLogger();
+        global.configureLogging({
+            json: true,
+            console: 'debug',
+        }, new Writable({
+            write(chunk, _encoding, callback) {
+                data = JSON.parse(chunk.toString());
+                callback();
+            },
+        }));
+
+        const log = new Logger(MODULE_NAME, {}, global);
+        for (const args of tortureArgs) {
+            it(`handles logging '${args.map(t => typeof t).join(', ')}'`, () => {
+                for (const level of ['debug', 'info', 'warn', 'error']) {
+                    log[level as 'debug'|'info'|'warn'|'error'](args[0], ...args.slice(1));
+                    expect(data.level).toEqual(level.toUpperCase());
+                    expect(data.module).toEqual(MODULE_NAME);
+                    expect(data.message).toBeDefined();
+                    expect(data.timestamp).toBeDefined();
+                    if (args.length > 1) {
+                        expect(data.args).toHaveSize(args.length-1);
+                    }
+                }
+            })
+        }
+    });
+});

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -35,7 +35,7 @@ import { MembershipCache, UserMembership, UserProfile } from "./components/membe
 import { RoomLinkValidator, RoomLinkValidatorStatus, Rules } from "./components/room-link-validator"
 import { RoomUpgradeHandler, RoomUpgradeHandlerOpts } from "./components/room-upgrade-handler";
 import { EventQueue } from "./components/event-queue";
-import * as logging from "./components/logging";
+import { Logger } from ".";
 import { UserActivityTracker } from "./components/user-activity";
 import { Defer, defer as deferPromise } from "./utils/promiseutil";
 import { unstable } from "./errors";
@@ -53,7 +53,7 @@ import * as BotSDK from "matrix-bot-sdk";
 import { ActivityTracker, ActivityTrackerOpts } from "./components/activity-tracker";
 import { EncryptedIntent, EncryptedIntentOpts } from "./components/encrypted-intent";
 
-const log = logging.get("bridge");
+const log = new Logger("bridge");
 
 // The frequency at which we will check the list of accumulated Intent objects.
 const INTENT_CULL_CHECK_PERIOD_MS = 1000 * 60; // once per minute

--- a/src/components/activity-tracker.ts
+++ b/src/components/activity-tracker.ts
@@ -1,6 +1,6 @@
 import { MatrixClient } from "matrix-bot-sdk";
-import * as logging from "./logging";
-const log = logging.get("ActivityTracker");
+import { Logger } from ".."
+const log = new Logger("ActivityTracker");
 
 export interface ActivityTrackerOpts {
     /**

--- a/src/components/bridge-blocker.ts
+++ b/src/components/bridge-blocker.ts
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import * as logging from "./logging";
-const log = logging.get("BridgeBlocker");
+import { Logger } from "..";
+const log = new Logger("BridgeBlocker");
 
 /**
  * Monitor the active user limit (or any limit you desire),

--- a/src/components/bridge-info-state.ts
+++ b/src/components/bridge-info-state.ts
@@ -1,8 +1,8 @@
 import { Bridge } from "../bridge";
-import logger from "./logging";
+import { Logger } from "..";
 import PQueue from "p-queue";
 
-const log = logger.get("BridgeStateSyncer");
+const log = new Logger("BridgeStateSyncer");
 export interface MappingInfo {
     creator?: string;
     protocol: {

--- a/src/components/cli.ts
+++ b/src/components/cli.ts
@@ -20,9 +20,9 @@ import * as yaml from "js-yaml";
 import nopt from "nopt";
 import { AppServiceOutput, AppServiceRegistration } from "matrix-appservice";
 import { ConfigValidator } from "./config-validator";
-import * as logging from "./logging";
+import { Logger } from "..";
 
-const log = logging.get("cli");
+const log = new Logger("cli");
 
 export interface CliOpts<ConfigType extends Record<string, unknown>> {
     /**

--- a/src/components/encrypted-intent.ts
+++ b/src/components/encrypted-intent.ts
@@ -1,12 +1,10 @@
-import { UserMembership } from "./membership-cache";
 import { APPSERVICE_LOGIN_TYPE, ClientEncryptionSession } from "./encryption";
-import Logging from "./logging";
-import { ReadStream } from "fs";
+import { Logger } from "..";
 import BotSdk, { MatrixClient } from "matrix-bot-sdk";
 import { FileUploadOpts, Intent, IntentOpts } from "./intent";
 import { WeakStateEvent } from "./event-types";
 
-const log = Logging.get("EncryptedIntent");
+const log = new Logger("EncryptedIntent");
 
 export interface EncryptedIntentOpts {
     sessionPromise: Promise<ClientEncryptionSession|null>;

--- a/src/components/encryption.ts
+++ b/src/components/encryption.ts
@@ -2,14 +2,14 @@ import { MembershipCache } from "./membership-cache";
 import { AppServiceBot } from "./app-service-bot";
 import { WeakEvent } from "./event-types";
 import { Intent } from "./intent";
-import Logging from "./logging";
+import { Logger } from "..";
 import { MatrixClient } from "matrix-bot-sdk";
 import LRU from "@alloc/quick-lru"
 
-const log = Logging.get("EncryptedEventBroker");
-
 export const APPSERVICE_LOGIN_TYPE = "m.login.application_service";
 const EVENT_CACHE_FOR_MS = 5 * 60000; // 5 minutes
+
+const log = new Logger('EncryptedEventBroker');
 
 interface PantalaimonWeakEvent extends WeakEvent {
     decrypted: true;

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -265,7 +265,7 @@ export class Intent {
     public sendText(roomId: string, text: string): Promise<{event_id: string}> {
         return this.sendMessage(roomId, {
             body: text,
-            msgtype: "m.text"
+            LogEntryPart: "m.text"
         });
     }
 

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -19,12 +19,11 @@ import { defer } from "../utils/promiseutil";
 import { UserMembership } from "./membership-cache";
 import { unstable } from "../errors";
 import BridgeErrorReason = unstable.BridgeErrorReason;
-import Logging from "./logging";
-import { ReadStream } from "fs";
 import BotSdk, { MatrixClient, MatrixProfileInfo, PresenceState } from "matrix-bot-sdk";
 import { WeakStateEvent } from "./event-types";
+import { Logger } from '..';
 
-const log = Logging.get("Intent");
+const log = new Logger("Intent");
 export type IntentBackingStore = {
     getMembership: (roomId: string, userId: string) => UserMembership,
     getMemberProfile: (roomId: string, userid: string) => MatrixProfileInfo,

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -265,7 +265,7 @@ export class Intent {
     public sendText(roomId: string, text: string): Promise<{event_id: string}> {
         return this.sendMessage(roomId, {
             body: text,
-            LogEntryPart: "m.text"
+            msgtype: "m.text"
         });
     }
 

--- a/src/components/logging.ts
+++ b/src/components/logging.ts
@@ -27,13 +27,13 @@ type LogEntryPart = string|Error|any|{error?: string};
  * @param LogEntryPart A list of values being logged.
  * @returns True is the message is noise, or false otherwise.
  */
-function isMessageNoise(LogEntryPart: LogEntryPart[]) {
-    return LogEntryPart.some(messageOrObject => {
-        if (typeof messageOrObject !== "object") {
+function isMessageNoise(logEntryParts: LogEntryPart[]) {
+    return logEntryParts.some(part => {
+        if (typeof part !== "object") {
             return false;
         }
 
-        const possibleError = messageOrObject as {
+        const possibleError = part as {
             error?: string, body?: { error?: string, errcode?: string}, errcode?: string
         }
 

--- a/src/components/membership-queue.ts
+++ b/src/components/membership-queue.ts
@@ -1,9 +1,9 @@
 import { Bridge } from "../bridge";
-import { get as getLogger } from "./logging";
+import { Logger } from ".."
 import PQueue from "p-queue";
 import { Counter, Gauge } from "prom-client";
 
-const log = getLogger("MembershipQueue");
+const log = new Logger("MembershipQueue");
 
 export interface ThinRequest {
     getId(): string;

--- a/src/components/prometheusmetrics.ts
+++ b/src/components/prometheusmetrics.ts
@@ -16,8 +16,7 @@ limitations under the License.
 import PromClient, { Registry } from "prom-client";
 import { AgeCounters } from "./agecounters";
 import { Request, Response } from "express";
-import { Bridge } from "..";
-import Logger from "./logging";
+import { Bridge, Logger } from "..";
 import { Appservice as BotSdkAppservice, FunctionCallContext, METRIC_MATRIX_CLIENT_FAILED_FUNCTION_CALL,
     METRIC_MATRIX_CLIENT_SUCCESSFUL_FUNCTION_CALL } from "matrix-bot-sdk";
 import { getBridgeVersion } from "../utils/package-info";
@@ -45,7 +44,7 @@ interface HistogramOpts extends CounterOpts {
     buckets?: number[];
 }
 
-interface GagueOpts extends CounterOpts {
+interface GaugeOpts extends CounterOpts {
     refresh?: (gauge: PromClient.Gauge<string>) => void;
 }
 
@@ -104,7 +103,7 @@ interface GagueOpts extends CounterOpts {
  * @constructor
  */
 
-const log = Logger.get('PrometheusMetrics');
+const log = new Logger('PrometheusMetrics');
 
 export class PrometheusMetrics {
     public static AgeCounters = AgeCounters;
@@ -290,7 +289,7 @@ export class PrometheusMetrics {
      * gauge in order to provide a new value for it.
      * @return {Gauge} A gauge metric.
      */
-    public addGauge (opts: GagueOpts): PromClient.Gauge<string> {
+    public addGauge (opts: GaugeOpts): PromClient.Gauge<string> {
         const refresh = opts.refresh;
         const name = [opts.namespace || "bridge", opts.name].join("_");
 

--- a/src/components/room-link-validator.ts
+++ b/src/components/room-link-validator.ts
@@ -15,8 +15,8 @@ limitations under the License.
 
 import util from "util";
 import { AppServiceBot } from "./app-service-bot";
-import logging from "./logging";
-const log = logging.get("room-link-validator");
+import { Logger } from "..";
+const log = new Logger("room-link-validator");
 const VALIDATION_CACHE_LIFETIME = 30 * 60 * 1000;
 
 export interface Rules {

--- a/src/components/room-upgrade-handler.ts
+++ b/src/components/room-upgrade-handler.ts
@@ -12,13 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import logging from "./logging";
+import { Logger } from "..";
 import { MatrixRoom } from "../models/rooms/matrix";
 import { MatrixUser } from "../models/users/matrix";
 import { RoomBridgeStoreEntry } from "./room-bridge-store";
 import { Bridge } from "..";
 
-const log = logging.get("RoomUpgradeHandler");
+const log = new Logger("RoomUpgradeHandler");
 
 export interface RoomUpgradeHandlerOpts {
     /**

--- a/src/components/state-lookup.ts
+++ b/src/components/state-lookup.ts
@@ -14,7 +14,7 @@ limitations under the License.
 */
 import PQueue from "p-queue";
 import { Intent } from "./intent";
-import Logging from "./logging";
+import { Logger } from "..";
 
 interface StateLookupOpts {
     intent: Intent;
@@ -33,7 +33,7 @@ interface StateLookupRoom {
     };
 }
 
-const log = Logging.get("StateLookup");
+const log = new Logger("StateLookup");
 export interface StateLookupEvent {
     // eslint-disable-next-line camelcase
     room_id: string;

--- a/src/components/user-activity.ts
+++ b/src/components/user-activity.ts
@@ -12,8 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import * as logging from "./logging";
-const log = logging.get("UserActTracker");
+import { Logger } from "..";
+const log = new Logger("UserActTracker");
 
 interface UserActivityMetadata {
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+
+export * from "./components/logging";
+
 // Requests
 export * from "./components/request";
 export * from "./components/request-factory";
@@ -51,7 +54,6 @@ export * from "./components/prometheusmetrics";
 export * from "./components/agecounters";
 export * from "./components/membership-cache";
 export * from "./components/membership-queue";
-export * as Logging from "./components/logging";
 export { unstable } from "./errors";
 export * from "./components/event-types";
 export * from "./components/bridge-info-state";

--- a/src/provisioning/api.ts
+++ b/src/provisioning/api.ts
@@ -3,7 +3,6 @@ import { ProvisioningStore } from "./store";
 import { Server } from "http";
 import { v4 as uuid } from "uuid";
 import axios from "axios";
-import Logs from "../components/logging";
 import { ErrCode, IApiError, ProvisioningRequest, ApiError } from ".";
 import { URL } from "url";
 import { MatrixHostResolver } from "../utils/matrix-host-resolver";
@@ -12,6 +11,7 @@ import { isIP } from "net";
 import { promises as dns } from "dns";
 import ratelimiter, { RateLimitInfo, Options as RatelimitOptions, AugmentedRequest } from "express-rate-limit";
 import { Methods } from "./request";
+import { Logger } from "..";
 
 // Borrowed from
 // https://github.com/matrix-org/synapse/blob/91221b696156e9f1f9deecd425ae58af03ebb5d3/docs/sample_config.yaml#L215
@@ -37,7 +37,7 @@ export const DefaultDisallowedIpRanges = [
     'fec0::/10'
 ]
 
-const log = Logs.get("ProvisioningApi");
+const log = new Logger("ProvisioningApi");
 
 interface ExpRequestProvisioner extends Request {
     matrixWidgetToken?: string;

--- a/src/provisioning/request.ts
+++ b/src/provisioning/request.ts
@@ -1,6 +1,5 @@
-import Logging, { LogWrapper } from "../components/logging";
 import crypto from "crypto";
-import { ThinRequest } from "..";
+import { ThinRequest, Logger } from "..";
 import { Request } from "express";
 import { ParsedQs } from "qs";
 
@@ -41,7 +40,7 @@ export class ProvisioningRequest<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ReqBody = any,
     ReqQuery = ParsedQs> implements ThinRequest {
-    public readonly log: LogWrapper;
+    public readonly log: Logger;
     public readonly id: string;
 
     constructor(
@@ -53,9 +52,7 @@ export class ProvisioningRequest<
     ) {
         this.id = crypto.randomBytes(4).toString('hex');
         this.fnName = fnName || expressReq.path;
-        this.log = Logging.get(
-            `ProvisionRequest ${[this.id, fnName].filter(n => !!n).join(" ")}`
-        );
+        this.log = new Logger('ProvisionRequest', { requestId: [this.id, fnName].filter(n => !!n).join(" ") });
         this.log.debug(`Request ${userId} (${requestSource}) ${this.fnName}`);
     }
 

--- a/src/utils/matrix-host-resolver.ts
+++ b/src/utils/matrix-host-resolver.ts
@@ -2,7 +2,7 @@ import { Axios } from "axios";
 import { URL } from "url";
 import { isIP } from "net";
 import { promises as dns, SrvRecord } from "dns"
-import Logging from "../components/logging";
+import { Logger } from "..";
 
 interface MatrixServerWellKnown {
     "m.server": string;
@@ -19,7 +19,7 @@ const DefaultMatrixServerPort = 8448;
 const MaxPortNumber = 65535;
 const WellKnownTimeout = 10000;
 
-const log = Logging.get('MatrixHostResolver');
+const log = new Logger('MatrixHostResolver');
 
 type CachedResult = {timestamp: number, result: HostResolveResult}|{timestamp: number, error: Error};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,10 +417,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
-"@types/mime@^1":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
-  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+"@types/mime@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
+  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
 "@types/nedb@^1.8.11":
   version "1.8.12"
@@ -3235,11 +3235,6 @@ v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
-
-v8-compile-cache@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Split out from #410 

Our current logging system is hard to use, and also difficult to override. As such we've ended up building our own solutions in the Discord bridges, IRC bridge and the hookshot bridge. This PR attempts to pull in the hookshot way of doing logging into this bridge without trying to break the API entirely. 

I've retained our existing log rotation transport feature, but I'm not wholly convinced it's something we want long term. Log rotation is best left to other services (KISS principle applies).

For reference https://github.com/matrix-org/matrix-hookshot/blob/main/src/LogWrapper.ts

---

The PR rotted enough that trying to merge some changes in broke the world, so I have restarted again on a single PR.