### PR TITLE
Update required Node version to 18 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This library sits on top of the
 and provides an API for setting up bridges quickly. Check out the
 [HOW-TO](HOWTO.md) for a step-by-step tutorial on setting up a new bridge.
 
-`matrix-appservice-bridge` requires Node JS 16.x or greater.
+`matrix-appservice-bridge` requires Node JS 18.x or greater.
 
 If you are looking to contribute to this library, please check out our [CONTRIBUTING](./CONTRIBUTING.md) guide.
 

--- a/changelog.d/470.doc
+++ b/changelog.d/470.doc
@@ -1,0 +1,1 @@
+Update required Node version (from 16 to 18) in README.md

--- a/changelog.d/470.doc
+++ b/changelog.d/470.doc
@@ -1,1 +1,1 @@
-Update required Node version (from 16 to 18) in README.md
+Update required Node version (from 16 to 18) in README.md.


### PR DESCRIPTION
Support for node 16 has been dropped in https://github.com/matrix-org/matrix-appservice-bridge/pull/466
