### PR TITLE
Add debouncing support to UserActivityTracker

### DIFF
--- a/changelog.d/448.feature
+++ b/changelog.d/448.feature
@@ -1,0 +1,1 @@
+Add debouncing support to UserActivityTracker (defaults to 60 seconds).

--- a/spec/unit/userActivity.spec.js
+++ b/spec/unit/userActivity.spec.js
@@ -9,7 +9,7 @@ const USER_THREE = "@charlie:example.com";
 const ONE_DAY = 24 * 60 * 60 * 1000;
 
 describe("userActivity", () => {
-    const emptyDataSet = () => { return { users: {} } };
+    const emptyDataSet = () => { return new Map() };
     describe("updateUserActivity", () => {
         it("can update a user's activity", async () => {
             let userData;
@@ -28,9 +28,9 @@ describe("userActivity", () => {
             });
             // This data is comitted asyncronously.
             const data = await trackerPromise;
-            expect(data).toEqual({
-                users: {[USER_ONE]: userData}
-            });
+            expect(data).toEqual(new Map([
+                [USER_ONE, userData],
+            ]));
         });
         it("can update a user's activity with metadata", () => {
             const tracker = new UserActivityTracker(
@@ -132,16 +132,14 @@ describe("userActivity", () => {
             const DATE_MINUS_THIRTY_TWO = new Date(Date.UTC(2020, 11, 30, 0));
             const tracker = new UserActivityTracker(
                 UserActivityTrackerConfig.DEFAULT,
-                {
-                    users: {
-                        [USER_ONE]: {
-                            ts: [DATE_MINUS_THIRTY_TWO.getTime() / 1000],
-                            metadata: {
-                                active: true,
-                            }
+                new Map([
+                    [USER_ONE, {
+                        ts: [DATE_MINUS_THIRTY_TWO.getTime() / 1000],
+                        metadata: {
+                            active: true,
                         }
-                    }
-                },
+                    }]
+                ]),
             );
             expect(tracker.countActiveUsers(DATE_NOW)).toEqual({
                 allUsers: 0,
@@ -152,16 +150,14 @@ describe("userActivity", () => {
             const DATE_MINUS_THIRTY_ONE = new Date(Date.UTC(2020, 12, 1, 0));
             const tracker = new UserActivityTracker(
                 UserActivityTrackerConfig.DEFAULT,
-                {
-                    users: {
-                        [USER_ONE]: {
-                            ts: [DATE_MINUS_THIRTY_ONE.getTime() / 1000],
-                            metadata: {
-                                active: true,
-                            }
+                new Map([
+                    [USER_ONE, {
+                        ts: [DATE_MINUS_THIRTY_ONE.getTime() / 1000],
+                        metadata: {
+                            active: true,
                         }
-                    }
-                },
+                    }]
+                ]),
             );
             expect(tracker.countActiveUsers(DATE_NOW)).toEqual({
                 allUsers: 1,

--- a/spec/unit/userActivity.spec.js
+++ b/spec/unit/userActivity.spec.js
@@ -199,4 +199,22 @@ describe("userActivity", () => {
             });
         });
     })
+    describe("debouncing", () => {
+        it("should only send one update in a specified period", async () => {
+            let updates = 0;
+            const tracker = new UserActivityTracker(
+                {
+                    ...UserActivityTrackerConfig.DEFAULT,
+                    debounceTimeMs: 100,
+                },
+                emptyDataSet(),
+                () => updates++,
+            );
+            tracker.updateUserActivity(USER_ONE, undefined, DATE_NOW);
+            tracker.updateUserActivity(USER_ONE, undefined, DATE_NOW);
+            tracker.updateUserActivity(USER_ONE, undefined, DATE_NOW);
+            await new Promise(resolve => setTimeout(resolve, 200));
+            expect(updates).toEqual(1);
+        });
+    });
 })

--- a/spec/unit/userActivity.spec.js
+++ b/spec/unit/userActivity.spec.js
@@ -10,12 +10,16 @@ const ONE_DAY = 24 * 60 * 60 * 1000;
 
 describe("userActivity", () => {
     const emptyDataSet = () => { return new Map() };
+    const instantConfig = {
+        ...UserActivityTrackerConfig.DEFAULT,
+        debounceTimeMs: 0,
+    };
     describe("updateUserActivity", () => {
         it("can update a user's activity", async () => {
             let userData;
             const trackerPromise = new Promise((resolve, _) => {
                 const tracker = new UserActivityTracker(
-                    UserActivityTrackerConfig.DEFAULT,
+                    instantConfig,
                     emptyDataSet(),
                     (data) => resolve(data.dataSet),
                 );
@@ -34,7 +38,7 @@ describe("userActivity", () => {
         });
         it("can update a user's activity with metadata", () => {
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 emptyDataSet(),
             );
             tracker.updateUserActivity(USER_ONE, { private: true }, DATE_NOW);
@@ -47,7 +51,7 @@ describe("userActivity", () => {
         });
         it("can update a user's activity twice", () => {
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 emptyDataSet(),
             );
             tracker.updateUserActivity(USER_ONE, undefined, DATE_MINUS_ONE);
@@ -62,7 +66,7 @@ describe("userActivity", () => {
         });
         it("will not remove metadata from a user", () => {
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 emptyDataSet(),
             );
             tracker.updateUserActivity(USER_ONE, { private: true}, DATE_MINUS_ONE);
@@ -79,7 +83,7 @@ describe("userActivity", () => {
         });
         it("will cut off a users activity after 31 days", () => {
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 emptyDataSet(),
             );
             const LAST_EXPECTED_DATE = (DATE_NOW.getTime() - (ONE_DAY * 30)) / 1000;
@@ -95,7 +99,7 @@ describe("userActivity", () => {
     describe("countActiveUsers", () => {
         it("should have no users when the dataset is blank", () => {
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 emptyDataSet(),
             );
             expect(tracker.countActiveUsers(DATE_NOW)).toEqual({
@@ -105,7 +109,7 @@ describe("userActivity", () => {
         });
         it("should have no users when the user hasn't been active for 3 days", () => {
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 emptyDataSet(),
             );
             tracker.updateUserActivity(USER_ONE, undefined, DATE_MINUS_ONE);
@@ -117,7 +121,7 @@ describe("userActivity", () => {
         });
         it("should have users when the user has been active for at least 3 days", () => {
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 emptyDataSet(),
             );
             tracker.updateUserActivity(USER_ONE, undefined, DATE_MINUS_TWO);
@@ -131,7 +135,7 @@ describe("userActivity", () => {
         it("should not include 'active' users who have not talked in 32 days", () => {
             const DATE_MINUS_THIRTY_TWO = new Date(Date.UTC(2020, 11, 30, 0));
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 new Map([
                     [USER_ONE, {
                         ts: [DATE_MINUS_THIRTY_TWO.getTime() / 1000],
@@ -149,7 +153,7 @@ describe("userActivity", () => {
         it("should include 'active' users who have talked in 31 days", () => {
             const DATE_MINUS_THIRTY_ONE = new Date(Date.UTC(2020, 12, 1, 0));
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 new Map([
                     [USER_ONE, {
                         ts: [DATE_MINUS_THIRTY_ONE.getTime() / 1000],
@@ -166,7 +170,7 @@ describe("userActivity", () => {
         });
         it("should mark user as private if metadata specifies it", () => {
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 emptyDataSet(),
             );
             tracker.updateUserActivity(USER_ONE, { private: true}, DATE_MINUS_TWO);
@@ -179,7 +183,7 @@ describe("userActivity", () => {
         });
         it("should handle multiple users", () => {
             const tracker = new UserActivityTracker(
-                UserActivityTrackerConfig.DEFAULT,
+                instantConfig,
                 emptyDataSet(),
             );
             tracker.updateUserActivity(USER_ONE, { private: true }, DATE_MINUS_TWO);

--- a/spec/unit/userActivity.spec.js
+++ b/spec/unit/userActivity.spec.js
@@ -197,20 +197,26 @@ describe("userActivity", () => {
     })
     describe("debouncing", () => {
         it("should only send one update in a specified period", async () => {
-            let updates = 0;
+            const updates = [];
             const tracker = new UserActivityTracker(
                 {
                     ...UserActivityTrackerConfig.DEFAULT,
                     debounceTimeMs: 100,
                 },
                 emptyDataSet(),
-                () => updates++,
+                (changes) => updates.push(changes),
             );
-            tracker.updateUserActivity(USER_ONE, undefined, DATE_NOW);
-            tracker.updateUserActivity(USER_ONE, undefined, DATE_NOW);
+            tracker.updateUserActivity(USER_ONE, undefined, DATE_MINUS_ONE);
+            tracker.updateUserActivity(USER_TWO, undefined, DATE_MINUS_ONE);
+            tracker.updateUserActivity(USER_ONE, undefined, DATE_MINUS_ONE);
+            await new Promise(resolve => setTimeout(resolve, 200));
+            expect(updates.length).toEqual(1);
+            expect(updates[0].changed.sort()).toEqual([USER_ONE, USER_TWO]);
+
             tracker.updateUserActivity(USER_ONE, undefined, DATE_NOW);
             await new Promise(resolve => setTimeout(resolve, 200));
-            expect(updates).toEqual(1);
+            expect(updates.length).toEqual(2);
+            expect(updates[1].changed.length).toEqual(1);
         });
     });
 })

--- a/src/components/user-activity-store.ts
+++ b/src/components/user-activity-store.ts
@@ -53,14 +53,14 @@ export class UserActivityStore extends BridgeStore {
 
     public async getActivitySet(): Promise<UserActivitySet> {
         return this.select({}).then((records: any[]) => {
-            const users: {[mxid: string]: any} = {};
+            const userActivity: UserActivitySet = new Map();
             for (const record of records) {
-                users[record.mxid] = {
+                userActivity.set(record.mxid, {
                     ts:       record.ts,
                     metadata: record.metadata,
-                };
+                });
             }
-            return { users } as UserActivitySet;
+            return userActivity;
         });
     }
 }

--- a/src/components/user-activity.ts
+++ b/src/components/user-activity.ts
@@ -36,7 +36,7 @@ export interface UserActivity {
 export interface UserActivityTrackerConfig {
     inactiveAfterDays: number;
     minUserActiveDays: number;
-    debounceTimeMs:    number;
+    debounceTimeMs: number;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace,no-redeclare

--- a/src/components/user-activity.ts
+++ b/src/components/user-activity.ts
@@ -28,11 +28,6 @@ interface UserActivityMetadata {
 
 export type UserActivitySet = Map<string, UserActivity>;
 
-// eslint-disable-next-line @typescript-eslint/no-namespace,no-redeclare
-export namespace UserActivitySet {
-    export const DEFAULT: UserActivitySet = new Map();
-}
-
 export interface UserActivity {
     ts: number[];
     metadata: UserActivityMetadata;

--- a/src/components/user-activity.ts
+++ b/src/components/user-activity.ts
@@ -44,7 +44,7 @@ export namespace UserActivityTrackerConfig {
     export const DEFAULT: UserActivityTrackerConfig = {
         inactiveAfterDays: 31,
         minUserActiveDays: 3,
-        debounceTimeMs:    0,
+        debounceTimeMs:    60 * 1000, // 1 minute
     };
 }
 


### PR DESCRIPTION
This allows us to throttle how often active user calculations are allowed to run – by default they run on every event sent, which for large deployments means both multiple times per second (which is completely unnecessary), and very costly (since we need to check every user against the current timestamp).

Currently it's defaulting to "as often as you want to" keeping backwards compatibility – but I'd rather make the default somewhat sane by default – possibly auto-scaled with the number of users in the dataset? It's okay to run every second if we have ten users but for 10k users once a minute would be both sensible and acceptable, so I'm tempted to put some "smart default" in place, but I'm curious of others' opinions.