### PR TITLE
Release helper script and CI

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,18 @@
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: yarn --strict-semver --frozen-lockfile
+      - run: yarn build
+      - run: npm publish --dry-run # TODO: Remove dry
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,3 @@
-
 on:
   release:
     types: [published]
@@ -7,12 +6,13 @@ jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
       - run: yarn --strict-semver --frozen-lockfile
       - run: yarn build
-      - run: npm publish --dry-run # TODO: Remove dry
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+
+on:
+  push:
+    tags: ["[0-9].[0-9].[0-9]"]
+
+jobs:
+  do-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get changelog
+        id: extract-changelog
+        run: |
+          RELEASE_BODY=`git diff --minimal --no-color HEAD~ CHANGELOG.md | tail -n +6 | sed -r "s/^([^-+ ]*)[-+ ]/\\1/" | head -n -3`
+          RELEASE_NAME=`echo $RELEASE_BODY | head -n 1`
+          RELEASE_BODY=`echo $RELEASE_BODY | tail -n +3`
+          echo "RELEASE_BODY=$RELEASE_BODY" >> $GITHUB_OUTPUT
+          echo "RELEASE_NAME=$RELEASE_NAME" >> $GITHUB_OUTPUT
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ steps.extract-changelog.outputs.RELEASE_NAME }}
+          body: ${{ steps.extract-changelog.outputs.RELEASE_BODY }}
+          draft: true # Draft it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
           echo "RELEASE_BODY=$RELEASE_BODY" >> $GITHUB_OUTPUT
           echo "RELEASE_NAME=$RELEASE_NAME" >> $GITHUB_OUTPUT
       - name: Create Release
-        id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,22 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Check tag is signed
-        run: git tag -v ${{ github.ref }}
       - name: Get changelog
         id: extract-changelog
         run: |
-          RELEASE_BODY=`git diff --minimal --no-color HEAD~ CHANGELOG.md | tail -n +6 | sed -r "s/^([^-+ ]*)[-+ ]/\\1/" | head -n -3`
-          RELEASE_NAME=`echo $RELEASE_BODY | head -n 1`
-          RELEASE_BODY=`echo $RELEASE_BODY | tail -n +3`
-          echo "RELEASE_BODY=$RELEASE_BODY" >> $GITHUB_OUTPUT
+          git fetch --tags --force
+          RELEASE_NAME="${{ github.ref_name }} $(date +'%Y-%m-%d')"
+          git tag -l --format='%(contents:body)' ${{ github.ref_name }} > next-changelog.txt
           echo "RELEASE_NAME=$RELEASE_NAME" >> $GITHUB_OUTPUT
       - name: Create Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ steps.extract-changelog.outputs.RELEASE_NAME }}
-          body: ${{ steps.extract-changelog.outputs.RELEASE_BODY }}
+          name: ${{ steps.extract-changelog.outputs.RELEASE_NAME }}
+          body_path: next-changelog.txt
           draft: true # Draft it
+          token: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,15 @@
 
 on:
   push:
-    tags: ["[0-9].[0-9].[0-9]"]
+    tags: ["testing-[0-9].[0-9].[0-9]"]
 
 jobs:
-  do-release:
+  draft-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Check tag is signed
+        run: git tag -v ${{ github.ref }}
       - name: Get changelog
         id: extract-changelog
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
-
 on:
   push:
-    tags: ["testing-[0-9].[0-9].[0-9]"]
+    tags: ["[0-9].[0-9].[0-9]"]
 
 jobs:
   draft-release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: yarn --strict-semver --frozen-lockfile
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - run: yarn --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Tests
 on:
   push:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   lint:
@@ -23,7 +22,6 @@ jobs:
       matrix:
         node-version: [16, 18]
     runs-on: ubuntu-20.04
-    container: node:14
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+testing-9.9.9.9 (2022-11-30)
+==================
+
+**Note**: The API for `UserActivityTracker` has changed. Please see [\#448](https://github.com/matrix-org/matrix-appservice-bridge/issues/448) for more details.
+
+Features
+--------
+
+- Add debouncing support to UserActivityTracker (defaults to 60 seconds). ([\#448](https://github.com/matrix-org/matrix-appservice-bridge/issues/448))
+
+
+Bugfixes
+--------
+
+- Fix postgres-store attempting to overwrite existing schema whenever `ensureSchema` is called. ([\#451](https://github.com/matrix-org/matrix-appservice-bridge/issues/451))
+
+
 8.0.0 (2022-11-30)
 ==================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,3 @@
-testing-9.9.9.9 (2022-11-30)
-==================
-
-**Note**: The API for `UserActivityTracker` has changed. Please see [\#448](https://github.com/matrix-org/matrix-appservice-bridge/issues/448) for more details.
-
-Features
---------
-
-- Add debouncing support to UserActivityTracker (defaults to 60 seconds). ([\#448](https://github.com/matrix-org/matrix-appservice-bridge/issues/448))
-
-
-Bugfixes
---------
-
-- Fix postgres-store attempting to overwrite existing schema whenever `ensureSchema` is called. ([\#451](https://github.com/matrix-org/matrix-appservice-bridge/issues/451))
-
-
 8.0.0 (2022-11-30)
 ==================
 

--- a/changelog.d/452.misc
+++ b/changelog.d/452.misc
@@ -1,0 +1,1 @@
+Add `release.sh` script to automate the release process.

--- a/scripts/changelog-release.sh
+++ b/scripts/changelog-release.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# This script will run towncrier to generate a changelog entry.
-
-VERSION=`python3 -c "import json; f = open('./package.json', 'r'); v = json.loads(f.read())['version']; f.close(); print(v)"`
-towncrier build --version $VERSION $1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 # This script will run towncrier to and generate a release commit, tag and push to the origin.
 
-VERSION=`python3 -c "import json; f = open('./package.json', 'r'); v = json.loads(f.read())['version']; f.close(); print(v)"`
+if ! command -v jq &> /dev/null
+then
+    echo "You must install jq to use this script"
+    exit
+fi
+
+VERSION=`jq -r .version package.json`
 TAG="$VERSION"
 
 if [[ "`git branch --show-current`" != "develop" ]]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This script will run towncrier to generate a changelog entry.
+# This script will run towncrier to and generate a release commit, tag and push to the origin.
 
 VERSION=`python3 -c "import json; f = open('./package.json', 'r'); v = json.loads(f.read())['version']; f.close(); print(v)"`
 TAG="$VERSION"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This script will run towncrier to generate a changelog entry.
+
+VERSION=`python3 -c "import json; f = open('./package.json', 'r'); v = json.loads(f.read())['version']; f.close(); print(v)"`
+TAG="testing-$VERSION"
+
+if [ $(git tag -l "$TAG") ]; then
+    echo "Tag $TAG exists, not overwriting"
+    exit 1
+fi
+
+echo "Drafting a new release"
+towncrier build --draft --version $VERSION $1 > draft-release.txt
+cat draft-release.txt
+
+read -p "Happy with the changelog? <y/N> " prompt
+if [[ $prompt != "y" && $prompt != "Y" && $prompt != "yes" && $prompt != "Yes" ]]
+then
+  exit 0
+fi
+
+echo "Proceeding to generate tags"
+cat draft-release.txt | git tag --force -m - -s $TAG
+rm draft-release.txt
+echo "Generated tag $TAG"
+
+echo "Pushing to origin"
+git push origin $TAG
+
+echo "The CI to generate a release is now running. Check https://github.com/matrix-org/matrix-appservice-bridge/releases and publish the release when it's ready."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,8 +4,13 @@
 VERSION=`python3 -c "import json; f = open('./package.json', 'r'); v = json.loads(f.read())['version']; f.close(); print(v)"`
 TAG="$VERSION"
 
+if [[ "`git branch --show-current`" != "develop" ]]; then
+    echo "You must be on the develop branch to run this command."
+    exit 1
+fi
+
 if [ $(git tag -l "$TAG") ]; then
-    echo "Tag $TAG exists, not overwriting"
+    echo "Tag $TAG already exists, not continuing."
     exit 1
 fi
 
@@ -30,5 +35,7 @@ echo "Generated tag $TAG"
 
 echo "Pushing to origin"
 git push origin $TAG
+# Push develop too
+git push
 
 echo "The CI to generate a release is now running. Check https://github.com/matrix-org/matrix-appservice-bridge/releases and publish the release when it's ready."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,7 +2,7 @@
 # This script will run towncrier to generate a changelog entry.
 
 VERSION=`python3 -c "import json; f = open('./package.json', 'r'); v = json.loads(f.read())['version']; f.close(); print(v)"`
-TAG="testing-$VERSION"
+TAG="$VERSION"
 
 if [ $(git tag -l "$TAG") ]; then
     echo "Tag $TAG exists, not overwriting"
@@ -10,7 +10,7 @@ if [ $(git tag -l "$TAG") ]; then
 fi
 
 echo "Drafting a new release"
-towncrier build --draft --version $VERSION $1 > draft-release.txt
+towncrier build --draft --version $VERSION> draft-release.txt
 cat draft-release.txt
 
 read -p "Happy with the changelog? <y/N> " prompt
@@ -18,6 +18,10 @@ if [[ $prompt != "y" && $prompt != "Y" && $prompt != "yes" && $prompt != "Yes" ]
 then
   exit 0
 fi
+
+echo "Committing version"
+towncrier build --version $VERSION
+git commit CHANGELOG.md changelog.d/ package.json -m $TAG
 
 echo "Proceeding to generate tags"
 cat draft-release.txt | git tag --force -m - -s $TAG


### PR DESCRIPTION
This should help people other than me release changes for matrix-appservice-bridge.

This comes in 3 parts:
- The `release.sh` script replaces the old `changelog-release.sh` script. It will now generate a draft changelog, check you are happy with it, then create the correct commits, tags and push the right things.
- A CI that takes the incoming changelog and creates a release automatically, you are then invited to check the draft to make sure it is sane.
- Once that's complete, there is a final CI job to build the npm package and publish it.