### PR TITLE
Ensure we close timeouts

### DIFF
--- a/changelog.d/439.bugfix
+++ b/changelog.d/439.bugfix
@@ -1,0 +1,1 @@
+Cleanup any outstanding Timer handles after running `Bridge.close`, which may prevent the process from closing.

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1400,7 +1400,7 @@ export class Bridge {
                     // We don't care about the results
                     await this.prevRequestPromise;
                 }
- finally {
+                finally {
                     return promise;
                 }
             })();
@@ -1605,6 +1605,11 @@ export class Bridge {
         if (this.eeEventBroker) {
             this.eeEventBroker.close();
         }
+        if (this.selfPingDeferred?.timeout) {
+            clearInterval(this.selfPingDeferred.timeout);
+            this.selfPingDeferred = undefined;
+        }
+        this.requestFactory.close();
     }
 
 

--- a/src/components/request-factory.ts
+++ b/src/components/request-factory.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { clearTimeout } from "timers";
 import { Request, RequestOpts } from "./request";
 
 type HandlerFunction = (req: Request<unknown>, value: unknown) => Promise<unknown>|unknown;


### PR DESCRIPTION
We were not clearing these timeouts after executing a close on the Bridge object, which meant they would keep the process going until the eventually expired.