### PR TITLE
Fix: leave should not execute kick as user can't kick itself.

### DIFF
--- a/changelog.d/468.bugfix
+++ b/changelog.d/468.bugfix
@@ -1,0 +1,1 @@
+Fixed error when user leaves an IRC channel that made Matrix user kick itself instead of leaving when a reason was set.

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -586,7 +586,7 @@ export class Intent {
      */
     public async leave(roomId: string, reason?: string) {
         await this.botSdkIntent.ensureRegistered();
-        return this.botSdkIntent.leaveRoom(roomId);
+        return this.botSdkIntent.leaveRoom(roomId, reason);
     }
 
     /**

--- a/src/components/intent.ts
+++ b/src/components/intent.ts
@@ -585,10 +585,7 @@ export class Intent {
      * @param reason An optional string to explain why the user left the room.
      */
     public async leave(roomId: string, reason?: string) {
-        if (reason) {
-            await this.botSdkIntent.ensureRegistered();
-            return this.botSdkIntent.underlyingClient.kickUser(this.userId, roomId, reason);
-        }
+        await this.botSdkIntent.ensureRegistered();
         return this.botSdkIntent.leaveRoom(roomId);
     }
 


### PR DESCRIPTION
When a user leaves an IRC channel this should execute leaveRoom instead of kickUser even if it has a reason. Otherwise it fails because user has no permission to kick himself.