### PR TITLE
Fix unable to use package without installing NeDB

### DIFF
--- a/changelog.d/491.bugfix
+++ b/changelog.d/491.bugfix
@@ -1,0 +1,1 @@
+Fix NeDB errors if you haven't installed the nedb packages.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/matrix-org/matrix-appservice-bridge#readme",
   "dependencies": {
+    "@types/nedb": "^1.8.16",
     "@alloc/quick-lru": "^5.2.0",
     "@vector-im/matrix-bot-sdk": "^0.6.7-element.1",
     "chalk": "^4.1.0",
@@ -55,7 +56,6 @@
     "@types/extend": "^3.0.4",
     "@types/jasmine": "^4.0.3",
     "@types/js-yaml": "^4.0.9",
-    "@types/nedb": "^1.8.16",
     "@types/node": "^20",
     "@types/nopt": "^3.0.32",
     "@types/jsbn": "^1.2.33",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import type Datastore from "nedb";
-const nedb = import("nedb");
 import {promises as fs} from "fs";
 import * as util from "util";
 import yaml from "js-yaml";
@@ -1723,7 +1722,7 @@ export class Bridge {
 
 async function loadDatabase<T extends BridgeStore>(path: string, Cls: new (db: Datastore) => T) {
     try {
-        const datastoreFn = (await nedb).default;
+        const datastoreFn = (await import("nedb")).default;
         return new Promise<T>((resolve, reject) => {
             const dbInstance = new datastoreFn({
             filename: path,


### PR DESCRIPTION
We still need to include types for NeDB in the final published library, and `import` will throw an inline error on failure.