### PR TITLE
Stop skipping dependency type checks

### DIFF
--- a/changelog.d/490.bugfix
+++ b/changelog.d/490.bugfix
@@ -1,0 +1,1 @@
+Start checking types on dependencies to avoid publishing broken type releases.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/nedb": "^1.8.16",
     "@types/node": "^20",
     "@types/nopt": "^3.0.32",
+    "@types/jsbn": "^1.2.33",
     "@types/pkginfo": "^0.4.3",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "checkJs": false,
     "declaration": true,
     "sourceMap": true,
+    "skipLibCheck": false,
     "outDir": "./lib",
     "composite": false,
     "strictNullChecks": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,6 +567,11 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
   integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
 
+"@types/jsbn@^1.2.33":
+  version "1.2.33"
+  resolved "https://registry.yarnpkg.com/@types/jsbn/-/jsbn-1.2.33.tgz#470a4ff059f40fa6ca59838a8fa3f30c62a8c5ac"
+  integrity sha512-ZlLkHfu8xqqVFSbCe1FSPtAMUs7LKxk7TPskMb+sI5IbuzqyVqIEt9SVaQfFD2vrFcQunqKAmEBOuBEkoNLw4g==
+
 "@types/json-schema@^7.0.12":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"


### PR DESCRIPTION
Which means we won't publish a release with broken types.