### PR TITLE
Use `once` with process 'beforeExit'.

### DIFF
--- a/changelog.d/453.bugfix
+++ b/changelog.d/453.bugfix
@@ -1,0 +1,1 @@
+The PostgresStore had a beforeExit hook that would itself prevent the process from exiting.

--- a/spec/helpers/postgres-helper.ts
+++ b/spec/helpers/postgres-helper.ts
@@ -9,7 +9,7 @@ export function isPostgresTestingEnabled() {
 export function initPostgres() {
     // Setup postgres for the whole process.
     pgClient = postgres(`${process.env.BRIDGE_TEST_PGURL}/postgres`);
-    process.on("beforeExit", async () => {
+    process.once("beforeExit", async () => {
         pgClient.end();
     })
 }

--- a/src/components/stores/postgres-store.ts
+++ b/src/components/stores/postgres-store.ts
@@ -60,7 +60,7 @@ export abstract class PostgresStore {
     constructor(private readonly schemas: SchemaUpdateFunction[], private readonly opts: PostgresStoreOpts) {
         opts.autocreateSchemaTable = opts.autocreateSchemaTable ?? true;
         this.sql = opts.url ? postgres(opts.url, opts) : postgres(opts);
-        process.on("beforeExit", () => {
+        process.once("beforeExit", () => {
             // Ensure we clean up on exit
             this.destroy().catch(ex => {
                 log.warn('Failed to cleanly exit', ex);


### PR DESCRIPTION
This is because when we call `PostgresStore.destroy`, we put a new task on the event loop. This "revives" the process and so the callback for process 'beforeExit' will be called repeatedly.

Signed-off-by: Gnuxie <gnuxie@element.io>