### PR TITLE
Add support for MSC3968 ('poorer features')

### DIFF
--- a/changelog.d/463.feature
+++ b/changelog.d/463.feature
@@ -1,0 +1,1 @@
+Add support for MSC3968 ('poorer features')

--- a/src/components/bridge-info-state.ts
+++ b/src/components/bridge-info-state.ts
@@ -100,7 +100,7 @@ export class BridgeInfoStateSyncer<BridgeMappingInfo> {
             const realMapping = await this.opts.getMapping(roomId, mappingInfo);
             const key = this.createStateKey(realMapping);
             const bridgeInfoContent = this.createBridgeInfoContent(realMapping);
-            const eventFeaturesContent = this.createEventFeaturesContent(realMapping);
+            const eventFeaturesContent = this.getEventFeaturesContent(realMapping);
             if (!await this.syncRoomStateEvent(
                 intent,
                 roomId,
@@ -173,7 +173,7 @@ export class BridgeInfoStateSyncer<BridgeMappingInfo> {
             },
         ];
 
-        const eventFeaturesContent = this.createEventFeaturesContent(mapping)
+        const eventFeaturesContent = this.getEventFeaturesContent(mapping)
         if (eventFeaturesContent) {
             events.push({
                 type: BridgeInfoStateSyncer.EventFeaturesEventType,
@@ -207,11 +207,8 @@ export class BridgeInfoStateSyncer<BridgeMappingInfo> {
         return content;
     }
 
-    public createEventFeaturesContent(mapping: MappingInfo)
+    public getEventFeaturesContent(mapping: MappingInfo)
     : MSC3968Content|null {
-        if (!mapping.eventFeatures) {
-            return null;
-        }
-        return mapping.eventFeatures;
+        return mapping?.eventFeatures ?? null;
     }
 }


### PR DESCRIPTION
This is a breaking change, as it makes `createInitialState` return a
list of events instead of a single event.

No new test, because components don't have any.

https://github.com/matrix-org/matrix-appservice-irc/pull/1686 uses it and is tested for PMs