### PR TITLE
Fix provisioning token parsing

### DIFF
--- a/changelog.d/462.misc
+++ b/changelog.d/462.misc
@@ -1,0 +1,1 @@
+Fix provisioning token parsing.

--- a/src/provisioning/api.ts
+++ b/src/provisioning/api.ts
@@ -243,11 +243,11 @@ export class ProvisioningApi {
         // Historically, user_id has been used. The bridge library supports either.
         // eslint-disable-next-line camelcase
         req: Request<unknown, unknown, {userId?: string, user_id?: string}>, res: Response, next: NextFunction) {
-        const authHeader = req.header("Authorization")?.toLowerCase();
+        const authHeader = req.header("Authorization");
         if (!authHeader) {
             throw new ApiError('No Authorization header', ErrCode.BadToken);
         }
-        const token = authHeader.startsWith("bearer ") && authHeader.substring("bearer ".length);
+        const token = authHeader.replace("Bearer ", "").replace("bearer ", "");
         if (!token) {
             throw new ApiError('Invalid Authorization header format', ErrCode.BadToken);
         }


### PR DESCRIPTION
Removes lowercasing the header which would break auth when the provisioning token contains uppercase characters.