### PR TITLE
Add checkToken back to addAppServicePath and ensure metrics doesn't require a token

### DIFF
--- a/changelog.d/435.bugfix
+++ b/changelog.d/435.bugfix
@@ -1,0 +1,1 @@
+Fix bug introduced in 5.0.0 which caused the `/metrics` endpoint to request authentication. The endpoint no longer requires authentication.

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -960,23 +960,23 @@ export class Bridge {
      * @param opts Named options
      * @param opts.method The HTTP method name.
      * @param opts.path Path to the endpoint.
-     * @param opts.checkToken Should the token be automatically checked. Defaults to true.
+     * @param opts.authenticate Should the token be automatically checked. Defaults to true.
      * @param opts.handler Function to handle requests
      * to this endpoint.
      */
     public addAppServicePath(opts: {
         method: "GET"|"PUT"|"POST"|"DELETE",
         path: string,
-        checkToken?: boolean,
+        authenticate: boolean,
         handler: (req: ExRequest, respose: ExResponse, next: NextFunction) => void,
     }): void {
         if (!this.appservice) {
             throw Error('Cannot call addAppServicePath before calling .run()');
         }
         const app: Application = this.appservice.expressApp;
-
+        const authenticate = opts.authenticate ?? true;
         app[opts.method.toLowerCase() as "get"|"put"|"post"|"delete"](opts.path, (req, res, ...args) => {
-            if (opts.checkToken === false || !this.requestCheckToken(req)) {
+            if (authenticate && !this.requestCheckToken(req)) {
                 return res.status(403).send({
                     errcode: "M_FORBIDDEN",
                     error: "Bad token supplied,"

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -958,10 +958,10 @@ export class Bridge {
      * Install a custom handler for an incoming HTTP API request. This allows
      * callers to add extra functionality, implement new APIs, etc...
      * @param opts Named options
-     * @param opts.method The HTTP method name.
-     * @param opts.path Path to the endpoint.
      * @param opts.authenticate Should the token be automatically checked. Defaults to true.
      * @param opts.handler Function to handle requests
+     * @param opts.method The HTTP method name.
+     * @param opts.path Path to the endpoint.
      * to this endpoint.
      */
     public addAppServicePath(opts: {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -967,7 +967,7 @@ export class Bridge {
     public addAppServicePath(opts: {
         method: "GET"|"PUT"|"POST"|"DELETE",
         path: string,
-        authenticate: boolean,
+        authenticate?: boolean,
         handler: (req: ExRequest, respose: ExResponse, next: NextFunction) => void,
     }): void {
         if (!this.appservice) {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -967,6 +967,7 @@ export class Bridge {
     public addAppServicePath(opts: {
         method: "GET"|"PUT"|"POST"|"DELETE",
         path: string,
+        checkToken?: boolean,
         handler: (req: ExRequest, respose: ExResponse, next: NextFunction) => void,
     }): void {
         if (!this.appservice) {
@@ -975,7 +976,7 @@ export class Bridge {
         const app: Application = this.appservice.expressApp;
 
         app[opts.method.toLowerCase() as "get"|"put"|"post"|"delete"](opts.path, (req, res, ...args) => {
-            if (!this.requestCheckToken(req)) {
+            if (opts.checkToken === false || !this.requestCheckToken(req)) {
                 return res.status(403).send({
                     errcode: "M_FORBIDDEN",
                     error: "Bad token supplied,"

--- a/src/components/prometheusmetrics.ts
+++ b/src/components/prometheusmetrics.ts
@@ -398,6 +398,7 @@ export class PrometheusMetrics {
     public addAppServicePath(bridge: Bridge): void {
         bridge.addAppServicePath({
             method: "GET",
+            checkToken: false,
             path: "/metrics",
             handler: async (_req: Request, res: Response) => {
                 try {

--- a/src/components/prometheusmetrics.ts
+++ b/src/components/prometheusmetrics.ts
@@ -398,7 +398,7 @@ export class PrometheusMetrics {
     public addAppServicePath(bridge: Bridge): void {
         bridge.addAppServicePath({
             method: "GET",
-            checkToken: false,
+            authenticate: false,
             path: "/metrics",
             handler: async (_req: Request, res: Response) => {
                 try {


### PR DESCRIPTION
This was broken in a previous release where we suddenly enabled authentication forcefully across all our endpoints, which broke bridges that used it for unauthenticated metrics access.