### PR TITLE
Support NPM Trusted Publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: node:22
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,8 +20,5 @@ jobs:
         run: npm i -g npm@latest
       - run: yarn --strict-semver --frozen-lockfile
       - run: yarn build
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
       - name: Publish to npmjs.com
         run: npm publish --access public --provenance

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,14 +5,23 @@ on:
 jobs:
   publish-to-npm:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
+          registry-url: https://registry.npmjs.org/
+          scope: '@matrix-org'
+      - name: Upgrade npm for Trusted Publishing
+        run: npm i -g npm@latest
       - run: yarn --strict-semver --frozen-lockfile
       - run: yarn build
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npmjs.com
+        run: npm publish --access public --provenance

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish-to-npm:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: node:22
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         node-version: [22, 24]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -31,7 +31,7 @@ jobs:
       - run: yarn add nedb --peer
       - run: yarn build && yarn test
   test-postgres:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: node:22
     services:
       postgres:

--- a/changelog.d/523.misc
+++ b/changelog.d/523.misc
@@ -1,0 +1,1 @@
+Update CI to use NPM Trusted Publishing.


### PR DESCRIPTION
This updates our CI to publish to NPM using it's new trusted publishing things. This is mostly ripped from our other repos. The NPM side is all configured.