### PR TITLE
Stop existing schema in postgres-store being overwritten

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   push:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   lint:

--- a/changelog.d/451.bugfix
+++ b/changelog.d/451.bugfix
@@ -1,0 +1,1 @@
+The postgres-store was attempting to overwrite existing schema everytime `ensureSchema` was called.

--- a/spec/integ/postgres.spec.ts
+++ b/spec/integ/postgres.spec.ts
@@ -33,6 +33,8 @@ descr('PostgresStore', () => {
             url: await getPgDatabase(),
         });
         await store.ensureSchema();
+        // it should not overwrite the existing schema if we run `ensureSchema` again...
+        await store.ensureSchema();
     });
 
     afterEach(async () => {

--- a/src/components/stores/postgres-store.ts
+++ b/src/components/stores/postgres-store.ts
@@ -84,11 +84,10 @@ export abstract class PostgresStore {
                 log.info(`Applying v0 schema (schema table)`);
                 await v0Schema(this.sql);
                 currentVersion = 0;
+            } else {
+                // We aren't autocreating the schema table, so assume schema 0.
+                currentVersion = 0;
             }
-        }
-        else {
-            // We aren't autocreating the schema table, so assume schema 0.
-            currentVersion = 0;
         }
 
         // Zero-indexed, so schema 1 would be in slot 0.


### PR DESCRIPTION
It was always assuming the schema version is always 0.

As discussed in https://matrix.to/#/!ViClwbclMrgQwyPuvH:matrix.org/$iC8QsDQHCrJQ922sUeZnXSTgFqErWndsKkXmWhk7iEk?via=half-shot.uk&via=matrix.org&via=gitter.im

Signed-off-by: Gnuxie <gnuxie@element.io>