### PR TITLE
Throw on invalid provisioner header

### DIFF
--- a/changelog.d/461.bugfix
+++ b/changelog.d/461.bugfix
@@ -1,0 +1,1 @@
+Fix provisioner requests failing to signal an error when your `Authorization` header lacks a `Bearer`.

--- a/src/provisioning/api.ts
+++ b/src/provisioning/api.ts
@@ -249,7 +249,7 @@ export class ProvisioningApi {
         }
         const token = authHeader.startsWith("bearer ") && authHeader.substring("bearer ".length);
         if (!token) {
-            return;
+            throw new ApiError('Invalid Authorization header format', ErrCode.BadToken);
         }
         const requestProv = (req as ExpRequestProvisioner);
         if (!this.opts.provisioningToken && req.body.userId) {


### PR DESCRIPTION
I think the return was a mistake here.