### PR TITLE
Improve Provisioning API rate limiting

### DIFF
--- a/changelog.d/458.misc
+++ b/changelog.d/458.misc
@@ -1,0 +1,1 @@
+Improve Provisioning API rate limiting and fix response headers.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "axios": "^0.27.2",
     "chalk": "^4.1.0",
     "express": "^4.18.1",
-    "express-rate-limit": "^6.2.0",
+    "express-rate-limit": "^6.7.0",
     "extend": "^3.0.2",
     "ip-cidr": "^3.0.4",
     "is-my-json-valid": "^2.20.5",

--- a/src/provisioning/api.ts
+++ b/src/provisioning/api.ts
@@ -145,8 +145,15 @@ export class ProvisioningApi {
         this.app.get('/health', this.getHealth.bind(this));
 
         const limiter = this.opts.ratelimit && ratelimiter({
-            handler: (req, _res, next) => {
-                next(new ApiError("Too many requests", ErrCode.Ratelimited, 429));
+            handler: (req, _res, next, options) => {
+                next(new ApiError(
+                    "Too many requests",
+                    ErrCode.Ratelimited,
+                    429,
+                    {
+                        retry_after_ms: options.windowMs,
+                    }
+                ));
             },
             windowMs: 1 * 60 * 1000, // 1 minute
             max: 30, // Limit per window

--- a/src/provisioning/api.ts
+++ b/src/provisioning/api.ts
@@ -149,7 +149,7 @@ export class ProvisioningApi {
                 next(new ApiError("Too many requests", ErrCode.Ratelimited, 429));
             },
             windowMs: 1 * 60 * 1000, // 1 minute
-            max: 20, // Limit per window
+            max: 30, // Limit per window
             standardHeaders: true,
             legacyHeaders: false,
             ...(typeof this.opts.ratelimit === "object" ? this.opts.ratelimit : {})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1308,10 +1308,10 @@ eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-express-rate-limit@^6.2.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-6.4.0.tgz#b7066afe21157a012ed2b7c9adde386e712485cd"
-  integrity sha512-lxQRZI4gi3qAWTf0/Uqsyugsz57h8bd7QyllXBgJvd6DJKokzW7C5DTaNvwzvAQzwHGFaItybfYGhC8gpu0V2A==
+express-rate-limit@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-6.7.0.tgz#6aa8a1bd63dfe79702267b3af1161a93afc1d3c2"
+  integrity sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==
 
 express@^4.17.1, express@^4.18.1:
   version "4.18.1"


### PR DESCRIPTION
Improves the Provisioning API rate limiting implementation:
* Updates `express-rate-limit`
* Corrects the parameter type to `Partial` rate limit options, so that bridges can pass overrides if necessary
* Changes the default from 100req/6 minutes to 30req/1 minute
    * I think this is more balanced for a default rate limit, allowing a lower burst while having a shorter period before the rate limit resets. In any case, bridges can override this if necessary.

And finally, fixes the rate limit response.
Previously, response headers looked like this:
```
X-RateLimit-Limit: 20
X-RateLimit-Remaining: 18
X-RateLimit-Reset: 1675712280
```
This is the legacy format, and the reset number is obviously not correct.
Now the response headers look like this:
```
RateLimit-Limit: 20
RateLimit-Remaining: 7
RateLimit-Reset: 21
```
Using the new format and correct reset value.
And if a request has been rate limited, includes a `Retry-After`:
```
RateLimit-Limit: 20
RateLimit-Remaining: 0
RateLimit-Reset: 18
Retry-After: 60
```