### PR TITLE
Pin to matrix-bot-sdk@0.6.0-beta.2

### DIFF
--- a/changelog.d/416.bugfix
+++ b/changelog.d/416.bugfix
@@ -1,0 +1,1 @@
+Pin matrix-bot-sdk version to avoid inadvertently requiring Node 16.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "is-my-json-valid": "^2.20.5",
     "js-yaml": "^4.0.0",
     "matrix-appservice": "^0.10.0",
-    "matrix-bot-sdk": "^0.6.0-beta.2",
+    "matrix-bot-sdk": "0.6.0-beta.2",
     "nedb": "^1.8.0",
     "nopt": "^5.0.0",
     "p-queue": "^6.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2335,7 +2335,7 @@ matrix-appservice@^0.10.0:
     js-yaml "^4.1.0"
     morgan "^1.10.0"
 
-matrix-bot-sdk@^0.6.0-beta.2:
+matrix-bot-sdk@0.6.0-beta.2:
   version "0.6.0-beta.2"
   resolved "https://registry.yarnpkg.com/matrix-bot-sdk/-/matrix-bot-sdk-0.6.0-beta.2.tgz#abfddaeaf339da167717a1ca4148fa8f847f36f5"
   integrity sha512-D9aQ2++1bJIzka2uIz22HkaeyT058QGOh96xdxiDOaezyzLY5BN7ehYg+P0xRzDYDFKx9DbqDYCt97IkfahtPw==


### PR DESCRIPTION
0.6.0 of the bot-sdk has a hard dependency on Node 16, unfortunately since we didn't pin the beta versions in previous releases this has meant that "^0.6.0-beta.2" has been resolved to "0.6.0", which means we accidentally now require Node 16. #415 will explicitly support that, but for now we want to pin back to avoid breaking current packages.