### PR TITLE
Use the new authenticated endpoints in MediaProxy

### DIFF
--- a/changelog.d/506.bugfix
+++ b/changelog.d/506.bugfix
@@ -1,0 +1,1 @@
+Use the new authenticated endpoints in MediaProxy.

--- a/src/components/media-proxy.ts
+++ b/src/components/media-proxy.ts
@@ -147,7 +147,12 @@ export class MediaProxy {
         }
         // Cache from this point onwards.
         // Extract the media from the event.
-        const url = this.matrixClient.mxcToHttp('mxc://' + metadata.mxc);
+        const mxcMatch = metadata.mxc.match(new RegExp('^([^/]+)/(.+)$'));
+        if (!mxcMatch) {
+            throw new ApiError('Invalid MXC URI', ErrCode.BadValue);
+        }
+        const [, serverName, mediaId ] = mxcMatch;
+        const url = `${this.matrixClient.homeserverUrl}/_matrix/client/v1/media/download/${serverName}/${mediaId}`;
         get(url, {
             headers: {
                 'Authorization': `Bearer ${this.matrixClient.accessToken}`,

--- a/src/components/media-proxy.ts
+++ b/src/components/media-proxy.ts
@@ -151,7 +151,7 @@ export class MediaProxy {
         if (!mxcMatch) {
             throw new ApiError('Invalid MXC URI', ErrCode.BadValue);
         }
-        const [, serverName, mediaId ] = mxcMatch;
+        const [, serverName, mediaId] = mxcMatch;
         const url = `${this.matrixClient.homeserverUrl}/_matrix/client/v1/media/download/${serverName}/${mediaId}`;
         get(url, {
             headers: {


### PR DESCRIPTION
Fixes the requests failing in https://github.com/matrix-org/matrix-appservice-irc/issues/1816