### PR TITLE
Add PostgresStore abstraction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,5 +58,5 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn test
         env:
-          BRIDGE_TEST_PGDB: "ircbridge_integtest"
+          BRIDGE_TEST_PGDB: "bridge_integtest"
           BRIDGE_TEST_PGURL: "postgresql://postgres_user:postgres_password@postgres"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 18
-      - run: npm ci
-      - run: npm run-script test
+      - run: yarn --frozen-lockfile
+      - run: yarn test
         env:
           BRIDGE_TEST_PGDB: "ircbridge_integtest"
           BRIDGE_TEST_PGURL: "postgresql://postgres_user:postgres_password@postgres"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,32 @@ jobs:
           node-version: "${{ matrix.node-version }}"
       - run: yarn --frozen-lockfile
       - run: yarn build && yarn test
+  test-postgres:
+    runs-on: ubuntu-20.04
+    container: node:18
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: postgres_password
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: postgres_user
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run-script test
+        env:
+          BRIDGE_TEST_PGDB: "ircbridge_integtest"
+          BRIDGE_TEST_PGURL: "postgresql://postgres_user:postgres_password@postgres"

--- a/changelog.d/442.bugfix
+++ b/changelog.d/442.bugfix
@@ -1,0 +1,1 @@
+Add implementation of a PostgreSQL datastore for use by other bridges.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "p-queue": "^6.6.2",
     "pkginfo": "^0.4.1",
     "postgres": "^3.3.1",
-    "prom-client": "^14.0.0",
+    "prom-client": "^14.1.0",
     "uuid": "^8.3.2",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.1"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "nopt": "^5.0.0",
     "p-queue": "^6.6.2",
     "pkginfo": "^0.4.1",
+    "postgres": "^3.3.1",
     "prom-client": "^14.0.0",
     "uuid": "^8.3.2",
     "winston": "^3.3.3",

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -1,4 +1,7 @@
 {
-  "strict": "off",
-  "no-var": "off"
+  "rules": {
+    "strict": "off",
+    "no-var": "off",
+    "eol-last": "off"
+  }
 }

--- a/spec/helpers/postgres-helper.ts
+++ b/spec/helpers/postgres-helper.ts
@@ -1,0 +1,21 @@
+import postgres, { Sql } from 'postgres';
+
+let pgClient: Sql;
+
+export function isPostgresTestingEnabled() {
+    return !!process.env.BRIDGE_TEST_PGURL;
+}
+
+export function initPostgres() {
+        // Setup postgres for the whole process.
+        pgClient = postgres(`${process.env.BRIDGE_TEST_PGURL}/postgres`);
+        process.on("beforeExit", async () => {
+            pgClient.end();
+        })
+}
+
+export async function getPgDatabase() {
+    const pgDb = `${process.env.BRIDGE_TEST_PGDB}_${process.hrtime().join("_")}`;
+    await pgClient`CREATE DATABASE ${pgClient(pgDb)}`;
+    return `${process.env.BRIDGE_TEST_PGURL}/${pgDb}`;
+}

--- a/spec/helpers/postgres-helper.ts
+++ b/spec/helpers/postgres-helper.ts
@@ -7,11 +7,11 @@ export function isPostgresTestingEnabled() {
 }
 
 export function initPostgres() {
-        // Setup postgres for the whole process.
-        pgClient = postgres(`${process.env.BRIDGE_TEST_PGURL}/postgres`);
-        process.on("beforeExit", async () => {
-            pgClient.end();
-        })
+    // Setup postgres for the whole process.
+    pgClient = postgres(`${process.env.BRIDGE_TEST_PGURL}/postgres`);
+    process.on("beforeExit", async () => {
+        pgClient.end();
+    })
 }
 
 export async function getPgDatabase() {

--- a/spec/integ/postgres.spec.ts
+++ b/spec/integ/postgres.spec.ts
@@ -1,0 +1,27 @@
+import { PostgresStore } from "../../src";
+import { getPgDatabase, initPostgres, isPostgresTestingEnabled } from "../helpers/postgres-helper";
+
+/**
+ * So we can use the abstraction.
+ */
+class TestPostgresStore extends PostgresStore {
+
+}
+
+describe('PostgresStore', () => {
+    let store: TestPostgresStore|undefined;
+    beforeAll(() => {
+        initPostgres();
+    })
+
+    it('can construct a simple database from schema', async () => {
+        store = new TestPostgresStore([], {
+            url: await getPgDatabase(),
+        });
+        await store.ensureSchema();
+    });
+
+    afterEach(async () => {
+        await store?.destroy();
+    })
+});

--- a/spec/integ/postgres.spec.ts
+++ b/spec/integ/postgres.spec.ts
@@ -1,14 +1,13 @@
 import { PostgresStore } from "../../src";
 import { getPgDatabase, initPostgres, isPostgresTestingEnabled } from "../helpers/postgres-helper";
 
-/**
- * So we can use the abstraction.
- */
-class TestPostgresStore extends PostgresStore {
 
-}
+// Only run the tests if we've enabled postgres testing.
+let descr = isPostgresTestingEnabled() ? describe : xdescribe;
 
-describe('PostgresStore', () => {
+class TestPostgresStore extends PostgresStore { }
+
+descr('PostgresStore', () => {
     let store: TestPostgresStore|undefined;
     beforeAll(() => {
         initPostgres();

--- a/spec/integ/postgres.spec.ts
+++ b/spec/integ/postgres.spec.ts
@@ -3,7 +3,7 @@ import { getPgDatabase, initPostgres, isPostgresTestingEnabled } from "../helper
 
 
 // Only run the tests if we've enabled postgres testing.
-let descr = isPostgresTestingEnabled() ? describe : xdescribe;
+const descr = isPostgresTestingEnabled() ? describe : xdescribe;
 
 class TestPostgresStore extends PostgresStore { }
 
@@ -15,6 +15,21 @@ descr('PostgresStore', () => {
 
     it('can construct a simple database from schema', async () => {
         store = new TestPostgresStore([], {
+            url: await getPgDatabase(),
+        });
+        await store.ensureSchema();
+    });
+
+    it('can run schema upgrades', async () => {
+        store = new TestPostgresStore([
+            sql => sql.begin(s => [
+                s`CREATE TABLE v1_users (mxid TEXT UNIQUE NOT NULL);`,
+            ]).then(),
+            sql => sql.begin(s => [
+                s`CREATE TABLE v2_rooms (mxid TEXT UNIQUE NOT NULL);`,
+            ]).then(),
+        ], {
+            autocreateSchemaTable: true,
             url: await getPgDatabase(),
         });
         await store.ensureSchema();

--- a/src/components/stores/PostgresStore.ts
+++ b/src/components/stores/PostgresStore.ts
@@ -1,0 +1,85 @@
+import postgres from 'postgres';
+import { Logger } from "../..";
+
+const log = new Logger("PostgresStore");
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export interface PostgresStoreOpts extends postgres.Options<{}> {
+    url?: string;
+}
+
+export type SchemaUpdateFunction = (sql: postgres.Sql) => void;
+
+/**
+ * A postgres store abstraction for use with a bridge.
+ */
+export abstract class PostgresStore {
+    public static readonly LATEST_SCHEMA = 9;
+    private hasEnded = false;
+    public readonly sql: postgres.Sql;
+
+    public get latestSchema() {
+        return this.schemas.length;
+    }
+
+    constructor(private readonly schemas: SchemaUpdateFunction[], opts: PostgresStoreOpts) {
+        this.sql = opts.url ? postgres(opts.url, opts) : postgres(opts);
+        process.on("beforeExit", () => {
+            // Ensure we clean up on exit
+            this.destroy().catch(ex => {
+                log.warn('Failed to cleanly exit', ex);
+            });
+        })
+    }
+
+    public async ensureSchema(): Promise<void> {
+        log.info("Starting database engine");
+        let currentVersion = await this.getSchemaVersion();
+        // Zero-indexed, so schema 1 would be in slot 0.
+        while (this.schemas[currentVersion]) {
+            log.info(`Updating schema to v${currentVersion + 1}`);
+            const runSchema = this.schemas[currentVersion];
+            try {
+                await runSchema(this.sql);
+                currentVersion++;
+                await this.updateSchemaVersion(currentVersion);
+            }
+            catch (ex) {
+                log.warn(`Failed to run schema v${currentVersion + 1}:`, ex);
+                throw Error("Failed to update database schema");
+            }
+        }
+        log.info(`Database schema is at version v${currentVersion}`);
+    }
+
+    public async destroy() {
+        log.info("Destroy called");
+        if (this.hasEnded) {
+            // No-op if end has already been called.
+            return;
+        }
+        this.hasEnded = true;
+        await this.sql.end();
+        log.info("PostgresSQL connection ended");
+    }
+
+    private async updateSchemaVersion(version: number) {
+        log.debug(`updateSchemaVersion: ${version}`);
+        await this.sql`UPDATE schema SET version = ${version};`;
+    }
+
+    private async getSchemaVersion(): Promise<number> {
+        try {
+            const result = await this.sql<{version: number}[]>`SELECT version FROM SCHEMA;`;
+            return result?.[0]?.version;
+        }
+        catch (ex) {
+            if (ex.code === "42P01") { // undefined_table
+                log.warn("Schema table could not be found");
+                return 0;
+            }
+            log.error("Failed to get schema version: %s", ex);
+        }
+        throw Error("Couldn't fetch schema version");
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export * from "./components/user-bridge-store";
 export * from "./components/user-activity-store";
 export * from "./components/room-bridge-store";
 export * from "./components/event-bridge-store";
-export * from "./components/stores/PostgresStore";
+export * from "./components/stores/postgres-store";
 
 // Models
 export * from "./models/rooms/matrix";

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export * from "./components/user-bridge-store";
 export * from "./components/user-activity-store";
 export * from "./components/room-bridge-store";
 export * from "./components/event-bridge-store";
+export * from "./components/stores/PostgresStore";
 
 // Models
 export * from "./models/rooms/matrix";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,6 +2619,11 @@ postcss@^8.3.11:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+postgres@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/postgres/-/postgres-3.3.1.tgz#1d9b5e8f01ee325df13b6db14f38ae2b8f6fe912"
+  integrity sha512-ak/xXToZYwRvQlZIUtLgPUIggz62eIIbPTgxl/Yl4oTu0TgNOd1CrzTCifsvZ89jBwLvnX6+Ky5frp5HzIBoaw==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,10 +2636,10 @@ process-on-spawn@^1.0.0:
   dependencies:
     fromentries "^1.2.0"
 
-prom-client@^14.0.0:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.0.1.tgz#bdd9583e02ec95429677c0e013712d42ef1f86a8"
-  integrity sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==
+prom-client@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.1.0.tgz#049609859483d900844924df740722c76ed1fdbb"
+  integrity sha512-iFWCchQmi4170omLpFXbzz62SQTmPhtBL35v0qGEVRHKcqIeiexaoYeP0vfZTujxEq3tA87iqOdRbC9svS1B9A==
   dependencies:
     tdigest "^0.1.1"
 


### PR DESCRIPTION
This semi-ports the IRC bridge implementation of a Postgres Datastore to this library. There are some key differences though:

- It's a very cut back abstract class that only deals with schema updates, for now.
- It deliberately doesn't try to implement any of our datastore classes for the moment, leaving that exercise to the bridge developer.
- We use the https://www.npmjs.com/package/postgres library, which has a (IMO) nicer syntax and natural support for TypeScript.
- Schema updates are now more typesafe than before.
