### PR TITLE
Add allowedIpRanges to ProvisionApiOpts

### DIFF
--- a/changelog.d/443.feature
+++ b/changelog.d/443.feature
@@ -1,0 +1,1 @@
+Enable allow-listing of specific IP ranges for OpenAPI requests without having to edit disallowedIpRanges.


### PR DESCRIPTION
Similar to Synapse's [ip_range_whitelist](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#ip_range_whitelist) add `allowedIpRanges` to `ProvisioningApiOpts` such that `disallowedIpRanges` can be kept simple and clear and if specific sub-ranges need to be allowed they can easily be specified without fraught editing of `disallowedIpRanges`.

I've never done typescript before, so there's significant potential for this to be incorrect but it seems simple and self-contained enough. Best I can tell ordering on `ProvisioningApiOpts` isn't important and that fields can be optional so this should be backwards compatible with existing users of this interface.