### PR TITLE
Account for the port specifier at the end of server names

### DIFF
--- a/changelog.d/414.bugfix
+++ b/changelog.d/414.bugfix
@@ -1,0 +1,1 @@
+Matrix users on a server that has an explicit port specifier in the server name will now be supported.

--- a/spec/unit/matrix-user.spec.js
+++ b/spec/unit/matrix-user.spec.js
@@ -7,7 +7,10 @@ describe("MatrixUser", function() {
                 new MatrixUser("@test:localhost", null, false),
                 new MatrixUser("@42:localhost", null, false),
                 new MatrixUser("@Test42:localhost", null, false),
-                new MatrixUser("@A=Good-set.of_chars:localhost", null, false)
+                new MatrixUser("@A=Good-set.of_chars:localhost", null, false),
+                new MatrixUser("@testoo:[1234:5678::abcd]:5678", null, false),
+                new MatrixUser("@testalso:localhost:9999", null, false),
+                new MatrixUser("@testthree:[1234:5678::abcd]", null, false)
             ].forEach((user) => {
                 const userId = user.getId();
                 user.escapeUserId();
@@ -42,6 +45,18 @@ describe("MatrixUser", function() {
         it("should escape if ESCAPE_DEFAULT is true", function() {
             MatrixUser.ESCAPE_DEFAULT = true;
             expect(new MatrixUser("@$:localhost", null).getId()).toBe("@=24:localhost");
+        });
+        it("should accept server names with explicit port or an ipv6 literal", function() {
+            const mxids = [
+                "@testoo:[1234:5678::abcd]:5678",
+                "@testalso:localhost:9999",
+                "@testthree:[1234:5678::abcd]"
+            ];
+            mxids
+                .map(mxid => new MatrixUser(mxid, null, false))
+                .forEach((user, i) => {
+                    expect(user.getId()).toBe(mxids[i]);
+                });
         });
     });
 });

--- a/src/models/users/matrix.ts
+++ b/src/models/users/matrix.ts
@@ -35,7 +35,7 @@ export class MatrixUser {
         }
         const split = this.userId.split(":");
         this._localpart = split[0].substring(1);
-        this.host = split[1];
+        this.host = split.slice(1).join(':');
         if (escape) {
             this.escapeUserId();
         }

--- a/src/models/users/matrix.ts
+++ b/src/models/users/matrix.ts
@@ -33,9 +33,9 @@ export class MatrixUser {
         if (_data && typeof _data !== "object") {
             throw Error("data arg must be an Object");
         }
-        const split = this.userId.split(":");
-        this._localpart = split[0].substring(1);
-        this.host = split.slice(1).join(':');
+        const split = this.userId.indexOf(':');
+        this._localpart = this.userId.substring(1, split);
+        this.host = this.userId.substring(split+1);
         if (escape) {
             this.escapeUserId();
         }

--- a/src/models/users/matrix.ts
+++ b/src/models/users/matrix.ts
@@ -33,9 +33,9 @@ export class MatrixUser {
         if (_data && typeof _data !== "object") {
             throw Error("data arg must be an Object");
         }
-        const split = this.userId.indexOf(':');
-        this._localpart = this.userId.substring(1, split);
-        this.host = this.userId.substring(split+1);
+        const split = this.userId.split(/:(.*)/); // only split on the first colon.
+        this._localpart = split[0].substring(1);
+        this.host = split[1];
         if (escape) {
             this.escapeUserId();
         }


### PR DESCRIPTION
I guess this also works for IPv6 literals.
https://spec.matrix.org/v1.3/appendices/#server-name