### PR TITLE
Use backend meta for signoff script

### DIFF
--- a/.github/workflows/sign-off.yml
+++ b/.github/workflows/sign-off.yml
@@ -3,44 +3,8 @@ name: Contribution requirements
 on:
   pull_request:
     types: [opened, edited, synchronize]
-  workflow_call:
 
 jobs:
   signoff:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check PR for sign-off text
-        uses: actions/github-script@v6
-        with:
-          script: |
-            // We don't require owners or members to sign off.
-            const authorAssociation = context.payload.pull_request.author_association;
-            if (['OWNER', 'MEMBER'].includes(authorAssociation) ||
-                // GitHub labels users who are part of the parent org as 'CONTRIBUTOR' sometimes, so check that the user
-                // created the PR on the base project to check they have write access.
-                (authorAssociation === 'CONTRIBUTOR' && context.payload.pull_request.head.user.login === context.repo.owner)) {
-              core.notice('Pull request does not require sign-off.');
-              return;
-            }
-
-            const signOffRegex = /Signed[_\- ]off[_\- ]by: [\w ]+ <.+(@|at).+>/i;
-
-            if (signOffRegex.test(context.payload.pull_request.body ?? "")) {
-              core.notice('Pull request body contains a sign-off notice');
-              return;
-            }
-
-            const commits = await github.rest.pulls.listCommits({
-              pull_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const commit = commits.data.find(c => signOffRegex.test(c.commit.message));
-            if (commit) {
-              core.notice(`Commit '${commit.id}' contains a sign-off notice`);
-              return;
-            }
-
-            core.setFailed('No sign-off found. Please ensure you have signed off the PR as per https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off.')
-            core.notice('If you have signed off privately instead (following the steps in Private Sign off), you can ignore this test.')
+    uses: matrix-org/backend-meta/.github/workflows/sign-off.yml@v1.4.0
           


### PR DESCRIPTION
Same as #428, just this time using the official backend repository 