### PR TITLE
Fix nedb's usage of `node:utils` for Node 24

### DIFF
--- a/spec/integ/bridge.spec.js
+++ b/spec/integ/bridge.spec.js
@@ -2,11 +2,6 @@
 const Datastore = require("nedb");
 const fs = require("fs");
 
-// required fix for nedb being incredibly outdated
-const util = require("node:util");
-util.isDate = util.types.isDate;
-util.isRegExp = util.types.isRegExp;
-
 const HS_URL = "http://example.com";
 const HS_DOMAIN = "example.com";
 const BOT_LOCALPART = "the_bridge";

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1723,6 +1723,13 @@ export class Bridge {
 async function loadDatabase<T extends BridgeStore>(path: string, Cls: new (db: Datastore) => T) {
     try {
         const datastoreFn = (await import("nedb")).default;
+        // required fix for nedb being incredibly outdated
+        if (parseInt(process.versions.node.split(".")[0]) >= 24) {
+            const util = require("node:util");
+            util.isDate = util.types.isDate;
+            util.isRegExp = util.types.isRegExp;
+        }
+
         return new Promise<T>((resolve, reject) => {
             const dbInstance = new datastoreFn({
             filename: path,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1721,6 +1721,7 @@ export class Bridge {
 }
 
 async function loadDatabase<T extends BridgeStore>(path: string, Cls: new (db: Datastore) => T) {
+    log.warn("NeDB-based stores are now deprecated.");
     try {
         const datastoreFn = (await import("nedb")).default;
         // required fix for nedb being incredibly outdated


### PR DESCRIPTION
Some parts of `nedb` don't work in Node 24 due to calling removed `node:utils` APIs.

https://github.com/matrix-org/matrix-appservice-bridge/pull/519 bypassed that problem in unit tests by injecting the required `node:utils` functions, but that doesn't fix the problem in production or for anything that uses this SDK as a dependency.

This PR moves that injection into source code to fix the problem outside of just tests.  It also adds a deprecation warning log to make it clear that NeDB is no longer supported & should not be used anymore.